### PR TITLE
Implement needlefish: core, adapters, prompts

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,5 +1,9 @@
 name: needlefish-review
 
+# Self-review mode: this repo IS needlefish, so the PR checkout's own src/ is
+# the tool. For OTHER repos, use the generic template in README.md (which adds a
+# second checkout of frankekn/needlefish as the tool).
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -13,28 +17,16 @@ jobs:
   review:
     runs-on: self-hosted
     steps:
-      - name: Checkout target PR
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Checkout needlefish
-        uses: actions/checkout@v4
-        with:
-          repository: frankekn/needlefish
-          path: needlefish
-          # If needlefish is private, provide a PAT with repo read scope:
-          # token: ${{ secrets.NEEDLEFISH_PAT }}
-
-      - name: Setup needlefish
+      - name: Install
         run: corepack enable && pnpm install --frozen-lockfile
-        working-directory: needlefish
 
-      - name: Review
-        working-directory: ${{ github.workspace }}
+      - name: Needlefish review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
-        run: |
-          ./needlefish/node_modules/.bin/tsx needlefish/src/cli.ts --github --pr ${{ github.event.pull_request.number }}
+        run: ./node_modules/.bin/tsx src/cli.ts --github --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch origin "$BASE_REF" --depth=1
+        run: git fetch origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,40 @@
+name: needlefish-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  review:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout target PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Checkout needlefish
+        uses: actions/checkout@v4
+        with:
+          repository: frankekn/needlefish
+          path: needlefish
+          # If needlefish is private, provide a PAT with repo read scope:
+          # token: ${{ secrets.NEEDLEFISH_PAT }}
+
+      - name: Setup needlefish
+        run: corepack enable && pnpm install --frozen-lockfile
+        working-directory: needlefish
+
+      - name: Review
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        run: |
+          ./needlefish/node_modules/.bin/tsx needlefish/src/cli.ts --github --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,6 +29,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
+      - name: Fetch base branch
+        run: git fetch origin "$BASE_REF" --depth=1
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
+
       - name: Install
         shell: zsh -l {0}
         run: corepack enable && pnpm install --frozen-lockfile

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   review:
     runs-on: self-hosted
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,16 +30,13 @@ jobs:
           PR_NUM: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
           EVENT_HEAD: ${{ github.event.pull_request.head.sha }}
           EVENT_BASE: ${{ github.event.pull_request.base.sha }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           if [ -n "$EVENT_HEAD" ]; then
-            echo "head=$EVENT_HEAD"      >> "$GITHUB_OUTPUT"
-            echo "base=$EVENT_BASE"      >> "$GITHUB_OUTPUT"
-            echo "base_ref=$EVENT_BASE_REF" >> "$GITHUB_OUTPUT"
+            echo "head=$EVENT_HEAD" >> "$GITHUB_OUTPUT"
+            echo "base=$EVENT_BASE" >> "$GITHUB_OUTPUT"
           else
-            echo "head=$(gh pr view "$PR_NUM" --json headRefOid -q .headRefOid)"   >> "$GITHUB_OUTPUT"
-            echo "base=$(gh pr view "$PR_NUM" --json baseRefOid -q .baseRefOid)"   >> "$GITHUB_OUTPUT"
-            echo "base_ref=$(gh pr view "$PR_NUM" --json baseRef -q .baseRef)"     >> "$GITHUB_OUTPUT"
+            echo "head=$(gh pr view "$PR_NUM" --json headRefOid -q .headRefOid)" >> "$GITHUB_OUTPUT"
+            echo "base=$(gh pr view "$PR_NUM" --json baseRefOid -q .baseRefOid)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout PR head

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -32,4 +32,6 @@ jobs:
         shell: zsh -l {0}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: ./node_modules/.bin/tsx src/cli.ts --github --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -27,6 +27,7 @@ jobs:
         id: refs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
           EVENT_HEAD: ${{ github.event.pull_request.head.sha }}
           EVENT_BASE: ${{ github.event.pull_request.base.sha }}
@@ -35,8 +36,8 @@ jobs:
             echo "head=$EVENT_HEAD" >> "$GITHUB_OUTPUT"
             echo "base=$EVENT_BASE" >> "$GITHUB_OUTPUT"
           else
-            echo "head=$(gh pr view "$PR_NUM" --json headRefOid -q .headRefOid)" >> "$GITHUB_OUTPUT"
-            echo "base=$(gh pr view "$PR_NUM" --json baseRefOid -q .baseRefOid)" >> "$GITHUB_OUTPUT"
+            echo "head=$(gh pr view "$PR_NUM" -R "$REPO" --json headRefOid -q .headRefOid)" >> "$GITHUB_OUTPUT"
+            echo "base=$(gh pr view "$PR_NUM" -R "$REPO" --json baseRefOid -q .baseRefOid)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout PR head

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -24,9 +24,11 @@ jobs:
           fetch-depth: 0
 
       - name: Install
+        shell: zsh -l {0}
         run: corepack enable && pnpm install --frozen-lockfile
 
       - name: Needlefish review
+        shell: zsh -l {0}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./node_modules/.bin/tsx src/cli.ts --github --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -23,16 +23,30 @@ jobs:
     runs-on: self-hosted
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Checkout
+      - name: Resolve PR refs
+        id: refs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD: ${{ github.event.pull_request.head.sha }}
+          EVENT_BASE: ${{ github.event.pull_request.base.sha }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ -n "$EVENT_HEAD" ]; then
+            echo "head=$EVENT_HEAD"      >> "$GITHUB_OUTPUT"
+            echo "base=$EVENT_BASE"      >> "$GITHUB_OUTPUT"
+            echo "base_ref=$EVENT_BASE_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "head=$(gh pr view "$PR_NUM" --json headRefOid -q .headRefOid)"   >> "$GITHUB_OUTPUT"
+            echo "base=$(gh pr view "$PR_NUM" --json baseRefOid -q .baseRefOid)"   >> "$GITHUB_OUTPUT"
+            echo "base_ref=$(gh pr view "$PR_NUM" --json baseRef -q .baseRef)"     >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ steps.refs.outputs.head }}
           fetch-depth: 0
-
-      - name: Fetch base branch
-        run: git fetch origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
 
       - name: Install
         shell: zsh -l {0}
@@ -42,6 +56,6 @@ jobs:
         shell: zsh -l {0}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ steps.refs.outputs.base }}
+          PR_HEAD_SHA: ${{ steps.refs.outputs.head }}
         run: ./node_modules/.bin/tsx src/cli.ts --github --pr ${{ github.event.inputs.pr_number || github.event.pull_request.number }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,6 +7,11 @@ name: needlefish-review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review (manual trigger; bypasses pull_request webhook)
+        required: true
 
 permissions:
   contents: read
@@ -16,12 +21,12 @@ permissions:
 jobs:
   review:
     runs-on: self-hosted
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Checkout PR head
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Install
@@ -34,4 +39,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: ./node_modules/.bin/tsx src/cli.ts --github --pr ${{ github.event.pull_request.number }}
+        run: ./node_modules/.bin/tsx src/cli.ts --github --pr ${{ github.event.inputs.pr_number || github.event.pull_request.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+artifacts/
+.needlefish/
+*.log

--- a/FUTURE_TODO.md
+++ b/FUTURE_TODO.md
@@ -1,0 +1,22 @@
+# Future TODO
+
+Deferred by design (v0.1 is read-only, local-diff + self-hosted action).
+
+## Issue-comment commands
+`@needlefish recheck` / `@needlefish review` / `@needlefish explain` via `issue_comment`
+trigger. v0.1 only auto-reviews on `pull_request` events.
+
+## Repair lane (`--fix`)
+Let needlefish mutate the branch and push a fix (ClawSweeper-style bounded repair
+loop). v0.1 is report-only; `--fix` is parsed but errors out.
+
+## Action packaging
+Ship as a reusable `action.yml` (Docker/node20) so others can `uses: frankekn/needlefish@v1`.
+v0.1 runs via workflow checkout + `pnpm review --github`.
+
+## Multi-repo config
+Per-repo config file (base branch, severity gates, focus defaults) instead of flags only.
+
+## Critic parallelism / depth
+Optional second critic model or deeper call-site archaeology (`--deep` currently only
+widens prompt framing).

--- a/README.md
+++ b/README.md
@@ -52,12 +52,15 @@ line-anchored inline comments plus a check run. Verdict → surface mapping:
 
 | verdict              | review event        | check     |
 | -------------------- | ------------------- | --------- |
-| pass                 | APPROVE             | success   |
+| pass                 | COMMENT             | success   |
 | changes_requested    | REQUEST_CHANGES     | failure   |
 | needs_human          | COMMENT             | neutral   |
-| run failed           | (none)              | neutral   |
+| run failed           | (none)              | failure   |
 
-A failed review never passes a PR — the check goes neutral with the error.
+`pass` posts a `COMMENT` (not `APPROVE`) plus a green check: the `GITHUB_TOKEN`
+bot is not permitted to formally approve PRs (anti-self-approval), so the green
+check-run is the merge gate. A failed review never passes a PR — the check goes
+`failure`.
 
 ### Runner setup (one-time)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,99 @@
+# needlefish
+
+Strict local PR review agent. Acts like a senior engineer reviewing your diff
+before merge — only real defects (bugs, regressions, security, data loss,
+migration/upgrade risk, missing validation, duplicate behavior), never style.
+
+Read-only by default. Two Codex calls per review: a deep pass, then an
+adversarial critic that prunes weak findings. Verdict is derived deterministically
+from the surviving findings, never freehanded by the model.
+
+## Install
+
+Requires Node 20+, pnpm, and the Codex CLI authed locally.
+
+```bash
+git clone https://github.com/frankekn/needlefish
+cd needlefish
+corepack enable
+pnpm install
+```
+
+## Local use (read-only, no GitHub writes)
+
+Run from inside any repo you want reviewed, on a branch with changes:
+
+```bash
+# Option A — run from inside the target repo (cwd is the target):
+cd /path/to/some-repo
+/path/to/needlefish/node_modules/.bin/tsx /path/to/needlefish/src/cli.ts
+
+# Option B — point at the target with --repo from anywhere:
+tsx /path/to/needlefish/src/cli.ts --repo /path/to/some-repo --focus security
+tsx /path/to/needlefish/src/cli.ts --repo /path/to/some-repo --deep
+tsx /path/to/needlefish/src/cli.ts --repo /path/to/some-repo --pr 123  # pulls PR metadata via gh
+tsx /path/to/needlefish/src/cli.ts --repo /path/to/some-repo --base develop
+```
+
+Tip: alias it — `alias needlefish="tsx $HOME/Github/needlefish/src/cli.ts"`,
+then `needlefish --repo .` from any repo.
+
+Output: Markdown to stdout, JSON saved to `~/.cache/needlefish/<repo>/last-review.json`.
+
+## Base detection
+
+`--base` → `origin/HEAD` → `main`. Pass `--base <ref>` to override.
+
+## GitHub Action mode (self-hosted runner)
+
+`needlefish --github --pr N` collects the PR via `gh api`, runs the same core,
+and posts a formal PR review (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) with
+line-anchored inline comments plus a check run. Verdict → surface mapping:
+
+| verdict              | review event        | check     |
+| -------------------- | ------------------- | --------- |
+| pass                 | APPROVE             | success   |
+| changes_requested    | REQUEST_CHANGES     | failure   |
+| needs_human          | COMMENT             | neutral   |
+| run failed           | (none)              | neutral   |
+
+A failed review never passes a PR — the check goes neutral with the error.
+
+### Runner setup (one-time)
+
+The workflow lives in the **target** repo (`.github/workflows/review.yml`),
+not in needlefish — copy it from this repo. It checks out needlefish as a tool.
+
+1. Register a **self-hosted runner** on the target repo (free, unlimited minutes).
+   Keep it on a machine you control (EC2/pod/Mac).
+2. On that runner, auth Codex non-interactively once (persisted):
+   ```bash
+   printf '%s' "$CODEX_API_KEY" | codex login --with-api-key -c 'service_tier="fast"'
+   ```
+3. If needlefish stays **private**, set a PAT secret (`NEEDLEFISH_PAT`) and
+   uncomment the `token:` line in the workflow's needlefish checkout step.
+   If needlefish is **public**, the default `GITHUB_TOKEN` is enough.
+
+> Self-hosted runners execute PR code on your machine. Fine for solo use on your
+> own repos; if you ever open PRs to outside contributors, isolate the runner
+> (ephemeral container) so contributor code can't touch your persistent host.
+
+## Codex invocation
+
+`src/shared/codex.ts` shells out to `codex exec` (prompt via stdin), reading
+`CODEX_BIN`, `CODEX_MODEL`, `CODEX_TIMEOUT_MS` from env. If your installed
+Codex CLI uses different exec flags, adjust that one file.
+
+## Verdict derivation (deterministic)
+
+- any P0 / P1 / P2 finding → `changes_requested`
+- otherwise a blocking residual risk → `needs_human`
+- otherwise → `pass`
+
+P3-only findings are reported but do not block (check stays green).
+
+## Status
+
+v0.1. Read-only. `--fix` and `@needlefish` comment commands are in
+`FUTURE_TODO.md`. Every push re-triggers the action, so server-side re-review is
+automatic; `--recheck` is a local affordance only.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,329 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.20.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true

--- a/prompts/critic.md
+++ b/prompts/critic.md
@@ -1,0 +1,17 @@
+You are the adversarial critic for a Needlefish PR review. You receive candidate findings (JSON) plus the original diff. Your ONLY job is to PRUNE: delete weak findings and correct severity inflation. Never add new findings.
+
+# Rules
+- DELETE a finding if it is: a style/naming preference, speculative, not actually introduced by this diff, not tied to a concrete changed line, something a strict senior reviewer would NOT ask the author to fix before merge, or a duplicate of another kept finding.
+- DOWNGRADE severity when inflated (e.g. a P1 that is really a P3 nit). You may UPGRADE only when clearly under-rated and high-confidence.
+- KEEP findings that are concrete, introduced by this PR, behavior/security/data/compatibility-affecting, line-anchored, and have a plausible minimal fix.
+- If every finding is weak, return an empty findings array. An empty list is a good outcome — do not pad.
+- Re-check residual_risks: keep blocks=true only when it genuinely prevents a verdict.
+
+# Output
+Return ONLY a single ```json block with the SAME shape as the input (summary, findings[], checked[], residual_risks[]), pruned. Nothing else.
+
+# Candidate findings
+{{FINDINGS}}
+
+# Diff
+{{PATCH}}

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -1,0 +1,56 @@
+You are Needlefish, Frank's strict local PR review agent. Act like a senior engineer reviewing code right before merge: precise, calm, and interested only in real defects.
+
+# Inputs
+A context bundle (JSON) follows under "Context bundle". It contains: base/head SHAs, the full diff, changed files pre-classified by surface, the repository's AGENTS.md (review policy — apply it), and optional PR metadata. You may run read-only inspection inside the repo path (rg, git log, git show, sed, nl) to verify findings, but never edit files or run mutating commands.
+
+# Hard rules
+- Read the full AGENTS.md and apply its conventions as review policy. Do not rely on snippets or assumptions.
+- Report ONLY: correctness bugs, regressions, security/supply-chain issues, data loss, migration/upgrade breakage, missing validation that hides a real bug, and duplicate behavior (reimplementing an existing config/flag/API/feature).
+- Do NOT report: style, naming, formatting, speculative "could be cleaner", missing tests without a concrete bug path, broad architecture opinions, or unchanged code unless needed to prove a changed line is wrong.
+- Every finding MUST cite a concrete changed file and line range from this diff.
+- Prefer ZERO findings over weak ones. If a strict senior reviewer would not ask the author to fix it before merge, drop it.
+- If evidence is insufficient to verify something material, put it in residual_risks. Set blocks=true ONLY when the gap actually prevents a verdict.
+
+# Process — inspect in order, cross-check across lenses
+1. Surface map: read changed_files with surface labels. Flag anything small with large blast radius (public-api, cli, config default, schema/migration, workflow, dependency/lockfile).
+2. Hunk bugs: per hunk — introduced by this PR? affects real behavior? points to a changed line? has a minimal fix? Any "no" → drop it.
+3. Call sites: for each changed symbol, read the full function and trace 1-2 layers of callers/callees. Check args, nullability, async ordering, cleanup, return values, error propagation.
+4. Contract / compatibility: CLI flags, config defaults, env vars, API/schema, serialized or persisted state, DB schema, cache keys. Does this break old users, old data, or old settings on upgrade? Default/migration/schema/provider-routing changes are high-risk even when they fix a real bug.
+5. Existing behavior: search the repo (rg, docs, config, flags, existing API) for whether this capability already exists. Reimplementing existing behavior is a defect — point to the existing path.
+6. Runtime / security: concurrency, retry, idempotency, stale state, partial failure, timeout; and supply-chain surfaces — CI workflows, GitHub Action refs, dependency sources, lockfiles, install/build/release scripts, permissions, secrets, downloaded or executed artifacts.
+7. Validation: do tests actually cover the changed behavior (not just typecheck/mock/snapshot/lint)? Report a test-gap finding only when a real regression would slip through. Give the minimal validation command.
+
+# Do not decide from a single search hit or the PR title. Search synonyms and old names; cross-check implementation, call sites, tests, and history before raising or dismissing a finding.
+
+# Severity
+- P0: data loss, security bypass, crash loop, unusable core path
+- P1: likely user-facing regression or broken workflow
+- P2: normal bug or missing validation for a real behavior risk
+- P3: low-risk correctness, docs, or test gap
+
+# Output
+Return ONLY a single ```json block, nothing else, in exactly this shape:
+```json
+{
+  "summary": "one-line verdict + rationale",
+  "findings": [
+    {
+      "severity": "P0|P1|P2|P3",
+      "title": "imperative, <=80 chars",
+      "category": "bug|contract|duplicate|runtime|security|validation",
+      "file": "repo-relative path",
+      "lineStart": 1,
+      "lineEnd": 1,
+      "confidence": 0.0,
+      "whyItBreaks": "concrete reason current behavior breaks",
+      "suggestedFix": "minimal fix",
+      "validation": "command or step to prove the fix"
+    }
+  ],
+  "checked": ["what you verified"],
+  "residual_risks": [{ "text": "...", "blocks": false }]
+}
+```
+
+# Context bundle
+{{BUNDLE}}

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -34,7 +34,11 @@ function ghText(args: string[]): string {
 }
 
 function git(args: string[], cwd: string): string {
-  const res = spawnSync("git", args, { cwd, encoding: "utf8" });
+  const res = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 64,
+  });
   if (res.status !== 0) {
     throw new Error(`git ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
   }
@@ -162,7 +166,7 @@ export async function runGithub(cwd: string, prNumber: number): Promise<void> {
 
   const bundle: Bundle = {
     repoPath: cwd,
-    baseSha,
+    baseSha: mergeBase,
     headSha,
     patch,
     changedFiles,

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -107,6 +107,8 @@ function postReview(
         "-f",
         `event=${event}`,
         "-f",
+        `commit_id=${headSha}`,
+        "-f",
         `body=${body}`,
       ]
     );

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -134,8 +134,8 @@ export async function runGithub(cwd: string, prNumber: number): Promise<void> {
   if (!repo) throw new Error("GITHUB_REPOSITORY not set (must run in Actions)");
 
   const pr = gh(["api", `repos/${repo}/pulls/${prNumber}`]);
-  const headSha = process.env.PR_HEAD_SHA ?? git(["rev-parse", "HEAD"], cwd);
-  const baseSha = process.env.PR_BASE_SHA ?? git(["merge-base", "origin/main", "HEAD"], cwd);
+  const headSha = process.env.PR_HEAD_SHA || git(["rev-parse", "HEAD"], cwd);
+  const baseSha = process.env.PR_BASE_SHA || git(["merge-base", "origin/main", "HEAD"], cwd);
   const patch = git(["diff", baseSha, "HEAD"], cwd);
   const changedFiles = changedFileSet(cwd, baseSha);
   const changedPaths = new Set(changedFiles.map((f) => f.path));

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -136,8 +136,9 @@ export async function runGithub(cwd: string, prNumber: number): Promise<void> {
   const pr = gh(["api", `repos/${repo}/pulls/${prNumber}`]);
   const headSha = process.env.PR_HEAD_SHA || git(["rev-parse", "HEAD"], cwd);
   const baseSha = process.env.PR_BASE_SHA || git(["merge-base", "origin/main", "HEAD"], cwd);
-  const patch = git(["diff", baseSha, "HEAD"], cwd);
-  const changedFiles = changedFileSet(cwd, baseSha);
+  const mergeBase = git(["merge-base", baseSha, headSha], cwd);
+  const patch = git(["diff", mergeBase, headSha], cwd);
+  const changedFiles = changedFileSet(cwd, mergeBase);
   const changedPaths = new Set(changedFiles.map((f) => f.path));
 
   const agentsPath = path.join(cwd, "AGENTS.md");

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -134,8 +134,8 @@ export async function runGithub(cwd: string, prNumber: number): Promise<void> {
   if (!repo) throw new Error("GITHUB_REPOSITORY not set (must run in Actions)");
 
   const pr = gh(["api", `repos/${repo}/pulls/${prNumber}`]);
-  const baseSha = pr.base?.sha ?? git(["merge-base", "origin/main", "HEAD"], cwd);
-  const headSha = git(["rev-parse", "HEAD"], cwd);
+  const headSha = process.env.PR_HEAD_SHA ?? git(["rev-parse", "HEAD"], cwd);
+  const baseSha = process.env.PR_BASE_SHA ?? git(["merge-base", "origin/main", "HEAD"], cwd);
   const patch = git(["diff", baseSha, "HEAD"], cwd);
   const changedFiles = changedFileSet(cwd, baseSha);
   const changedPaths = new Set(changedFiles.map((f) => f.path));

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -1,0 +1,198 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { classifyFiles } from "../shared/classify";
+import { review } from "../core/review";
+import { renderMarkdown } from "../shared/render";
+import type {
+  Bundle,
+  PrMeta,
+  ReviewResult,
+  Verdict,
+  Finding,
+} from "../shared/schema";
+
+function gh(args: string[], input?: string): any {
+  const res = spawnSync("gh", args, {
+    encoding: "utf8",
+    input,
+    maxBuffer: 1024 * 1024 * 64,
+  });
+  if (res.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
+  }
+  const out = (res.stdout ?? "").trim();
+  return out ? JSON.parse(out) : {};
+}
+
+function ghText(args: string[]): string {
+  const res = spawnSync("gh", args, { encoding: "utf8", maxBuffer: 1024 * 1024 * 64 });
+  if (res.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
+  }
+  return (res.stdout ?? "").trim();
+}
+
+function git(args: string[], cwd: string): string {
+  const res = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
+  }
+  return (res.stdout ?? "").trim();
+}
+
+const VERDICT_EVENT: Record<Verdict, "APPROVE" | "REQUEST_CHANGES" | "COMMENT"> = {
+  pass: "APPROVE",
+  changes_requested: "REQUEST_CHANGES",
+  needs_human: "COMMENT",
+};
+
+const VERDICT_CONCLUSION: Record<string, "success" | "failure" | "neutral"> = {
+  pass: "success",
+  changes_requested: "failure",
+  needs_human: "neutral",
+};
+
+function changedFileSet(cwd: string, baseSha: string): { path: string; surface: any }[] {
+  const nameOnly = git(["diff", "--name-only", baseSha, "HEAD"], cwd);
+  return classifyFiles(nameOnly.split("\n").filter(Boolean));
+}
+
+function inlineComments(findings: Finding[], changedPaths: Set<string>) {
+  return findings
+    .filter((f) => f.file && changedPaths.has(f.file) && f.lineStart > 0)
+    .map((f) => ({
+      path: f.file,
+      line: f.lineStart,
+      side: "RIGHT" as const,
+      body: `**${f.severity} (${f.category}): ${f.title}**\n\n${f.whyItBreaks}\n\n_Suggested fix:_ ${f.suggestedFix}`,
+    }));
+}
+
+function postReview(
+  repo: string,
+  prNumber: number,
+  headSha: string,
+  result: ReviewResult,
+  changedPaths: Set<string>
+) {
+  const event = VERDICT_EVENT[result.verdict];
+  const body = renderMarkdown(result);
+  const comments = inlineComments(result.findings, changedPaths);
+  const repoArg = `repos/${repo}`;
+
+  const payload = JSON.stringify({
+    commit_id: headSha,
+    body,
+    event,
+    comments,
+  });
+
+  try {
+    gh(
+      ["api", "-X", "POST", `${repoArg}/pulls/${prNumber}/reviews`, "--input", "-"],
+      payload
+    );
+  } catch {
+    gh(
+      [
+        "api",
+        "-X",
+        "POST",
+        `${repoArg}/pulls/${prNumber}/reviews`,
+        "-f",
+        `event=${event}`,
+        "-f",
+        `body=${body}`,
+      ]
+    );
+  }
+}
+
+function postCheck(
+  repo: string,
+  headSha: string,
+  result: ReviewResult | null,
+  conclusion: "success" | "failure" | "neutral",
+  title: string,
+  summary: string
+) {
+  gh(
+    ["api", "-X", "POST", `repos/${repo}/check-runs`, "--input", "-"],
+    JSON.stringify({
+      name: "Needlefish",
+      head_sha: headSha,
+      status: "completed",
+      conclusion,
+      output: { title, summary },
+    })
+  );
+}
+
+export async function runGithub(cwd: string, prNumber: number): Promise<void> {
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error("GITHUB_REPOSITORY not set (must run in Actions)");
+
+  const pr = gh([
+    "api",
+    `repos/${repo}/pulls/${prNumber}`,
+  ]);
+  const headSha = pr.head?.sha ?? git(["rev-parse", "HEAD"], cwd);
+  const baseSha = pr.base?.sha ?? git(["merge-base", "origin/" + (pr.base?.ref ?? "main"), "HEAD"], cwd);
+
+  const patch = ghText(["pr", "diff", String(prNumber)]);
+  const changedFiles = changedFileSet(cwd, baseSha);
+  const changedPaths = new Set(changedFiles.map((f) => f.path));
+
+  const agentsPath = path.join(cwd, "AGENTS.md");
+  const agentsMd = existsSync(agentsPath) ? readFileSync(agentsPath, "utf8") : null;
+
+  const comments = (pr.comments_url
+    ? gh(["api", pr.comments_url])
+    : []) as any[];
+  const reviews = (pr.review_comments_url
+    ? gh(["api", pr.review_comments_url])
+    : []) as any[];
+
+  const prMeta: PrMeta = {
+    number: prNumber,
+    title: pr.title ?? "",
+    body: pr.body ?? null,
+    comments: comments.map((c) => c.body ?? "").filter(Boolean),
+    reviews: reviews.map((r) => r.body ?? "").filter(Boolean),
+    checks: [],
+  };
+
+  const bundle: Bundle = {
+    repoPath: cwd,
+    baseSha,
+    headSha,
+    patch,
+    changedFiles,
+    agentsMd,
+    prMeta,
+    deep: false,
+    focus: null,
+  };
+
+  let result: ReviewResult | null = null;
+  try {
+    result = await review(bundle);
+    const conclusion = VERDICT_CONCLUSION[result.verdict];
+    postReview(repo, prNumber, headSha, result, changedPaths);
+    postCheck(repo, headSha, result, conclusion, `Needlefish: ${result.verdict}`, renderMarkdown(result));
+    process.stdout.write(renderMarkdown(result));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    postCheck(
+      repo,
+      headSha,
+      null,
+      "neutral",
+      "Needlefish: review failed",
+      `Review errored and did NOT pass this PR.\n\n\`\`\`\n${msg.slice(0, 4000)}\n\`\`\``
+    );
+    process.stderr.write(`needlefish review failed: ${msg}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -41,8 +41,8 @@ function git(args: string[], cwd: string): string {
   return (res.stdout ?? "").trim();
 }
 
-const VERDICT_EVENT: Record<Verdict, "APPROVE" | "REQUEST_CHANGES" | "COMMENT"> = {
-  pass: "APPROVE",
+const VERDICT_EVENT: Record<Verdict, "COMMENT" | "REQUEST_CHANGES" | "COMMENT"> = {
+  pass: "COMMENT",
   changes_requested: "REQUEST_CHANGES",
   needs_human: "COMMENT",
 };

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -133,14 +133,10 @@ export async function runGithub(cwd: string, prNumber: number): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY;
   if (!repo) throw new Error("GITHUB_REPOSITORY not set (must run in Actions)");
 
-  const pr = gh([
-    "api",
-    `repos/${repo}/pulls/${prNumber}`,
-  ]);
-  const headSha = pr.head?.sha ?? git(["rev-parse", "HEAD"], cwd);
-  const baseSha = pr.base?.sha ?? git(["merge-base", "origin/" + (pr.base?.ref ?? "main"), "HEAD"], cwd);
-
-  const patch = ghText(["pr", "diff", String(prNumber)]);
+  const pr = gh(["api", `repos/${repo}/pulls/${prNumber}`]);
+  const baseSha = pr.base?.sha ?? git(["merge-base", "origin/main", "HEAD"], cwd);
+  const headSha = git(["rev-parse", "HEAD"], cwd);
+  const patch = git(["diff", baseSha, "HEAD"], cwd);
   const changedFiles = changedFileSet(cwd, baseSha);
   const changedPaths = new Set(changedFiles.map((f) => f.path));
 
@@ -188,7 +184,7 @@ export async function runGithub(cwd: string, prNumber: number): Promise<void> {
       repo,
       headSha,
       null,
-      "neutral",
+      "failure",
       "Needlefish: review failed",
       `Review errored and did NOT pass this PR.\n\n\`\`\`\n${msg.slice(0, 4000)}\n\`\`\``
     );

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -8,7 +8,11 @@ import { renderMarkdown } from "../shared/render";
 import type { Bundle, PrMeta, ReviewResult } from "../shared/schema";
 
 function git(args: string[], cwd: string): string {
-  const res = spawnSync("git", args, { cwd, encoding: "utf8" });
+  const res = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 64,
+  });
   if (res.status !== 0) {
     throw new Error(`git ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
   }

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -29,9 +29,21 @@ function detectBase(cwd: string, override?: string): string {
   return "main";
 }
 
+function gh(args: string[], cwd: string): string {
+  const res = spawnSync("gh", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 64,
+  });
+  if (res.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
+  }
+  return (res.stdout ?? "").trim();
+}
+
 function fetchPrMeta(cwd: string, prNumber: number): PrMeta | null {
   try {
-    const raw = git(
+    const raw = gh(
       [
         "pr",
         "view",

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -1,0 +1,130 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { classifyFiles } from "../shared/classify";
+import { review } from "../core/review";
+import { renderMarkdown } from "../shared/render";
+import type { Bundle, PrMeta, ReviewResult } from "../shared/schema";
+
+function git(args: string[], cwd: string): string {
+  const res = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
+  }
+  return (res.stdout ?? "").trim();
+}
+
+function detectBase(cwd: string, override?: string): string {
+  if (override) return override;
+  try {
+    const head = git(
+      ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+      cwd
+    );
+    if (head) return head;
+  } catch {
+    /* fall through */
+  }
+  return "main";
+}
+
+function fetchPrMeta(cwd: string, prNumber: number): PrMeta | null {
+  try {
+    const raw = git(
+      [
+        "pr",
+        "view",
+        String(prNumber),
+        "--json",
+        "number,title,body,comments,reviews,statusCheckRollup",
+      ],
+      cwd
+    );
+    const j = JSON.parse(raw);
+    return {
+      number: j.number,
+      title: j.title ?? "",
+      body: j.body ?? null,
+      comments: (j.comments ?? []).map((c: any) => c.body ?? "").filter(Boolean),
+      reviews: (j.reviews ?? []).map((r: any) => r.body ?? "").filter(Boolean),
+      checks: (j.statusCheckRollup ?? []).map((c: any) => ({
+        name: c.name ?? c.context ?? "",
+        status: c.status ?? "",
+        conclusion: c.conclusion ?? null,
+      })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function repoSlug(cwd: string): string {
+  try {
+    const url = git(["config", "--get", "remote.origin.url"], cwd);
+    const m = url.match(/[:/]([^/]+)\/([^/]+?)(\.git)?$/);
+    if (m) return `${m[1]}-${m[2]}`;
+  } catch {
+    /* ignore */
+  }
+  return path.basename(cwd);
+}
+
+export interface LocalOptions {
+  base?: string;
+  pr?: number;
+  deep?: boolean;
+  focus?: string;
+  cacheDir?: string;
+}
+
+export async function runLocal(
+  cwd: string,
+  opts: LocalOptions
+): Promise<ReviewResult> {
+  const baseRef = detectBase(cwd, opts.base);
+  const baseSha = git(["merge-base", baseRef, "HEAD"], cwd);
+  const headSha = git(["rev-parse", "HEAD"], cwd);
+  const patch = git(["diff", baseSha, "HEAD"], cwd);
+  const nameOnly = git(["diff", "--name-only", baseSha, "HEAD"], cwd);
+  const changedFiles = classifyFiles(
+    nameOnly.split("\n").filter(Boolean)
+  );
+
+  if (!patch.trim()) {
+    throw new Error(
+      `No diff between ${baseSha} and HEAD (${baseRef}). Nothing to review.`
+    );
+  }
+
+  const agentsPath = path.join(cwd, "AGENTS.md");
+  const agentsMd = existsSync(agentsPath)
+    ? readFileSync(agentsPath, "utf8")
+    : null;
+
+  const prMeta = opts.pr ? fetchPrMeta(cwd, opts.pr) : null;
+
+  const bundle: Bundle = {
+    repoPath: cwd,
+    baseSha,
+    headSha,
+    patch,
+    changedFiles,
+    agentsMd,
+    prMeta,
+    deep: Boolean(opts.deep),
+    focus: opts.focus ?? null,
+  };
+
+  const result = await review(bundle);
+
+  const cache = opts.cacheDir ?? path.join(os.homedir(), ".cache", "needlefish", repoSlug(cwd));
+  mkdirSync(cache, { recursive: true });
+  writeFileSync(path.join(cache, "last-review.json"), JSON.stringify(result, null, 2));
+
+  return result;
+}
+
+export function printLocal(result: ReviewResult): void {
+  process.stdout.write(renderMarkdown(result) + "\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { runGithub } from "./adapters/github";
+import { runLocal, printLocal, type LocalOptions } from "./adapters/local";
+
+function parse(argv: string[]): {
+  github: boolean;
+  pr?: number;
+  repo?: string;
+  opts: LocalOptions;
+  fix: boolean;
+  recheck: boolean;
+} {
+  const out = {
+    github: false,
+    pr: undefined as number | undefined,
+    repo: undefined as string | undefined,
+    opts: {} as LocalOptions,
+    fix: false,
+    recheck: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--github":
+        out.github = true;
+        break;
+      case "--pr":
+        out.pr = Number(argv[++i]);
+        out.opts.pr = out.pr;
+        break;
+      case "--base":
+        out.opts.base = argv[++i];
+        break;
+      case "--repo":
+        out.repo = argv[++i];
+        break;
+      case "--deep":
+        out.opts.deep = true;
+        break;
+      case "--focus":
+        out.opts.focus = argv[++i];
+        break;
+      case "--fix":
+        out.fix = true;
+        break;
+      case "--recheck":
+        out.recheck = true;
+        break;
+      case "-h":
+      case "--help":
+        process.stdout.write(USAGE);
+        process.exit(0);
+        break;
+      default:
+        if (a?.startsWith("--base=")) out.opts.base = a.slice(7);
+        else if (a?.startsWith("--pr=")) {
+          out.pr = Number(a.slice(5));
+          out.opts.pr = out.pr;
+        }         else if (a?.startsWith("--focus=")) out.opts.focus = a.slice(8);
+        else if (a?.startsWith("--repo=")) out.repo = a.slice(7);
+    }
+  }
+  return out;
+}
+
+const USAGE = `Needlefish — strict local PR review agent.
+
+Usage:
+  needlefish                       review merge-base..HEAD (local, read-only)
+  needlefish --focus security      narrow the review lens
+  needlefish --deep                wider context (call sites, history, adjacent tests)
+  needlefish --pr 123              also pull PR body/comments/checks via gh
+  needlefish --base develop        override base ref
+  needlefish --github --pr 123     GitHub Action mode (post review + check)
+  needlefish --recheck             re-run review on current head
+
+Env:
+  CODEX_BIN           codex executable (default: codex)
+  CODEX_MODEL         model id
+  CODEX_TIMEOUT_MS    per-call timeout (default: 600000)
+`;
+
+async function main() {
+  const { github, pr, repo, opts, fix, recheck } = parse(process.argv.slice(2));
+
+  if (fix) {
+    process.stderr.write("--fix is not implemented in v0.1 (see FUTURE_TODO.md).\n");
+    process.exitCode = 2;
+    return;
+  }
+  if (recheck) {
+    process.stderr.write(
+      "v0.1 --recheck runs a full re-review; smart prior-findings verification is TODO.\n"
+    );
+  }
+
+  const cwd = repo ?? process.cwd();
+
+  if (github) {
+    if (!pr) throw new Error("--github requires --pr <number>");
+    await runGithub(cwd, pr);
+    return;
+  }
+
+  const result = await runLocal(cwd, opts);
+  printLocal(result);
+}
+
+main().catch((err) => {
+  process.stderr.write(`needlefish: ${err instanceof Error ? err.message : err}\n`);
+  process.exitCode = 1;
+});

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -27,8 +27,8 @@ export async function review(
 
   const rawCandidate = runCodex(reviewPrompt, { repoPath: bundle.repoPath });
   const candidate = normalizeReview(extractJson(rawCandidate));
-  if (!candidate.summary) {
-    throw new Error("review produced no summary (likely malformed model output)");
+  if (!candidate.summary || candidate.checked.length === 0) {
+    throw new Error("review produced no summary or checked list (likely malformed output)");
   }
 
   const criticPrompt = loadPrompt("critic.md")
@@ -36,8 +36,8 @@ export async function review(
     .replace("{{PATCH}}", () => bundle.patch);
   const rawPruned = runCodex(criticPrompt, { repoPath: bundle.repoPath });
   const pruned: RawReview = normalizeReview(extractJson(rawPruned));
-  if (!pruned.summary) {
-    throw new Error("critic produced no summary (likely malformed model output)");
+  if (!pruned.summary || pruned.checked.length === 0) {
+    throw new Error("critic produced no summary or checked list (likely malformed output)");
   }
 
   const verdict = deriveVerdict(pruned.findings, pruned.residual_risks);

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -26,7 +26,7 @@ export async function review(
   );
 
   const rawCandidate = runCodex(reviewPrompt, { repoPath: bundle.repoPath });
-  const candidate = normalizeReview(extractJson(rawCandidate));
+  const candidate = normalizeReview(extractJson(rawCandidate), false);
   if (!candidate.summary || candidate.checked.length === 0) {
     throw new Error("review produced no summary or checked list (likely malformed output)");
   }

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -22,15 +22,15 @@ export async function review(
 ): Promise<ReviewResult> {
   const reviewPrompt = loadPrompt("review.md").replace(
     "{{BUNDLE}}",
-    JSON.stringify(bundle, null, 2)
+    () => JSON.stringify(bundle, null, 2)
   );
 
   const rawCandidate = runCodex(reviewPrompt, { repoPath: bundle.repoPath });
   const candidate = normalizeReview(extractJson(rawCandidate));
 
   const criticPrompt = loadPrompt("critic.md")
-    .replace("{{FINDINGS}}", JSON.stringify(candidate, null, 2))
-    .replace("{{PATCH}}", bundle.patch);
+    .replace("{{FINDINGS}}", () => JSON.stringify(candidate, null, 2))
+    .replace("{{PATCH}}", () => bundle.patch);
   const rawPruned = runCodex(criticPrompt, { repoPath: bundle.repoPath });
   const pruned: RawReview = normalizeReview(extractJson(rawPruned));
 

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -33,6 +33,11 @@ export async function review(
     .replace("{{PATCH}}", () => bundle.patch);
   const rawPruned = runCodex(criticPrompt, { repoPath: bundle.repoPath });
   const pruned: RawReview = normalizeReview(extractJson(rawPruned));
+  if (!pruned.summary && pruned.findings.length === 0 && pruned.checked.length === 0) {
+    throw new Error(
+      "review produced no usable output (empty summary, findings, and checks)"
+    );
+  }
 
   const verdict = deriveVerdict(pruned.findings, pruned.residual_risks);
 

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { runCodex, extractJson } from "../shared/codex";
+import {
+  normalizeReview,
+  type Bundle,
+  type RawReview,
+  type ReviewResult,
+} from "../shared/schema";
+import { deriveVerdict } from "./verdict";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROMPTS_DIR = path.resolve(__dirname, "..", "..", "prompts");
+
+function loadPrompt(name: string): string {
+  return readFileSync(path.join(PROMPTS_DIR, name), "utf8");
+}
+
+export async function review(
+  bundle: Bundle
+): Promise<ReviewResult> {
+  const reviewPrompt = loadPrompt("review.md").replace(
+    "{{BUNDLE}}",
+    JSON.stringify(bundle, null, 2)
+  );
+
+  const rawCandidate = runCodex(reviewPrompt, { repoPath: bundle.repoPath });
+  const candidate = normalizeReview(extractJson(rawCandidate));
+
+  const criticPrompt = loadPrompt("critic.md")
+    .replace("{{FINDINGS}}", JSON.stringify(candidate, null, 2))
+    .replace("{{PATCH}}", bundle.patch);
+  const rawPruned = runCodex(criticPrompt, { repoPath: bundle.repoPath });
+  const pruned: RawReview = normalizeReview(extractJson(rawPruned));
+
+  const verdict = deriveVerdict(pruned.findings, pruned.residual_risks);
+
+  return {
+    verdict,
+    summary: pruned.summary || candidate.summary,
+    findings: pruned.findings,
+    checked: pruned.checked.length ? pruned.checked : candidate.checked,
+    residualRisks: pruned.residual_risks,
+    baseSha: bundle.baseSha,
+    headSha: bundle.headSha,
+  };
+}

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -26,7 +26,7 @@ export async function review(
   );
 
   const rawCandidate = runCodex(reviewPrompt, { repoPath: bundle.repoPath });
-  const candidate = normalizeReview(extractJson(rawCandidate), false);
+  const candidate = normalizeReview(extractJson(rawCandidate));
   if (!candidate.summary || candidate.checked.length === 0) {
     throw new Error("review produced no summary or checked list (likely malformed output)");
   }

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -27,16 +27,17 @@ export async function review(
 
   const rawCandidate = runCodex(reviewPrompt, { repoPath: bundle.repoPath });
   const candidate = normalizeReview(extractJson(rawCandidate));
+  if (!candidate.summary) {
+    throw new Error("review produced no summary (likely malformed model output)");
+  }
 
   const criticPrompt = loadPrompt("critic.md")
     .replace("{{FINDINGS}}", () => JSON.stringify(candidate, null, 2))
     .replace("{{PATCH}}", () => bundle.patch);
   const rawPruned = runCodex(criticPrompt, { repoPath: bundle.repoPath });
   const pruned: RawReview = normalizeReview(extractJson(rawPruned));
-  if (!pruned.summary && pruned.findings.length === 0 && pruned.checked.length === 0) {
-    throw new Error(
-      "review produced no usable output (empty summary, findings, and checks)"
-    );
+  if (!pruned.summary) {
+    throw new Error("critic produced no summary (likely malformed model output)");
   }
 
   const verdict = deriveVerdict(pruned.findings, pruned.residual_risks);

--- a/src/core/verdict.ts
+++ b/src/core/verdict.ts
@@ -1,0 +1,14 @@
+import type { Finding, ResidualRisk, Verdict } from "../shared/schema";
+
+const BLOCKING: Finding["severity"][] = ["P0", "P1", "P2"];
+
+export function deriveVerdict(
+  findings: Finding[],
+  residualRisks: ResidualRisk[]
+): Verdict {
+  const hasBlocking = findings.some((f) => BLOCKING.includes(f.severity));
+  if (hasBlocking) return "changes_requested";
+  const hasBlockingRisk = residualRisks.some((r) => r.blocks);
+  if (hasBlockingRisk) return "needs_human";
+  return "pass";
+}

--- a/src/shared/classify.ts
+++ b/src/shared/classify.ts
@@ -1,0 +1,31 @@
+import type { Surface } from "./schema";
+
+const RULES: { test: RegExp; surface: Surface }[] = [
+  { test: /(^|\/)\.github\/workflows\/.+\.ya?ml$/i, surface: "workflow" },
+  { test: /(^|\/)node_modules\//i, surface: "dependency" },
+  {
+    test: /(package\.json|pnpm-lock\.yaml|package-lock\.json|yarn\.lock|.*\.lock|go\.mod|go\.sum|cargo\.toml|cargo\.lock|requirements\.txt|pyproject\.toml|uv\.lock|gemfile|gemfile\.lock)$/i,
+    surface: "dependency",
+  },
+  { test: /(^|\/)(test|tests|__tests__|spec|specs)\/|\.test\.|\.spec\.|-test\.|-spec\./i, surface: "test" },
+  { test: /\.md$|(^|\/)docs?\//i, surface: "docs" },
+  { test: /(^|\/)(migrations?|schema|db)\//i, surface: "schema" },
+  { test: /\.sql$/i, surface: "schema" },
+  { test: /(^|\/)(bin|cli|cmd)\//i, surface: "cli" },
+  { test: /(^|\/)(src|lib)\/api\/|(^|\/)routes?\//i, surface: "public-api" },
+  {
+    test: /(^|\/)\.env|\.config\.(js|ts|mjs|cjs|json|yaml|yml|toml)|(^|\/)config\/|(^|\/)\.needlefish\//i,
+    surface: "config",
+  },
+];
+
+export function classifySurface(file: string): Surface {
+  for (const rule of RULES) {
+    if (rule.test.test(file)) return rule.surface;
+  }
+  return "source";
+}
+
+export function classifyFiles(files: string[]): { path: string; surface: Surface }[] {
+  return files.map((p) => ({ path: p, surface: classifySurface(p) }));
+}

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface CodexOptions {
+  repoPath: string;
+  model?: string;
+  timeoutMs?: number;
+}
+
+export function runCodex(prompt: string, opts: CodexOptions): string {
+  const bin = process.env.CODEX_BIN ?? "codex";
+  const model = opts.model ?? process.env.CODEX_MODEL;
+  const timeoutMs =
+    opts.timeoutMs ?? Number(process.env.CODEX_TIMEOUT_MS ?? 600000);
+
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-"));
+  const lastMsg = path.join(tmp, "last.txt");
+  const args = ["exec", "--color", "never", "--output-last-message", lastMsg];
+  if (model) args.push("-m", model);
+
+  const res = spawnSync(bin, args, {
+    cwd: opts.repoPath,
+    input: prompt,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    maxBuffer: 1024 * 1024 * 64,
+  });
+
+  let out = "";
+  try {
+    out = readFileSync(lastMsg, "utf8");
+  } catch {
+    out = res.stdout ?? "";
+  }
+  rmSync(tmp, { recursive: true, force: true });
+
+  if (res.error) throw res.error;
+  if (res.status !== 0) {
+    throw new Error(
+      `codex exec exited ${res.status}: ${(res.stderr ?? "").slice(0, 2000)}`
+    );
+  }
+  return out;
+}
+
+export function extractJson(text: string): any {
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const raw = fence ? fence[1] : text;
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error("no JSON object found in codex output");
+  }
+  return JSON.parse(raw.slice(start, end + 1));
+}

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -20,8 +20,14 @@ export function runCodex(prompt: string, opts: CodexOptions): string {
   const args = ["exec", "--color", "never", "-s", "read-only", "--output-last-message", lastMsg];
   if (model) args.push("-m", model);
 
+  const env = { ...process.env };
+  delete env.GH_TOKEN;
+  delete env.GITHUB_TOKEN;
+  delete env.GITHUB_API_TOKEN;
+
   const res = spawnSync(bin, args, {
     cwd: opts.repoPath,
+    env,
     input: prompt,
     encoding: "utf8",
     timeout: timeoutMs,

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -17,7 +17,7 @@ export function runCodex(prompt: string, opts: CodexOptions): string {
 
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-"));
   const lastMsg = path.join(tmp, "last.txt");
-  const args = ["exec", "--color", "never", "--output-last-message", lastMsg];
+  const args = ["exec", "--color", "never", "-s", "read-only", "--output-last-message", lastMsg];
   if (model) args.push("-m", model);
 
   const res = spawnSync(bin, args, {

--- a/src/shared/render.ts
+++ b/src/shared/render.ts
@@ -1,0 +1,72 @@
+import type { ReviewResult, Severity } from "./schema";
+
+const SEV_ORDER: Record<Severity, number> = {
+  P0: 0,
+  P1: 1,
+  P2: 2,
+  P3: 3,
+};
+
+const VERDICT_BADGE: Record<string, string> = {
+  pass: "✅ pass",
+  changes_requested: "⛔ changes_requested",
+  needs_human: "👀 needs_human",
+};
+
+export function renderMarkdown(result: ReviewResult): string {
+  const lines: string[] = [];
+  lines.push("# Needlefish PR Review");
+  lines.push("");
+  lines.push(`**Verdict:** ${VERDICT_BADGE[result.verdict] ?? result.verdict}`);
+  lines.push(`**Base:** ${result.baseSha}  →  **Head:** ${result.headSha}`);
+  if (result.summary) lines.push("");
+  if (result.summary) lines.push(result.summary);
+  lines.push("");
+
+  const findings = [...result.findings].sort(
+    (a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity]
+  );
+
+  if (findings.length === 0) {
+    lines.push("## Findings");
+    lines.push("");
+    lines.push("No actionable findings. Prefer this over padding weak ones.");
+  } else {
+    lines.push("## Findings");
+    lines.push("");
+    for (const f of findings) {
+      lines.push(`### ${f.severity}: ${f.title}`);
+      lines.push(
+        `${f.file || "(no file)"}:${f.lineStart}${
+          f.lineEnd && f.lineEnd !== f.lineStart ? `-${f.lineEnd}` : ""
+        }`
+      );
+      lines.push("");
+      lines.push(`**Why this breaks:** ${f.whyItBreaks}`);
+      lines.push("");
+      lines.push(`**Suggested fix:** ${f.suggestedFix}`);
+      if (f.validation) {
+        lines.push("");
+        lines.push(`**Validation:** \`${f.validation}\``);
+      }
+      lines.push("");
+    }
+  }
+
+  if (result.checked.length > 0) {
+    lines.push("## Checked");
+    lines.push("");
+    for (const c of result.checked) lines.push(`- ${c}`);
+    lines.push("");
+  }
+
+  if (result.residualRisks.length > 0) {
+    lines.push("## Residual Risk");
+    lines.push("");
+    for (const r of result.residualRisks) {
+      lines.push(`- ${r.blocks ? "⛔ " : ""}${r.text}`);
+    }
+  }
+
+  return lines.join("\n").trim() + "\n";
+}

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -93,10 +93,9 @@ const CATEGORIES: Category[] = [
 ];
 
 export function normalizeFinding(raw: Partial<Finding>): Finding {
+  const sev = String(raw.severity ?? "").trim().toUpperCase();
   return {
-    severity: (SEVERITIES.includes(raw.severity as Severity)
-      ? raw.severity
-      : "P3") as Severity,
+    severity: (SEVERITIES.includes(sev as Severity) ? sev : "P1") as Severity,
     title: String(raw.title ?? "Untitled finding").slice(0, 120),
     category: (CATEGORIES.includes(raw.category as Category)
       ? raw.category

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -92,25 +92,49 @@ const CATEGORIES: Category[] = [
   "validation",
 ];
 
-export function normalizeFinding(raw: Partial<Finding>): Finding {
+export function normalizeFinding(raw: any): Finding {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("malformed finding: not an object");
+  }
   const sev = String(raw.severity ?? "").trim().toUpperCase();
+  if (!SEVERITIES.includes(sev as Severity)) {
+    throw new Error(`malformed finding: invalid severity "${raw.severity}"`);
+  }
+  const cat = String(raw.category ?? "").trim();
+  if (!CATEGORIES.includes(cat as Category)) {
+    throw new Error(`malformed finding: invalid category "${raw.category}"`);
+  }
+  const file = String(raw.file ?? "").trim();
+  if (!file) throw new Error("malformed finding: missing file");
+  const title = String(raw.title ?? "").trim();
+  if (!title) throw new Error("malformed finding: missing title");
+  const whyItBreaks = String(raw.whyItBreaks ?? "").trim();
+  if (!whyItBreaks) throw new Error("malformed finding: missing whyItBreaks");
+  const suggestedFix = String(raw.suggestedFix ?? "").trim();
+  if (!suggestedFix) throw new Error("malformed finding: missing suggestedFix");
+  const lineStart = Number(raw.lineStart);
+  if (!Number.isFinite(lineStart) || lineStart <= 0) {
+    throw new Error(`malformed finding: invalid lineStart ${raw.lineStart}`);
+  }
+  const lineEnd = Number(raw.lineEnd ?? raw.lineStart);
+  if (!Number.isFinite(lineEnd) || lineEnd <= 0) {
+    throw new Error(`malformed finding: invalid lineEnd ${raw.lineEnd}`);
+  }
   return {
-    severity: (SEVERITIES.includes(sev as Severity) ? sev : "P1") as Severity,
-    title: String(raw.title ?? "Untitled finding").slice(0, 120),
-    category: (CATEGORIES.includes(raw.category as Category)
-      ? raw.category
-      : "bug") as Category,
-    file: String(raw.file ?? ""),
-    lineStart: Number(raw.lineStart ?? 0),
-    lineEnd: Number(raw.lineEnd ?? raw.lineStart ?? 0),
+    severity: sev as Severity,
+    category: cat as Category,
+    file,
+    title,
+    whyItBreaks,
+    suggestedFix,
+    lineStart,
+    lineEnd,
     confidence: Math.max(0, Math.min(1, Number(raw.confidence ?? 0))),
-    whyItBreaks: String(raw.whyItBreaks ?? ""),
-    suggestedFix: String(raw.suggestedFix ?? ""),
     validation: String(raw.validation ?? ""),
   };
 }
 
-export function normalizeReview(raw: any): RawReview {
+export function normalizeReview(raw: any, strict = true): RawReview {
   if (!raw || typeof raw !== "object") {
     throw new Error("malformed review output: not an object");
   }
@@ -128,7 +152,17 @@ export function normalizeReview(raw: any): RawReview {
       "malformed review output: residual_risks missing or not an array"
     );
   }
-  const findings = raw.findings.map(normalizeFinding);
+  const findings = strict
+    ? raw.findings.map(normalizeFinding)
+    : raw.findings
+        .map((f: any) => {
+          try {
+            return normalizeFinding(f);
+          } catch {
+            return null;
+          }
+        })
+        .filter((f: Finding | null): f is Finding => f !== null);
   const residual = raw.residual_risks.map((r: any) => ({
     text: String(r?.text ?? ""),
     blocks: Boolean(r?.blocks),

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -112,19 +112,32 @@ export function normalizeFinding(raw: Partial<Finding>): Finding {
 }
 
 export function normalizeReview(raw: any): RawReview {
-  const findings = Array.isArray(raw?.findings)
-    ? raw.findings.map(normalizeFinding)
-    : [];
-  const residual = Array.isArray(raw?.residual_risks)
-    ? raw.residual_risks.map((r: any) => ({
-        text: String(r?.text ?? ""),
-        blocks: Boolean(r?.blocks),
-      }))
-    : [];
+  if (!raw || typeof raw !== "object") {
+    throw new Error("malformed review output: not an object");
+  }
+  if (typeof raw.summary !== "string") {
+    throw new Error("malformed review output: summary missing or not a string");
+  }
+  if (!Array.isArray(raw.findings)) {
+    throw new Error("malformed review output: findings missing or not an array");
+  }
+  if (!Array.isArray(raw.checked)) {
+    throw new Error("malformed review output: checked missing or not an array");
+  }
+  if (!Array.isArray(raw.residual_risks)) {
+    throw new Error(
+      "malformed review output: residual_risks missing or not an array"
+    );
+  }
+  const findings = raw.findings.map(normalizeFinding);
+  const residual = raw.residual_risks.map((r: any) => ({
+    text: String(r?.text ?? ""),
+    blocks: Boolean(r?.blocks),
+  }));
   return {
-    summary: String(raw?.summary ?? ""),
+    summary: raw.summary,
     findings,
-    checked: Array.isArray(raw?.checked) ? raw.checked.map(String) : [],
+    checked: raw.checked.map(String),
     residual_risks: residual,
   };
 }

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -1,0 +1,130 @@
+export type Severity = "P0" | "P1" | "P2" | "P3";
+
+export type Category =
+  | "bug"
+  | "contract"
+  | "duplicate"
+  | "runtime"
+  | "security"
+  | "validation";
+
+export type Surface =
+  | "public-api"
+  | "cli"
+  | "config"
+  | "schema"
+  | "workflow"
+  | "dependency"
+  | "test"
+  | "docs"
+  | "source";
+
+export type Verdict = "pass" | "changes_requested" | "needs_human";
+
+export interface ChangedFile {
+  path: string;
+  surface: Surface;
+}
+
+export interface PrMeta {
+  number: number;
+  title: string;
+  body: string | null;
+  comments: string[];
+  reviews: string[];
+  checks: { name: string; status: string; conclusion: string | null }[];
+}
+
+export interface Bundle {
+  repoPath: string;
+  baseSha: string;
+  headSha: string;
+  patch: string;
+  changedFiles: ChangedFile[];
+  agentsMd: string | null;
+  prMeta: PrMeta | null;
+  deep: boolean;
+  focus: string | null;
+}
+
+export interface Finding {
+  severity: Severity;
+  title: string;
+  category: Category;
+  file: string;
+  lineStart: number;
+  lineEnd: number;
+  confidence: number;
+  whyItBreaks: string;
+  suggestedFix: string;
+  validation: string;
+}
+
+export interface ResidualRisk {
+  text: string;
+  blocks: boolean;
+}
+
+export interface RawReview {
+  summary: string;
+  findings: Finding[];
+  checked: string[];
+  residual_risks: ResidualRisk[];
+}
+
+export interface ReviewResult {
+  verdict: Verdict;
+  summary: string;
+  findings: Finding[];
+  checked: string[];
+  residualRisks: ResidualRisk[];
+  baseSha: string;
+  headSha: string;
+}
+
+const SEVERITIES: Severity[] = ["P0", "P1", "P2", "P3"];
+const CATEGORIES: Category[] = [
+  "bug",
+  "contract",
+  "duplicate",
+  "runtime",
+  "security",
+  "validation",
+];
+
+export function normalizeFinding(raw: Partial<Finding>): Finding {
+  return {
+    severity: (SEVERITIES.includes(raw.severity as Severity)
+      ? raw.severity
+      : "P3") as Severity,
+    title: String(raw.title ?? "Untitled finding").slice(0, 120),
+    category: (CATEGORIES.includes(raw.category as Category)
+      ? raw.category
+      : "bug") as Category,
+    file: String(raw.file ?? ""),
+    lineStart: Number(raw.lineStart ?? 0),
+    lineEnd: Number(raw.lineEnd ?? raw.lineStart ?? 0),
+    confidence: Math.max(0, Math.min(1, Number(raw.confidence ?? 0))),
+    whyItBreaks: String(raw.whyItBreaks ?? ""),
+    suggestedFix: String(raw.suggestedFix ?? ""),
+    validation: String(raw.validation ?? ""),
+  };
+}
+
+export function normalizeReview(raw: any): RawReview {
+  const findings = Array.isArray(raw?.findings)
+    ? raw.findings.map(normalizeFinding)
+    : [];
+  const residual = Array.isArray(raw?.residual_risks)
+    ? raw.residual_risks.map((r: any) => ({
+        text: String(r?.text ?? ""),
+        blocks: Boolean(r?.blocks),
+      }))
+    : [];
+  return {
+    summary: String(raw?.summary ?? ""),
+    findings,
+    checked: Array.isArray(raw?.checked) ? raw.checked.map(String) : [],
+    residual_risks: residual,
+  };
+}


### PR DESCRIPTION
Scaffold: schema + deterministic verdict, 2-call Codex orchestration (review + adversarial critic), local + github adapters, read-only by default.

Self-review trigger: the `needlefish-review` action on main will review this PR using the PR's own src/.

Dogfooded locally: reviewed itself, found 2 real bugs (git->gh for pr metadata; broken pnpm allowBuilds placeholder), both fixed.