### PR TITLE
feat(local): review PR refs from any branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Changes
+
+- Add `needlefish pr <number>` for reviewing pull request refs locally without switching branches. (#7) thanks @samzong

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requires:
 - Node 20+
 - Corepack (recommended) or the pinned pnpm from `packageManager`
 - One supported model CLI authed locally: Codex (default), Claude Code, or opencode
-- GitHub CLI (`gh`) for `--pr` / GitHub Action mode
+- GitHub CLI (`gh`) for `--pr`, `pr`, and GitHub Action mode
 
 ```bash
 git clone https://github.com/frankekn/needlefish
@@ -66,11 +66,16 @@ needlefish
 # Otherwise, full path (cwd is the target):
 /path/to/needlefish/node_modules/.bin/tsx /path/to/needlefish/src/cli.ts
 
-# Point at the target with --repo from anywhere:
+# Local diff review. Point at the target with --repo from anywhere:
 needlefish --repo /path/to/some-repo --focus security
 needlefish --repo /path/to/some-repo --deep
-needlefish --repo /path/to/some-repo --pr 123  # pulls PR metadata via gh
+needlefish --repo /path/to/some-repo --pr 123  # attaches PR metadata to the local diff
 needlefish --repo /path/to/some-repo --base develop
+
+# PR ref review from any branch:
+needlefish pr 123 --repo /path/to/some-repo
+
+# Runner selection:
 needlefish --repo /path/to/some-repo --runner claude
 needlefish --repo /path/to/some-repo --runner opencode --model zai-coding-plan/glm-5.2
 ```

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { commitAll, gitText, headSha, initRepo } from "../shared/codex-runner-test-fixtures";
+import { runGithub } from "./github";
+
+test("runGithub normalizes relative repo paths before building prompts", async (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-github-test-"));
+  const repo = initRepo(tmp);
+  const fakeBin = path.join(tmp, "bin");
+  const gh = path.join(fakeBin, "gh");
+  const claude = path.join(fakeBin, "claude");
+  const promptPath = path.join(tmp, "prompts.txt");
+  const promptRepoPath = path.join(tmp, "prompt-repo-path.txt");
+  const previous = {
+    path: process.env.PATH,
+    repository: process.env.GITHUB_REPOSITORY,
+    head: process.env.PR_HEAD_SHA,
+    base: process.env.PR_BASE_SHA,
+    runner: process.env.NEEDLEFISH_RUNNER,
+    claude: process.env.CLAUDE_BIN,
+  };
+  t.after(() => {
+    if (previous.path === undefined) delete process.env.PATH;
+    else process.env.PATH = previous.path;
+    if (previous.repository === undefined) delete process.env.GITHUB_REPOSITORY;
+    else process.env.GITHUB_REPOSITORY = previous.repository;
+    if (previous.head === undefined) delete process.env.PR_HEAD_SHA;
+    else process.env.PR_HEAD_SHA = previous.head;
+    if (previous.base === undefined) delete process.env.PR_BASE_SHA;
+    else process.env.PR_BASE_SHA = previous.base;
+    if (previous.runner === undefined) delete process.env.NEEDLEFISH_RUNNER;
+    else process.env.NEEDLEFISH_RUNNER = previous.runner;
+    if (previous.claude === undefined) delete process.env.CLAUDE_BIN;
+    else process.env.CLAUDE_BIN = previous.claude;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  gitText(["branch", "-M", "main"], repo);
+  const baseSha = headSha(repo);
+  gitText(["checkout", "-b", "feature"], repo);
+  writeFileSync(path.join(repo, "README.md"), "feature\n");
+  commitAll(repo, "feature");
+  const targetHeadSha = headSha(repo);
+
+  mkdirSync(fakeBin);
+  writeFileSync(
+    gh,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "if (args[0] !== 'api') process.exit(2);",
+      "if (args.includes('--input')) { fs.readFileSync(0, 'utf8'); process.stdout.write('{}'); process.exit(0); }",
+      `if (args[1] === 'repos/frankekn/needlefish/pulls/7') { process.stdout.write(${JSON.stringify(
+        JSON.stringify({
+          title: "PR",
+          body: "",
+          comments_url: "https://example.invalid/comments",
+          review_comments_url: "https://example.invalid/reviews",
+          head: { sha: targetHeadSha },
+          base: { sha: baseSha },
+        })
+      )}); process.exit(0); }`,
+      "if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
+      "process.stderr.write(`unexpected gh args ${args.join(' ')}`);",
+      "process.exit(2);",
+    ].join("\n")
+  );
+  chmodSync(gh, 0o755);
+  writeFileSync(
+    claude,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      "const input = fs.readFileSync(0, 'utf8');",
+      `fs.appendFileSync(${JSON.stringify(promptPath)}, input);`,
+      "const match = input.match(/\"repoPath\":\\s*\"([^\"]+)\"/);",
+      `if (match && !fs.existsSync(${JSON.stringify(promptRepoPath)})) fs.writeFileSync(${JSON.stringify(promptRepoPath)}, match[1]);`,
+      "process.stdout.write(JSON.stringify({ summary: 'ok', findings: [], checked: ['checked'], residual_risks: [] }));",
+    ].join("\n")
+  );
+  chmodSync(claude, 0o755);
+  process.env.PATH = `${fakeBin}:${previous.path ?? ""}`;
+  process.env.GITHUB_REPOSITORY = "frankekn/needlefish";
+  process.env.PR_BASE_SHA = baseSha;
+  process.env.PR_HEAD_SHA = targetHeadSha;
+  process.env.NEEDLEFISH_RUNNER = "claude";
+  process.env.CLAUDE_BIN = claude;
+
+  const relativeRepo = path.relative(process.cwd(), repo);
+  await runGithub(relativeRepo, 7, { timeoutMs: 1000 });
+
+  const prompts = readFileSync(promptPath, "utf8");
+  assert.equal(prompts.includes(relativeRepo), false);
+  const repoPathInPrompt = readFileSync(promptRepoPath, "utf8");
+  assert.equal(path.isAbsolute(repoPathInPrompt), true);
+  assert.equal(path.basename(repoPathInPrompt), "runner-repo");
+});

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { review } from "../core/review";
 import { renderMarkdown } from "../shared/render";
 import { changedFiles, ghText, git, makeBundle } from "../shared/repo";
@@ -89,21 +90,22 @@ export async function runGithub(
   prNumber: number,
   opts: RunnerOptions = {}
 ): Promise<void> {
+  const repoPath = path.resolve(cwd);
   const repo = process.env.GITHUB_REPOSITORY;
   if (!repo) throw new Error("GITHUB_REPOSITORY not set (must run in Actions)");
 
   const pr = ghJson(["api", `repos/${repo}/pulls/${prNumber}`]);
   if (!isRecord(pr)) throw new Error("GitHub PR response was not an object");
-  const headSha = process.env.PR_HEAD_SHA || nestedString(pr, "head", "sha") || git(["rev-parse", "HEAD"], cwd);
+  const headSha = process.env.PR_HEAD_SHA || nestedString(pr, "head", "sha") || git(["rev-parse", "HEAD"], repoPath);
   const baseSha = process.env.PR_BASE_SHA || nestedString(pr, "base", "sha");
   if (!baseSha || !headSha) throw new Error("Could not resolve PR base/head SHA");
-  const mergeBase = git(["merge-base", baseSha, headSha], cwd);
-  const patch = git(["diff", mergeBase, headSha], cwd);
+  const mergeBase = git(["merge-base", baseSha, headSha], repoPath);
+  const patch = git(["diff", mergeBase, headSha], repoPath);
   if (!patch.trim()) {
     throw new Error(`No diff between ${mergeBase} and ${headSha}. Nothing to review.`);
   }
-  const patchStat = git(["diff", "--stat", mergeBase, headSha], cwd);
-  const changed = changedFiles(cwd, mergeBase, headSha);
+  const patchStat = git(["diff", "--stat", mergeBase, headSha], repoPath);
+  const changed = changedFiles(repoPath, mergeBase, headSha);
 
   const commentsUrl = stringField(pr, "comments_url");
   const reviewsUrl = stringField(pr, "review_comments_url");
@@ -120,7 +122,7 @@ export async function runGithub(
   };
 
   const bundle = makeBundle({
-    repoPath: cwd,
+    repoPath,
     baseSha: mergeBase,
     headSha,
     patch,

--- a/src/adapters/local.test.ts
+++ b/src/adapters/local.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -39,4 +39,47 @@ test("runLocal fails loudly when explicit PR metadata cannot be fetched", async 
     () => runLocal(repo, { pr: 24 }),
     /--pr 24 requested, but PR metadata could not be fetched: gh pr view 24/
   );
+});
+
+test("runLocal normalizes relative repo paths before building prompts", async (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-local-test-"));
+  const repo = initRepo(tmp);
+  const promptPath = path.join(tmp, "prompts.txt");
+  const bin = path.join(tmp, "claude-bin.js");
+  const cacheDir = path.join(tmp, "cache");
+  const previous = {
+    bin: process.env.CLAUDE_BIN,
+    runner: process.env.NEEDLEFISH_RUNNER,
+  };
+  t.after(() => {
+    if (previous.bin === undefined) delete process.env.CLAUDE_BIN;
+    else process.env.CLAUDE_BIN = previous.bin;
+    if (previous.runner === undefined) delete process.env.NEEDLEFISH_RUNNER;
+    else process.env.NEEDLEFISH_RUNNER = previous.runner;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  gitText(["branch", "-M", "main"], repo);
+  gitText(["checkout", "-b", "feature"], repo);
+  writeFileSync(path.join(repo, "README.md"), "feature\n");
+  commitAll(repo, "feature");
+  writeFileSync(
+    bin,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      `fs.appendFileSync(${JSON.stringify(promptPath)}, fs.readFileSync(0, 'utf8'));`,
+      "process.stdout.write(JSON.stringify({ summary: 'ok', findings: [], checked: ['checked'], residual_risks: [] }));",
+    ].join("\n")
+  );
+  chmodSync(bin, 0o755);
+  process.env.CLAUDE_BIN = bin;
+  process.env.NEEDLEFISH_RUNNER = "claude";
+
+  const relativeRepo = path.relative(process.cwd(), repo);
+  await runLocal(relativeRepo, { cacheDir });
+
+  const prompts = readFileSync(promptPath, "utf8");
+  assert.equal(prompts.includes(`"repoPath": "${relativeRepo}"`), false);
+  assert.equal(prompts.includes("runner-repo"), true);
 });

--- a/src/adapters/local.test.ts
+++ b/src/adapters/local.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runLocal } from "./local";
+import { commitAll, gitText, initRepo } from "../shared/codex-runner-test-fixtures";
+
+test("runLocal fails loudly when explicit PR metadata cannot be fetched", async (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-local-test-"));
+  const repo = initRepo(tmp);
+  const fakeBin = path.join(tmp, "bin");
+  const gh = path.join(fakeBin, "gh");
+  const previousPath = process.env.PATH;
+  t.after(() => {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  gitText(["branch", "-M", "main"], repo);
+  gitText(["checkout", "-b", "feature"], repo);
+  writeFileSync(path.join(repo, "README.md"), "feature\n");
+  commitAll(repo, "feature");
+
+  mkdirSync(fakeBin);
+  writeFileSync(
+    gh,
+    [
+      "#!/usr/bin/env node",
+      "process.stderr.write('gh auth required');",
+      "process.exit(1);",
+    ].join("\n")
+  );
+  chmodSync(gh, 0o755);
+  process.env.PATH = `${fakeBin}:${previousPath ?? ""}`;
+
+  await assert.rejects(
+    () => runLocal(repo, { pr: 24 }),
+    /--pr 24 requested, but PR metadata could not be fetched: gh pr view 24/
+  );
+});

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -3,9 +3,18 @@ import os from "node:os";
 import path from "node:path";
 import { review } from "../core/review";
 import { renderMarkdown } from "../shared/render";
-import { changedFiles, ghText, git, makeBundle } from "../shared/repo";
+import {
+  changedFiles,
+  ensurePrCommits,
+  fetchPrRefInfo,
+  ghText,
+  git,
+  makeBundle,
+  prDiffFromShas,
+  readAgentsAt,
+} from "../shared/repo";
 import { normalizePrMeta } from "../shared/normalize";
-import type { ReviewResult } from "../shared/schema";
+import type { Bundle, ReviewResult } from "../shared/schema";
 import type { RunnerOptions } from "../shared/runner";
 
 function detectBase(cwd: string, override?: string): string {
@@ -52,7 +61,13 @@ function cacheSlug(cwd: string): string {
   return path.basename(cwd);
 }
 
-function diffBundle(cwd: string, opts: LocalOptions) {
+function writeCache(cwd: string, opts: LocalOptions, result: ReviewResult): void {
+  const cache = opts.cacheDir ?? path.join(os.homedir(), ".cache", "needlefish", cacheSlug(cwd));
+  mkdirSync(cache, { recursive: true });
+  writeFileSync(path.join(cache, "last-review.json"), JSON.stringify(result, null, 2));
+}
+
+function diffBundle(cwd: string, opts: LocalOptions): Bundle {
   const dirty = git(["status", "--porcelain"], cwd);
   if (dirty.trim()) {
     process.stderr.write(
@@ -81,6 +96,24 @@ function diffBundle(cwd: string, opts: LocalOptions) {
   });
 }
 
+function prDiffBundle(cwd: string, prNumber: number, opts: LocalOptions): Bundle {
+  const pr = fetchPrRefInfo(cwd, prNumber);
+  ensurePrCommits(cwd, pr);
+  const diff = prDiffFromShas(cwd, pr.baseSha, pr.headSha);
+  return makeBundle({
+    repoPath: cwd,
+    baseSha: diff.baseSha,
+    headSha: diff.headSha,
+    patch: diff.patch,
+    patchStat: diff.patchStat,
+    changedFiles: diff.changedFiles,
+    prMeta: pr.prMeta,
+    deep: Boolean(opts.deep),
+    focus: opts.focus ?? null,
+    agentsMd: readAgentsAt(cwd, pr.headSha),
+  });
+}
+
 export interface LocalOptions extends RunnerOptions {
   readonly base?: string;
   readonly pr?: number;
@@ -94,10 +127,17 @@ export async function runLocal(
   opts: LocalOptions
 ): Promise<ReviewResult> {
   const result = await review(diffBundle(cwd, opts), opts);
-  const cache = opts.cacheDir ?? path.join(os.homedir(), ".cache", "needlefish", cacheSlug(cwd));
-  mkdirSync(cache, { recursive: true });
-  writeFileSync(path.join(cache, "last-review.json"), JSON.stringify(result, null, 2));
+  writeCache(cwd, opts, result);
+  return result;
+}
 
+export async function runLocalPr(
+  cwd: string,
+  prNumber: number,
+  opts: LocalOptions
+): Promise<ReviewResult> {
+  const result = await review(prDiffBundle(cwd, prNumber, opts), opts);
+  writeCache(cwd, opts, result);
   return result;
 }
 

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -136,8 +136,9 @@ export async function runLocal(
   cwd: string,
   opts: LocalOptions
 ): Promise<ReviewResult> {
-  const result = await review(diffBundle(cwd, opts), opts);
-  writeCache(cwd, opts, result);
+  const repoPath = path.resolve(cwd);
+  const result = await review(diffBundle(repoPath, opts), opts);
+  writeCache(repoPath, opts, result);
   return result;
 }
 
@@ -146,8 +147,9 @@ export async function runLocalPr(
   prNumber: number,
   opts: LocalOptions
 ): Promise<ReviewResult> {
-  const result = await review(prDiffBundle(cwd, prNumber, opts), opts);
-  writeCache(cwd, opts, result);
+  const repoPath = path.resolve(cwd);
+  const result = await review(prDiffBundle(repoPath, prNumber, opts), opts);
+  writeCache(repoPath, opts, result);
   return result;
 }
 

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -45,7 +45,11 @@ function fetchPrMeta(cwd: string, prNumber: number) {
     );
     return normalizePrMeta(JSON.parse(raw), prNumber);
   } catch (err) {
-    if (err instanceof Error) return null;
+    if (err instanceof Error) {
+      throw new Error(
+        `--pr ${prNumber} requested, but PR metadata could not be fetched: ${err.message}. Check gh auth or remove --pr for local-only review.`
+      );
+    }
     throw err;
   }
 }
@@ -90,7 +94,12 @@ function diffBundle(cwd: string, opts: LocalOptions): Bundle {
     patch,
     patchStat: git(["diff", "--stat", baseSha, "HEAD"], cwd),
     changedFiles: changedFiles(cwd, baseSha),
-    prMeta: opts.pr ? fetchPrMeta(cwd, opts.pr) : null,
+    ...(opts.pr
+      ? {
+          reviewTarget: `Review target: local ${baseSha}..${headSha}\nPR context: #${opts.pr} metadata only`,
+          prMeta: fetchPrMeta(cwd, opts.pr),
+        }
+      : { prMeta: null }),
     deep: Boolean(opts.deep),
     focus: opts.focus ?? null,
   });
@@ -107,6 +116,7 @@ function prDiffBundle(cwd: string, prNumber: number, opts: LocalOptions): Bundle
     patch: diff.patch,
     patchStat: diff.patchStat,
     changedFiles: diff.changedFiles,
+    reviewTarget: `Review target: PR #${pr.prMeta.number} ${diff.baseSha}..${diff.headSha}`,
     prMeta: pr.prMeta,
     deep: Boolean(opts.deep),
     focus: opts.focus ?? null,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { runGithub } from "./adapters/github";
-import { runLocal, printLocal, type LocalOptions } from "./adapters/local";
+import { runLocal, runLocalPr, printLocal } from "./adapters/local";
 import { parseArgs, USAGE } from "./cli/args";
 
 async function main() {
@@ -27,7 +27,8 @@ async function main() {
       await runGithub(command.repo ?? process.cwd(), command.pr, command.opts);
       return;
     }
-    case "local": {
+    case "local":
+    case "pr": {
       if (command.fix) {
         process.stderr.write("--fix is not implemented in v0.2 (see FUTURE_TODO.md).\n");
         process.exitCode = 2;
@@ -38,8 +39,9 @@ async function main() {
           "v0.2 --recheck runs a full re-review; smart prior-findings verification is TODO.\n"
         );
       }
-      const opts: LocalOptions = command.opts;
-      const result = await runLocal(command.repo ?? process.cwd(), opts);
+      const cwd = command.repo ?? process.cwd();
+      const result =
+        command.kind === "pr" ? await runLocalPr(cwd, command.pr, command.opts) : await runLocal(cwd, command.opts);
       printLocal(result);
       return;
     }

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -17,6 +17,26 @@ test("parseArgs returns github command when pr is valid", () => {
   });
 });
 
+test("parseArgs separates pr command from --pr context", () => {
+  const prCommand = parseArgs(["pr", "24", "--repo", "/tmp/repo", "--focus", "security"]);
+
+  assert.equal(prCommand.kind, "pr");
+  if (prCommand.kind === "pr") {
+    assert.equal(prCommand.pr, 24);
+    assert.equal(prCommand.repo, "/tmp/repo");
+    assert.equal(prCommand.opts.focus, "security");
+  }
+
+  const contextCommand = parseArgs(["--pr", "24"]);
+
+  assert.equal(contextCommand.kind, "local");
+  if (contextCommand.kind === "local") {
+    assert.equal(contextCommand.opts.pr, 24);
+  }
+
+  assert.deepEqual(parseArgs(["pr", "--help"]), { kind: "help" });
+});
+
 test("parseArgs rejects missing option values", () => {
   const argv = ["--base"];
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -24,19 +24,35 @@ export type CliCommand =
       readonly opts: RunnerOptions;
       readonly fix: boolean;
       readonly recheck: boolean;
+    }
+  | {
+      readonly kind: "pr";
+      readonly pr: number;
+      readonly repo?: string;
+      readonly opts: LocalOptions;
+      readonly fix: boolean;
+      readonly recheck: boolean;
     };
 
 export const USAGE = `Needlefish — strict local PR review agent.
 
 Usage:
-  needlefish                       review merge-base..HEAD (local, read-only)
-  needlefish --focus security      narrow the review lens
-  needlefish --deep                wider context (call sites, history, adjacent tests)
-  needlefish --pr 123              also pull PR body/comments/checks via gh
-  needlefish --base develop        override base ref
-  needlefish --runner claude       run with codex, claude, or opencode
-  needlefish --github --pr 123     GitHub Action mode (post review + check)
-  needlefish --recheck             re-run review on current head
+  needlefish [options]                 review merge-base..HEAD (local, read-only)
+  needlefish pr <number> [options]     review PR base..head via gh (any branch)
+  needlefish --github --pr <number>    GitHub Action mode (post review + check)
+
+Shared options:
+  --repo <path>        target repository
+  --focus <text>       narrow the review lens
+  --deep               wider context (call sites, history, adjacent tests)
+  --runner <name>      codex | claude | opencode
+  --model <id>         model id for the selected runner
+  --timeout-ms <ms>    per-call timeout
+  --recheck            re-run review on current target
+
+Local diff options:
+  --pr <number>        attach PR metadata to the local diff review
+  --base <ref>         override base ref
 
 Env:
   NEEDLEFISH_RUNNER       codex | claude | opencode (default: codex)
@@ -91,6 +107,11 @@ function runnerOptionsFrom(opts: MutableLocalOptions): RunnerOptions {
 }
 
 export function parseArgs(argv: readonly string[]): CliCommand {
+  const prCommand = argv[0] === "pr";
+  if (prCommand && (argv[1] === "-h" || argv[1] === "--help")) return { kind: "help" };
+  if (prCommand && (argv[1] === "-v" || argv[1] === "--version")) return { kind: "version" };
+  const prCommandNumber = prCommand ? parsePositiveInteger(argv[1] ?? "", "pr") : undefined;
+  const start = prCommand ? 2 : 0;
   let github = false;
   let pr: number | undefined;
   let repo: string | undefined;
@@ -98,7 +119,7 @@ export function parseArgs(argv: readonly string[]): CliCommand {
   let fix = false;
   let recheck = false;
 
-  for (let i = 0; i < argv.length; i++) {
+  for (let i = start; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "-h" || arg === "--help") return { kind: "help" };
     if (arg === "-v" || arg === "--version") return { kind: "version" };
@@ -187,11 +208,18 @@ export function parseArgs(argv: readonly string[]): CliCommand {
   }
 
   if (github) {
+    if (prCommand) throw new Error("pr command cannot be combined with --github");
     if (!pr) throw new Error("--github requires --pr <number>");
     if (opts.base) throw new Error("--base is only valid in local mode");
     if (opts.focus) throw new Error("--focus is only valid in local mode");
     if (opts.deep) throw new Error("--deep is only valid in local mode");
     return { kind: "github", pr, repo, opts: runnerOptionsFrom(opts), fix, recheck };
+  }
+
+  if (prCommand) {
+    if (pr) throw new Error("pr command cannot be combined with --pr");
+    if (opts.base) throw new Error("--base is not valid with pr command");
+    return { kind: "pr", pr: prCommandNumber!, repo, opts, fix, recheck };
   }
 
   return { kind: "local", repo, opts, fix, recheck };

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -99,6 +99,7 @@ function toReviewResult(raw: RawReview, run: ReviewRun, summary = raw.summary): 
     residualRisks: raw.residual_risks,
     baseSha: bundle.baseSha,
     headSha: bundle.headSha,
+    ...(bundle.reviewTarget ? { reviewTarget: bundle.reviewTarget } : {}),
   };
 }
 

--- a/src/shared/codex-runners.test.ts
+++ b/src/shared/codex-runners.test.ts
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { runCodex } from "./codex";
-import { commitAll, headSha, initRepo, readStringArray } from "./codex-runner-test-fixtures";
+import { commitAll, gitText, headSha, initRepo, readStringArray } from "./codex-runner-test-fixtures";
 
 test("runCodex invokes claude in non-interactive plan mode", async (t) => {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
@@ -239,6 +239,52 @@ test("runCodex reviews a clean clone when the target starts dirty", async (t) =>
 
   assert.equal(output, "{\"ok\":true}");
   assert.equal(existsSync(path.join(repo, "preexisting.txt")), true);
+});
+
+test("runCodex can review an unreferenced target commit", async (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
+  const repo = initRepo(tmp);
+  const baseBranch = gitText(["branch", "--show-current"], repo);
+  gitText(["checkout", "-b", "feature"], repo);
+  writeFileSync(path.join(repo, "README.md"), "feature\n");
+  commitAll(repo, "feature");
+  const targetHeadSha = headSha(repo);
+  gitText(["checkout", baseBranch], repo);
+  gitText(["branch", "-D", "feature"], repo);
+  const bin = path.join(tmp, "claude-bin.js");
+  const readmePath = path.join(tmp, "readme.txt");
+  const previous = {
+    bin: process.env.CLAUDE_BIN,
+    runner: process.env.NEEDLEFISH_RUNNER,
+  };
+  t.after(() => {
+    if (previous.bin === undefined) delete process.env.CLAUDE_BIN;
+    else process.env.CLAUDE_BIN = previous.bin;
+    if (previous.runner === undefined) delete process.env.NEEDLEFISH_RUNNER;
+    else process.env.NEEDLEFISH_RUNNER = previous.runner;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+  writeFileSync(
+    bin,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      `fs.writeFileSync(${JSON.stringify(readmePath)}, fs.readFileSync('README.md', 'utf8'));`,
+      "process.stdout.write('{\"ok\":true}');",
+    ].join("\n")
+  );
+  chmodSync(bin, 0o755);
+  process.env.CLAUDE_BIN = bin;
+  process.env.NEEDLEFISH_RUNNER = "claude";
+
+  const output = await runCodex("prompt", {
+    repoPath: path.relative(process.cwd(), repo),
+    targetHeadSha,
+    timeoutMs: 1000,
+  });
+
+  assert.equal(output, "{\"ok\":true}");
+  assert.equal(readFileSync(readmePath, "utf8"), "feature\n");
 });
 
 test("runCodex reports opencode exit errors before parsing stdout", async (t) => {

--- a/src/shared/render.test.ts
+++ b/src/shared/render.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderMarkdown } from "./render";
+import type { ReviewResult } from "./schema";
+
+test("renderMarkdown includes review target disclosure", () => {
+  const result: ReviewResult = {
+    verdict: "pass",
+    summary: "Clean.",
+    findings: [],
+    checked: ["diff"],
+    residualRisks: [],
+    baseSha: "base",
+    headSha: "head",
+    reviewTarget: "Review target: local base..head\nPR context: #24 metadata only",
+  };
+
+  const markdown = renderMarkdown(result);
+
+  assert.match(markdown, /Review target: local base\.\.head/);
+  assert.match(markdown, /PR context: #24 metadata only/);
+});

--- a/src/shared/render.ts
+++ b/src/shared/render.ts
@@ -19,6 +19,7 @@ export function renderMarkdown(result: ReviewResult): string {
   lines.push("");
   lines.push(`**Verdict:** ${VERDICT_BADGE[result.verdict] ?? result.verdict}`);
   lines.push(`**Base:** ${result.baseSha}  →  **Head:** ${result.headSha}`);
+  if (result.reviewTarget) lines.push(...result.reviewTarget.split("\n"));
   if (result.summary) lines.push("");
   if (result.summary) lines.push(result.summary);
   lines.push("");

--- a/src/shared/repo.test.ts
+++ b/src/shared/repo.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { commitAll, gitText, headSha } from "./codex-runner-test-fixtures";
-import { ensurePrCommits, prDiffFromShas, type PrRefInfo } from "./repo";
+import { ensurePrCommits, makeBundle, prDiffFromShas, type PrRefInfo } from "./repo";
 
 test("ensurePrCommits fetches enough history for a shallow PR graph", () => {
   const tmp = mkdtempSync(join(tmpdir(), "needlefish-repo-"));
@@ -47,4 +47,24 @@ test("ensurePrCommits fetches enough history for a shallow PR graph", () => {
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
+});
+
+test("makeBundle preserves review target disclosure", () => {
+  const bundle = makeBundle({
+    repoPath: process.cwd(),
+    baseSha: "base",
+    headSha: "head",
+    patch: "diff",
+    patchStat: "stat",
+    changedFiles: [],
+    reviewTarget: "Review target: local base..head\nPR context: #24 metadata only",
+    prMeta: null,
+    deep: false,
+    focus: null,
+  });
+
+  assert.equal(
+    bundle.reviewTarget,
+    "Review target: local base..head\nPR context: #24 metadata only"
+  );
 });

--- a/src/shared/repo.test.ts
+++ b/src/shared/repo.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { commitAll, gitText, headSha } from "./codex-runner-test-fixtures";
+import { ensurePrCommits, prDiffFromShas, type PrRefInfo } from "./repo";
+
+test("ensurePrCommits fetches enough history for a shallow PR graph", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-repo-"));
+  try {
+    const work = join(tmp, "work");
+    const remote = join(tmp, "remote.git");
+    gitText(["init", "-q", work], tmp);
+    gitText(["config", "user.email", "test@example.com"], work);
+    gitText(["config", "user.name", "Test"], work);
+    writeFileSync(join(work, "root.txt"), "root\n");
+    commitAll(work, "root");
+    gitText(["branch", "-M", "main"], work);
+    gitText(["checkout", "-b", "feature"], work);
+    writeFileSync(join(work, "feature.txt"), "feature\n");
+    commitAll(work, "feature");
+    const targetHeadSha = headSha(work);
+    gitText(["checkout", "main"], work);
+    writeFileSync(join(work, "base.txt"), "base\n");
+    commitAll(work, "base");
+    const baseSha = headSha(work);
+    gitText(["clone", "--quiet", "--bare", work, remote], tmp);
+
+    const repo = join(tmp, "local");
+    gitText(["init", "-q", repo], tmp);
+    gitText(["remote", "add", "origin", remote], repo);
+    gitText(["fetch", "--quiet", "--depth=1", "origin", baseSha], repo);
+    gitText(["fetch", "--quiet", "--depth=1", "origin", targetHeadSha], repo);
+
+    const pr: PrRefInfo = {
+      baseSha,
+      headSha: targetHeadSha,
+      baseRefName: "main",
+      headRefName: "feature",
+      prMeta: { number: 1, title: "", body: null, comments: [], reviews: [], checks: [] },
+    };
+
+    assert.throws(() => prDiffFromShas(repo, baseSha, targetHeadSha));
+    ensurePrCommits(repo, pr);
+    assert.equal(prDiffFromShas(repo, baseSha, targetHeadSha).headSha, targetHeadSha);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/src/shared/repo.test.ts
+++ b/src/shared/repo.test.ts
@@ -49,6 +49,49 @@ test("ensurePrCommits fetches enough history for a shallow PR graph", () => {
   }
 });
 
+test("ensurePrCommits deepens ready shallow PR graph for sandbox fetch", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-repo-"));
+  try {
+    const work = join(tmp, "work");
+    const remote = join(tmp, "remote.git");
+    gitText(["init", "-q", work], tmp);
+    writeFileSync(join(work, "base.txt"), "base\n");
+    commitAll(work, "base");
+    gitText(["branch", "-M", "main"], work);
+    const baseSha = headSha(work);
+    gitText(["checkout", "-b", "feature"], work);
+    writeFileSync(join(work, "feature.txt"), "feature\n");
+    commitAll(work, "feature");
+    const targetHeadSha = headSha(work);
+    gitText(["clone", "--quiet", "--bare", work, remote], tmp);
+
+    const repo = join(tmp, "local");
+    gitText(["init", "-q", repo], tmp);
+    gitText(["remote", "add", "origin", remote], repo);
+    gitText(["fetch", "--quiet", "--depth=1", "origin", baseSha], repo);
+    gitText(["fetch", "--quiet", "--depth=2", "origin", targetHeadSha], repo);
+    assert.equal(gitText(["rev-parse", "--is-shallow-repository"], repo), "true");
+    assert.equal(gitText(["merge-base", baseSha, targetHeadSha], repo), baseSha);
+
+    const pr: PrRefInfo = {
+      baseSha,
+      headSha: targetHeadSha,
+      baseRefName: "main",
+      headRefName: "feature",
+      prMeta: { number: 1, title: "", body: null, comments: [], reviews: [], checks: [] },
+    };
+
+    ensurePrCommits(repo, pr);
+    const sandbox = join(tmp, "sandbox");
+    gitText(["clone", "--quiet", "--no-hardlinks", "--no-checkout", repo, sandbox], tmp);
+    gitText(["fetch", "--quiet", repo, targetHeadSha], sandbox);
+    gitText(["checkout", "--quiet", "--detach", "FETCH_HEAD"], sandbox);
+    assert.equal(headSha(sandbox), targetHeadSha);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("makeBundle preserves review target disclosure", () => {
   const bundle = makeBundle({
     repoPath: process.cwd(),

--- a/src/shared/repo.ts
+++ b/src/shared/repo.ts
@@ -42,6 +42,7 @@ export interface BundleInput {
   readonly patch: string;
   readonly patchStat: string;
   readonly changedFiles: ChangedFile[];
+  readonly reviewTarget?: string;
   readonly prMeta: PrMeta | null;
   readonly deep: boolean;
   readonly focus: string | null;
@@ -56,6 +57,7 @@ export function makeBundle(input: BundleInput): Bundle {
     patch: input.patch,
     patchStat: input.patchStat,
     changedFiles: input.changedFiles,
+    ...(input.reviewTarget ? { reviewTarget: input.reviewTarget } : {}),
     agentsMd: input.agentsMd ?? readAgents(input.repoPath),
     prMeta: input.prMeta,
     deep: input.deep,

--- a/src/shared/repo.ts
+++ b/src/shared/repo.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { classifyFiles } from "./classify";
+import { normalizePrMeta } from "./normalize";
 import { runText } from "./process";
 import type { Bundle, ChangedFile, PrMeta } from "./schema";
 
@@ -25,6 +26,15 @@ export function readAgents(cwd: string): string {
   return existsSync(agentsPath) ? readFileSync(agentsPath, "utf8") : NO_AGENTS;
 }
 
+export function readAgentsAt(cwd: string, ref: string): string {
+  try {
+    return git(["show", `${ref}:AGENTS.md`], cwd);
+  } catch (err) {
+    if (err instanceof Error) return NO_AGENTS;
+    throw err;
+  }
+}
+
 export interface BundleInput {
   readonly repoPath: string;
   readonly baseSha: string;
@@ -35,6 +45,7 @@ export interface BundleInput {
   readonly prMeta: PrMeta | null;
   readonly deep: boolean;
   readonly focus: string | null;
+  readonly agentsMd?: string;
 }
 
 export function makeBundle(input: BundleInput): Bundle {
@@ -45,9 +56,164 @@ export function makeBundle(input: BundleInput): Bundle {
     patch: input.patch,
     patchStat: input.patchStat,
     changedFiles: input.changedFiles,
-    agentsMd: readAgents(input.repoPath),
+    agentsMd: input.agentsMd ?? readAgents(input.repoPath),
     prMeta: input.prMeta,
     deep: input.deep,
     focus: input.focus,
+  };
+}
+
+export interface PrRefInfo {
+  readonly baseSha: string;
+  readonly headSha: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly prMeta: PrMeta;
+}
+
+export function fetchPrRefInfo(cwd: string, prNumber: number): PrRefInfo {
+  const raw = ghText(
+    [
+      "pr",
+      "view",
+      String(prNumber),
+      "--json",
+      "number,title,body,comments,reviews,statusCheckRollup,baseRefOid,headRefOid,baseRefName,headRefName",
+    ],
+    cwd
+  );
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`PR #${prNumber}: gh response was not an object`);
+  }
+  const record = parsed as Record<string, unknown>;
+  const baseSha = typeof record.baseRefOid === "string" ? record.baseRefOid : "";
+  const headSha = typeof record.headRefOid === "string" ? record.headRefOid : "";
+  const baseRefName = typeof record.baseRefName === "string" ? record.baseRefName : "";
+  const headRefName = typeof record.headRefName === "string" ? record.headRefName : "";
+  if (!baseSha || !headSha || !baseRefName || !headRefName) {
+    throw new Error(`PR #${prNumber}: could not resolve base/head refs via gh`);
+  }
+  return {
+    baseSha,
+    headSha,
+    baseRefName,
+    headRefName,
+    prMeta: normalizePrMeta(parsed, prNumber),
+  };
+}
+
+function hasCommit(cwd: string, sha: string): boolean {
+  try {
+    runText("git", ["cat-file", "-e", `${sha}^{commit}`], { cwd });
+    return true;
+  } catch (err) {
+    if (err instanceof Error) return false;
+    throw err;
+  }
+}
+
+function hasMergeBase(cwd: string, baseSha: string, headSha: string): boolean {
+  try {
+    runText("git", ["merge-base", baseSha, headSha], { cwd });
+    return true;
+  } catch (err) {
+    if (err instanceof Error) return false;
+    throw err;
+  }
+}
+
+function tryFetch(cwd: string, args: readonly string[]): boolean {
+  try {
+    runText("git", args, { cwd, timeoutMs: 120000 });
+    return true;
+  } catch (err) {
+    if (err instanceof Error) return false;
+    throw err;
+  }
+}
+
+function listRemotes(cwd: string): string[] {
+  const out = git(["remote"], cwd);
+  const preferred = ["upstream", "origin"];
+  const all = out.split("\n").filter(Boolean);
+  return [...preferred.filter((name) => all.includes(name)), ...all.filter((name) => !preferred.includes(name))];
+}
+
+function isShallow(cwd: string): boolean {
+  try {
+    return git(["rev-parse", "--is-shallow-repository"], cwd) === "true";
+  } catch (err) {
+    if (err instanceof Error) return false;
+    throw err;
+  }
+}
+
+export function ensurePrCommits(cwd: string, pr: PrRefInfo): void {
+  const ready = () =>
+    hasCommit(cwd, pr.baseSha) &&
+    hasCommit(cwd, pr.headSha) &&
+    hasMergeBase(cwd, pr.baseSha, pr.headSha);
+  if (ready()) return;
+
+  const remotes = listRemotes(cwd);
+  const pullRef = `pull/${pr.prMeta.number}/head`;
+
+  for (const remote of remotes) {
+    if (ready()) return;
+    tryFetch(cwd, ["fetch", "--quiet", remote, pullRef]);
+  }
+
+  for (const remote of remotes) {
+    for (const ref of [pr.baseRefName, pr.headRefName]) {
+      if (ready()) return;
+      tryFetch(cwd, ["fetch", "--quiet", remote, ref]);
+    }
+  }
+
+  for (const sha of [pr.baseSha, pr.headSha]) {
+    if (hasCommit(cwd, sha)) continue;
+    for (const remote of remotes) {
+      if (tryFetch(cwd, ["fetch", "--quiet", remote, sha])) break;
+    }
+  }
+
+  if (!ready() && isShallow(cwd)) {
+    for (const remote of remotes) {
+      for (const ref of [pullRef, pr.baseRefName, pr.headRefName]) {
+        if (ready()) return;
+        if (!isShallow(cwd)) break;
+        tryFetch(cwd, ["fetch", "--quiet", "--unshallow", remote, ref]);
+      }
+    }
+  }
+
+  const missingBase = !hasCommit(cwd, pr.baseSha);
+  const missingHead = !hasCommit(cwd, pr.headSha);
+  if (!missingBase && !missingHead && hasMergeBase(cwd, pr.baseSha, pr.headSha)) return;
+
+  throw new Error(
+    `PR #${pr.prMeta.number}: missing ${[
+      missingBase ? "base" : "",
+      missingHead ? "head" : "",
+      !missingBase && !missingHead ? "merge-base" : "",
+    ]
+      .filter(Boolean)
+      .join("/")} commit locally; try git fetch`
+  );
+}
+
+export function prDiffFromShas(cwd: string, baseSha: string, headSha: string) {
+  const mergeBase = git(["merge-base", baseSha, headSha], cwd);
+  const patch = git(["diff", mergeBase, headSha], cwd);
+  if (!patch.trim()) {
+    throw new Error(`No diff between ${mergeBase} and ${headSha}. Nothing to review.`);
+  }
+  return {
+    baseSha: mergeBase,
+    headSha,
+    patch,
+    patchStat: git(["diff", "--stat", mergeBase, headSha], cwd),
+    changedFiles: changedFiles(cwd, mergeBase, headSha),
   };
 }

--- a/src/shared/repo.ts
+++ b/src/shared/repo.ts
@@ -151,24 +151,39 @@ function isShallow(cwd: string): boolean {
   }
 }
 
+function deepenShallowPrRefs(cwd: string, remotes: readonly string[], refs: readonly string[]): void {
+  if (!isShallow(cwd)) return;
+  for (const remote of remotes) {
+    for (const ref of refs) {
+      if (!isShallow(cwd)) return;
+      tryFetch(cwd, ["fetch", "--quiet", "--unshallow", remote, ref]);
+    }
+  }
+}
+
 export function ensurePrCommits(cwd: string, pr: PrRefInfo): void {
   const ready = () =>
     hasCommit(cwd, pr.baseSha) &&
     hasCommit(cwd, pr.headSha) &&
     hasMergeBase(cwd, pr.baseSha, pr.headSha);
-  if (ready()) return;
-
   const remotes = listRemotes(cwd);
   const pullRef = `pull/${pr.prMeta.number}/head`;
+  const prRefs = [pullRef, pr.baseRefName, pr.headRefName];
+  const readyForSandbox = () => ready() && !isShallow(cwd);
+
+  if (ready()) {
+    deepenShallowPrRefs(cwd, remotes, prRefs);
+    if (readyForSandbox()) return;
+  }
 
   for (const remote of remotes) {
-    if (ready()) return;
+    if (readyForSandbox()) return;
     tryFetch(cwd, ["fetch", "--quiet", remote, pullRef]);
   }
 
   for (const remote of remotes) {
     for (const ref of [pr.baseRefName, pr.headRefName]) {
-      if (ready()) return;
+      if (readyForSandbox()) return;
       tryFetch(cwd, ["fetch", "--quiet", remote, ref]);
     }
   }
@@ -180,25 +195,20 @@ export function ensurePrCommits(cwd: string, pr: PrRefInfo): void {
     }
   }
 
-  if (!ready() && isShallow(cwd)) {
-    for (const remote of remotes) {
-      for (const ref of [pullRef, pr.baseRefName, pr.headRefName]) {
-        if (ready()) return;
-        if (!isShallow(cwd)) break;
-        tryFetch(cwd, ["fetch", "--quiet", "--unshallow", remote, ref]);
-      }
-    }
-  }
+  deepenShallowPrRefs(cwd, remotes, prRefs);
 
   const missingBase = !hasCommit(cwd, pr.baseSha);
   const missingHead = !hasCommit(cwd, pr.headSha);
-  if (!missingBase && !missingHead && hasMergeBase(cwd, pr.baseSha, pr.headSha)) return;
+  const missingMergeBase = !missingBase && !missingHead && !hasMergeBase(cwd, pr.baseSha, pr.headSha);
+  const shallow = isShallow(cwd);
+  if (!missingBase && !missingHead && !missingMergeBase && !shallow) return;
 
   throw new Error(
     `PR #${pr.prMeta.number}: missing ${[
       missingBase ? "base" : "",
       missingHead ? "head" : "",
-      !missingBase && !missingHead ? "merge-base" : "",
+      missingMergeBase ? "merge-base" : "",
+      shallow ? "unshallowed-history" : "",
     ]
       .filter(Boolean)
       .join("/")} commit locally; try git fetch`

--- a/src/shared/runner-sandbox.ts
+++ b/src/shared/runner-sandbox.ts
@@ -33,11 +33,13 @@ export function isRunnerSafetyError(error: unknown): boolean {
 
 export function prepareRunnerSandbox(options: RunnerSandboxOptions): RunnerSandbox {
   const sandboxPath = path.join(options.tmp, "runner-repo");
-  git(["clone", "--quiet", "--no-hardlinks", options.repoPath, sandboxPath], options.repoPath);
-  git(["checkout", "--quiet", "--detach", options.targetHeadSha], sandboxPath);
+  const sourceRepoPath = path.resolve(options.repoPath);
+  git(["clone", "--quiet", "--no-hardlinks", "--no-checkout", sourceRepoPath, sandboxPath], sourceRepoPath);
+  git(["fetch", "--quiet", sourceRepoPath, options.targetHeadSha], sandboxPath);
+  git(["checkout", "--quiet", "--detach", "FETCH_HEAD"], sandboxPath);
   return {
     repoPath: sandboxPath,
-    prompt: options.prompt.split(options.repoPath).join(sandboxPath),
+    prompt: options.prompt.split(sourceRepoPath).join(sandboxPath),
   };
 }
 

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -42,6 +42,7 @@ export interface Bundle {
   readonly patch: string;
   readonly patchStat: string;
   readonly changedFiles: readonly ChangedFile[];
+  readonly reviewTarget?: string;
   readonly agentsMd: string;
   readonly prMeta: PrMeta | null;
   readonly deep: boolean;
@@ -83,6 +84,7 @@ export interface ReviewResult {
   readonly residualRisks: readonly ResidualRisk[];
   readonly baseSha: string;
   readonly headSha: string;
+  readonly reviewTarget?: string;
 }
 
 export interface RiskEdge {


### PR DESCRIPTION
### What's changed?

- Review local `--pr` by resolving PR base/head refs and running against the PR head from any branch.
- Share PR diff construction with GitHub Action mode.
- Add repo helper coverage for PR diffs and detached worktree review paths.
- Update README/CLI wording for the new local `--pr` behavior.

### Why

- Local PR reviews should match the PR base..head range instead of depending on the current checkout branch.

### Verification

- `./node_modules/.bin/tsc --noEmit`
- `node scripts/test.mjs` (39 passed)
- `git diff --check && git diff --cached --check`
- `/pre-ship --committed` (0 MUST-FIX)