### PR TITLE
Fix post-merge findings from PR #13

### DIFF
--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -34,6 +34,59 @@ test("loadFixture materializes a git repo and builds a bundle with the defect di
     assert.ok(loaded.bundle.patch.includes('req.role === "viewer"'), "patch must contain the over-block guard");
     assert.ok(loaded.bundle.changedFiles.some((f) => f.path === "src/handler.ts"));
     assert.equal(loaded.bundle.deep, false);
+  } finally {
+    loaded.cleanup();
+  }
+});
+
+test("loadFixture materializes a renamed file", () => {
+  const loaded = loadFixture({
+    ...posOverBlock,
+    id: "rename-materialization",
+    baseFiles: { "src/old.ts": "export const value = 1;\n" },
+    deletedFiles: ["src/old.ts"],
+    headFiles: { "src/new.ts": "export const value = 1;\n" },
+  });
+  try {
+    assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/old.ts")), false);
+    assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/new.ts")), true);
+    assert.match(loaded.bundle.patch, /rename from src\/old\.ts/);
+    assert.match(loaded.bundle.patch, /rename to src\/new\.ts/);
+  } finally {
+    loaded.cleanup();
+  }
+});
+
+test("loadFixture materializes a deleted file", () => {
+  const loaded = loadFixture({
+    ...posOverBlock,
+    id: "deletion-materialization",
+    baseFiles: { "src/deleted.ts": "export const deleted = true;\n" },
+    deletedFiles: ["src/deleted.ts"],
+    headFiles: {},
+  });
+  try {
+    assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/deleted.ts")), false);
+    assert.match(loaded.bundle.patch, /deleted file mode/);
+    assert.match(loaded.bundle.patch, /-export const deleted = true;/);
+  } finally {
+    loaded.cleanup();
+  }
+});
+
+test("loadFixture preserves unchanged base-only files when deletedFiles is omitted", () => {
+  const loaded = loadFixture({
+    ...posOverBlock,
+    id: "overlay-materialization",
+    baseFiles: {
+      "src/context.ts": "export const context = true;\n",
+      "src/changed.ts": "export const value = 1;\n",
+    },
+    headFiles: { "src/changed.ts": "export const value = 2;\n" },
+  });
+  try {
+    assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/context.ts")), true);
+    assert.doesNotMatch(loaded.bundle.patch, /src\/context\.ts/);
   } finally {
     loaded.cleanup();
   }
@@ -347,6 +400,14 @@ test("fixtureSetHash: unset provenance hashes identically whether the key is omi
   const implicit = holdoutSpec("prov-b", false);
   const explicit: FixtureSpec = { ...implicit, provenance: undefined };
   assert.equal(fixtureSetHash([implicit]), fixtureSetHash([explicit]));
+});
+
+test("fixtureSetHash: changes when deletion metadata changes", () => {
+  const withoutDeletion = holdoutSpec("deletion-hash", false);
+  const withEmptyDeletion: FixtureSpec = { ...withoutDeletion, deletedFiles: [] };
+  const withDeletion: FixtureSpec = { ...withoutDeletion, deletedFiles: ["src/old.ts"] };
+  assert.equal(fixtureSetHash([withoutDeletion]), fixtureSetHash([withEmptyDeletion]));
+  assert.notEqual(fixtureSetHash([withoutDeletion]), fixtureSetHash([withDeletion]));
 });
 
 test("compare: rejects a legacy baseline without fixtureSetHash", () => {

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -268,6 +268,42 @@ test("loadFixture canonicalizes disjoint explicit rename order without mutating 
   }
 });
 
+test("loadFixture treats a leading-colon rename path as a literal Git pathspec", () => {
+  const loaded = loadFixture({
+    ...posOverBlock,
+    id: "literal-colon-rename",
+    baseFiles: { ":weird.ts": "same\n", "src/ordinary.ts": "old\n" },
+    deletedFiles: [":weird.ts"],
+    renamedFiles: [{ from: ":weird.ts", to: "weird.ts" }],
+    headFiles: { "weird.ts": "same\n", "src/ordinary.ts": "new\n" },
+  });
+  try {
+    assert.match(loaded.bundle.patch, /^rename from :weird\.ts$/m);
+    assert.match(loaded.bundle.patch, /^rename to weird\.ts$/m);
+    assert.match(loaded.bundle.patch, /^diff --git a\/src\/ordinary\.ts b\/src\/ordinary\.ts$/m);
+  } finally {
+    loaded.cleanup();
+  }
+});
+
+test("loadFixture isolates character-class rename paths from ordinary changes", () => {
+  const loaded = loadFixture({
+    ...posOverBlock,
+    id: "literal-character-class-rename",
+    baseFiles: { "lib[util].ts": "same\n", "libu.ts": "old\n" },
+    deletedFiles: ["lib[util].ts"],
+    renamedFiles: [{ from: "lib[util].ts", to: "lib_util.ts" }],
+    headFiles: { "lib_util.ts": "same\n", "libu.ts": "new\n" },
+  });
+  try {
+    assert.match(loaded.bundle.patch, /^rename from lib\[util\]\.ts$/m);
+    assert.match(loaded.bundle.patch, /^rename to lib_util\.ts$/m);
+    assert.match(loaded.bundle.patch, /^diff --git a\/libu\.ts b\/libu\.ts$/m);
+  } finally {
+    loaded.cleanup();
+  }
+});
+
 test("loadFixture preserves unchanged base-only files when deletedFiles is omitted", () => {
   const loaded = loadFixture({
     ...posOverBlock,

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -165,6 +165,19 @@ test("loadFixture rejects duplicate deletedFiles before materialization", () => 
   );
 });
 
+test("loadFixture rejects a deleted path that still exists in the head tree", () => {
+  assert.throws(
+    () => loadFixture({
+      ...posOverBlock,
+      id: "deleted-path-retained",
+      baseFiles: { "src/deleted.ts": "old\n" },
+      deletedFiles: ["src/deleted.ts"],
+      headFiles: { "src/deleted.ts": "new\n" },
+    }),
+    /deletedFiles path still exists in headFiles: src\/deleted\.ts/
+  );
+});
+
 test("loadFixture rejects a deletedFiles path that is absent from the base tree", () => {
   assert.throws(
     () => loadFixture({
@@ -214,7 +227,7 @@ test("loadFixture rejects overlapping explicit rename endpoints", () => {
   );
 });
 
-test("loadFixture rejects a rename source that remains in the head tree", () => {
+test("loadFixture rejects a rename source that remains in the head tree as a deletion overlap", () => {
   assert.throws(
     () => loadFixture({
       ...posOverBlock,
@@ -224,8 +237,35 @@ test("loadFixture rejects a rename source that remains in the head tree", () => 
       renamedFiles: [{ from: "src/old.ts", to: "src/new.ts" }],
       headFiles: { "src/old.ts": "old\n", "src/new.ts": "old\n" },
     }),
-    /renamedFiles from path still exists in headFiles: src\/old\.ts/
+    /deletedFiles path still exists in headFiles: src\/old\.ts/
   );
+});
+
+test("loadFixture canonicalizes disjoint explicit rename order without mutating the spec", () => {
+  const first = { from: "src/a.ts", to: "src/x.ts" };
+  const second = { from: "src/b.ts", to: "src/y.ts" };
+  const base: FixtureSpec = {
+    ...posOverBlock,
+    id: "canonical-renames",
+    baseFiles: { "src/a.ts": "alpha\n", "src/b.ts": "bravo\n" },
+    deletedFiles: ["src/a.ts", "src/b.ts"],
+    headFiles: { "src/x.ts": "alpha\n", "src/y.ts": "bravo\n" },
+  };
+  const forward: FixtureSpec = { ...base, renamedFiles: [first, second] };
+  const reversedRenames = [second, first];
+  const reversed: FixtureSpec = { ...base, renamedFiles: reversedRenames };
+  const forwardLoaded = loadFixture(forward);
+  const reversedLoaded = loadFixture(reversed);
+  try {
+    assert.equal(forwardLoaded.bundle.patch, reversedLoaded.bundle.patch);
+    assert.equal(forwardLoaded.bundle.patchStat, reversedLoaded.bundle.patchStat);
+    assert.deepEqual(forwardLoaded.bundle.changedFiles, reversedLoaded.bundle.changedFiles);
+    assert.equal(fixtureSetHash([forward]), fixtureSetHash([reversed]));
+    assert.deepEqual(reversedRenames, [second, first]);
+  } finally {
+    forwardLoaded.cleanup();
+    reversedLoaded.cleanup();
+  }
 });
 
 test("loadFixture preserves unchanged base-only files when deletedFiles is omitted", () => {

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -1,14 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Finding, Verdict } from "../src/shared/schema";
-import { fixtureSetHash, loadFixtures, mapLimit, parseArgs, filterByHoldout } from "./run";
+import { compare, fixtureSetHash, loadFixtures, mapLimit, parseArgs, filterByHoldout } from "./run";
 import { loadFixture } from "./shared/fixture";
 import { promptHash } from "./shared/prompt-hash";
 import { matchesSpec, score } from "./shared/score";
-import type { Expected, FixtureSpec } from "./shared/types";
+import type { Expected, FixtureSpec, Report } from "./shared/types";
 import posOverBlock from "./fixtures/pos-over-block/spec";
 import negStyleOnly from "./fixtures/neg-style-only/spec";
 
@@ -346,6 +347,44 @@ test("fixtureSetHash: unset provenance hashes identically whether the key is omi
   const implicit = holdoutSpec("prov-b", false);
   const explicit: FixtureSpec = { ...implicit, provenance: undefined };
   assert.equal(fixtureSetHash([implicit]), fixtureSetHash([explicit]));
+});
+
+test("compare: rejects a legacy baseline without fixtureSetHash", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "needlefish-compare-"));
+  const baselinePath = path.join(dir, "baseline.json");
+  const candidate: Report = {
+    promptHash: "prompt-hash",
+    runner: "codex",
+    model: null,
+    effort: null,
+    draws: 1,
+    createdAt: "2026-07-10T00:00:00.000Z",
+    baseline: false,
+    holdout: "include",
+    results: [],
+    aggregates: {
+      recall: 0,
+      falsePositiveRate: 0,
+      invalidJsonRate: 0,
+      verdictMatchRate: 0,
+      lineAnchorValidRate: 0,
+      meanDurationMs: 0,
+      recallByFixture: {},
+      criticPruneErrorRate: 0,
+      recallByTier: {},
+      meanNoisePerPositive: 0,
+      cheatDetectedCount: 0,
+    },
+    fixtureSetHash: "fixture-hash",
+  };
+  const legacyBaseline = { ...candidate, baseline: true };
+  delete legacyBaseline.fixtureSetHash;
+  writeFileSync(baselinePath, JSON.stringify(legacyBaseline));
+  try {
+    assert.throws(() => compare(baselinePath, candidate), /baseline report is missing fixtureSetHash/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("loadFixtures: discovers a fixture placed in eval/fixtures-real/", async () => {

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Finding, Verdict } from "../src/shared/schema";
-import { compare, fixtureSetHash, loadFixtures, mapLimit, parseArgs, filterByHoldout } from "./run";
+import { compare, fixtureSetHash, loadFixtures, mapLimit, parseArgs, filterByHoldout, resumeSlots } from "./run";
 import { loadFixture } from "./shared/fixture";
 import { promptHash } from "./shared/prompt-hash";
 import { matchesSpec, score } from "./shared/score";
@@ -474,6 +474,52 @@ test("fixtureSetHash: deletion order is canonical but deletion content remains s
   const different: FixtureSpec = { ...spec, deletedFiles: ["src/a.ts", "src/c.ts"] };
   assert.equal(fixtureSetHash([forward]), fixtureSetHash([reversed]));
   assert.notEqual(fixtureSetHash([forward]), fixtureSetHash([different]));
+});
+
+test("resumeSlots: a legacy report without fixtureSetHash reuses zero draws", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "needlefish-resume-"));
+  const resumePath = path.join(dir, "legacy.json");
+  const spec = holdoutSpec("legacy-resume", false);
+  const existing: Report = {
+    promptHash: promptHash(),
+    runner: "codex",
+    model: null,
+    effort: null,
+    draws: 1,
+    createdAt: "2026-07-10T00:00:00.000Z",
+    baseline: false,
+    holdout: "include",
+    results: [{
+      fixtureId: spec.id,
+      draw: 0,
+      score: score({ verdict: "pass", findings: [] }, spec.expected, spec.id),
+      durationMs: 1,
+      calls: 1,
+      retries: 0,
+    }],
+    aggregates: {
+      recall: 1,
+      falsePositiveRate: 0,
+      invalidJsonRate: 0,
+      verdictMatchRate: 1,
+      lineAnchorValidRate: 1,
+      meanDurationMs: 1,
+      recallByFixture: { [spec.id]: 1 },
+      criticPruneErrorRate: 0,
+      recallByTier: { t2: 1 },
+      meanNoisePerPositive: 0,
+      cheatDetectedCount: 0,
+    },
+  };
+  writeFileSync(resumePath, JSON.stringify(existing));
+  try {
+    const args = parseArgs(["--draws", "1", "--resume", resumePath]);
+    const resumed = resumeSlots(args, [spec], [{ spec, draw: 0 }]);
+    assert.equal(resumed.skipped, 0);
+    assert.deepEqual(resumed.slots, [null]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("compare: rejects a legacy baseline without fixtureSetHash", () => {

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -39,21 +39,37 @@ test("loadFixture materializes a git repo and builds a bundle with the defect di
   }
 });
 
-test("loadFixture materializes a renamed file", () => {
-  const loaded = loadFixture({
-    ...posOverBlock,
-    id: "rename-materialization",
-    baseFiles: { "src/old.ts": "export const value = 1;\n" },
-    deletedFiles: ["src/old.ts"],
-    headFiles: { "src/new.ts": "export const value = 1;\n" },
-  });
+test("loadFixture forces deterministic rename detection when git config disables it", () => {
+  const previousCount = process.env.GIT_CONFIG_COUNT;
+  const previousKey = process.env.GIT_CONFIG_KEY_0;
+  const previousValue = process.env.GIT_CONFIG_VALUE_0;
+  process.env.GIT_CONFIG_COUNT = "1";
+  process.env.GIT_CONFIG_KEY_0 = "diff.renames";
+  process.env.GIT_CONFIG_VALUE_0 = "false";
+
+  let loaded: ReturnType<typeof loadFixture> | undefined;
   try {
+    loaded = loadFixture({
+      ...posOverBlock,
+      id: "rename-materialization",
+      baseFiles: { "src/old.ts": "export const value = 1;\n" },
+      deletedFiles: ["src/old.ts"],
+      headFiles: { "src/new.ts": "export const value = 1;\n" },
+    });
     assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/old.ts")), false);
     assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/new.ts")), true);
     assert.match(loaded.bundle.patch, /rename from src\/old\.ts/);
     assert.match(loaded.bundle.patch, /rename to src\/new\.ts/);
+    assert.match(loaded.bundle.patchStat, /src\/\{old\.ts => new\.ts\}/);
+    assert.deepEqual(loaded.bundle.changedFiles.map((file) => file.path), ["src/new.ts"]);
   } finally {
-    loaded.cleanup();
+    loaded?.cleanup();
+    if (previousCount === undefined) delete process.env.GIT_CONFIG_COUNT;
+    else process.env.GIT_CONFIG_COUNT = previousCount;
+    if (previousKey === undefined) delete process.env.GIT_CONFIG_KEY_0;
+    else process.env.GIT_CONFIG_KEY_0 = previousKey;
+    if (previousValue === undefined) delete process.env.GIT_CONFIG_VALUE_0;
+    else process.env.GIT_CONFIG_VALUE_0 = previousValue;
   }
 });
 
@@ -72,6 +88,19 @@ test("loadFixture materializes a deleted file", () => {
   } finally {
     loaded.cleanup();
   }
+});
+
+test("loadFixture rejects a deletedFiles path that is absent from the base tree", () => {
+  assert.throws(
+    () => loadFixture({
+      ...posOverBlock,
+      id: "missing-deletion",
+      baseFiles: { "src/present.ts": "export const present = true;\n" },
+      deletedFiles: ["src/missing.ts"],
+      headFiles: {},
+    }),
+    /ENOENT|no such file or directory/
+  );
 });
 
 test("loadFixture preserves unchanged base-only files when deletedFiles is omitted", () => {

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -90,6 +90,34 @@ test("loadFixture materializes a deleted file", () => {
   }
 });
 
+test("loadFixture materializes a pure-add fixture from an empty base commit", () => {
+  const loaded = loadFixture({
+    ...posOverBlock,
+    id: "pure-add-materialization",
+    baseFiles: {},
+    headFiles: { "src/added.ts": "export const added = true;\n" },
+  });
+  try {
+    assert.match(loaded.bundle.patch, /new file mode/);
+    assert.match(loaded.bundle.patch, /\+export const added = true;/);
+  } finally {
+    loaded.cleanup();
+  }
+});
+
+test("loadFixture rejects duplicate deletedFiles before materialization", () => {
+  assert.throws(
+    () => loadFixture({
+      ...posOverBlock,
+      id: "duplicate-deletion",
+      baseFiles: { "src/deleted.ts": "export const deleted = true;\n" },
+      deletedFiles: ["src/deleted.ts", "src/deleted.ts"],
+      headFiles: {},
+    }),
+    /duplicate deletedFiles path: src\/deleted\.ts/
+  );
+});
+
 test("loadFixture rejects a deletedFiles path that is absent from the base tree", () => {
   assert.throws(
     () => loadFixture({
@@ -437,6 +465,15 @@ test("fixtureSetHash: changes when deletion metadata changes", () => {
   const withDeletion: FixtureSpec = { ...withoutDeletion, deletedFiles: ["src/old.ts"] };
   assert.equal(fixtureSetHash([withoutDeletion]), fixtureSetHash([withEmptyDeletion]));
   assert.notEqual(fixtureSetHash([withoutDeletion]), fixtureSetHash([withDeletion]));
+});
+
+test("fixtureSetHash: deletion order is canonical but deletion content remains significant", () => {
+  const spec = holdoutSpec("deletion-order-hash", false);
+  const forward: FixtureSpec = { ...spec, deletedFiles: ["src/a.ts", "src/b.ts"] };
+  const reversed: FixtureSpec = { ...spec, deletedFiles: ["src/b.ts", "src/a.ts"] };
+  const different: FixtureSpec = { ...spec, deletedFiles: ["src/a.ts", "src/c.ts"] };
+  assert.equal(fixtureSetHash([forward]), fixtureSetHash([reversed]));
+  assert.notEqual(fixtureSetHash([forward]), fixtureSetHash([different]));
 });
 
 test("compare: rejects a legacy baseline without fixtureSetHash", () => {

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -52,9 +52,10 @@ test("loadFixture forces deterministic rename detection when git config disables
     loaded = loadFixture({
       ...posOverBlock,
       id: "rename-materialization",
-      baseFiles: { "src/old.ts": "export const value = 1;\n" },
+      baseFiles: { "src/old.ts": "export const one = 1;\nexport const two = 2;\nexport const changed = 3;\nexport const four = 4;\n" },
       deletedFiles: ["src/old.ts"],
-      headFiles: { "src/new.ts": "export const value = 1;\n" },
+      renamedFiles: [{ from: "src/old.ts", to: "src/new.ts" }],
+      headFiles: { "src/new.ts": "export const one = 1;\nexport const two = 2;\nexport const changed = 30;\nexport const four = 4;\n" },
     });
     assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/old.ts")), false);
     assert.equal(existsSync(path.join(loaded.bundle.repoPath, "src/new.ts")), true);
@@ -70,6 +71,52 @@ test("loadFixture forces deterministic rename detection when git config disables
     else process.env.GIT_CONFIG_KEY_0 = previousKey;
     if (previousValue === undefined) delete process.env.GIT_CONFIG_VALUE_0;
     else process.env.GIT_CONFIG_VALUE_0 = previousValue;
+  }
+});
+
+test("loadFixture rejects an explicit rename with zero content similarity", () => {
+  assert.throws(
+    () => loadFixture({
+      ...posOverBlock,
+      id: "zero-similarity-rename",
+      baseFiles: { "src/old.ts": "export const oldOnly = true;\n" },
+      deletedFiles: ["src/old.ts"],
+      renamedFiles: [{ from: "src/old.ts", to: "src/new.ts" }],
+      headFiles: { "src/new.ts": "completely unrelated prose\n" },
+    }),
+    /explicit rename did not render as a rename: src\/old\.ts -> src\/new\.ts/
+  );
+});
+
+test("loadFixture rejects a rename destination that already exists in the base tree", () => {
+  assert.throws(
+    () => loadFixture({
+      ...posOverBlock,
+      id: "preexisting-rename-destination",
+      baseFiles: { "src/old.ts": "old\n", "src/new.ts": "preexisting\n" },
+      deletedFiles: ["src/old.ts"],
+      renamedFiles: [{ from: "src/old.ts", to: "src/new.ts" }],
+      headFiles: { "src/new.ts": "old\n" },
+    }),
+    /renamedFiles to path already exists in baseFiles: src\/new\.ts/
+  );
+});
+
+test("loadFixture does not synthesize an independent delete and add into a rename", () => {
+  const loaded = loadFixture({
+    ...posOverBlock,
+    id: "independent-delete-add",
+    baseFiles: { "src/old.ts": "export const value = 1;\n" },
+    deletedFiles: ["src/old.ts"],
+    headFiles: { "src/new.ts": "export const value = 1;\n" },
+  });
+  try {
+    assert.match(loaded.bundle.patch, /deleted file mode/);
+    assert.match(loaded.bundle.patch, /new file mode/);
+    assert.doesNotMatch(loaded.bundle.patch, /rename from|rename to/);
+    assert.deepEqual(loaded.bundle.changedFiles.map((file) => file.path), ["src/new.ts", "src/old.ts"]);
+  } finally {
+    loaded.cleanup();
   }
 });
 
@@ -128,6 +175,56 @@ test("loadFixture rejects a deletedFiles path that is absent from the base tree"
       headFiles: {},
     }),
     /ENOENT|no such file or directory/
+  );
+});
+
+test("loadFixture validates explicit rename metadata", () => {
+  const fixture: FixtureSpec = {
+    ...posOverBlock,
+    id: "invalid-rename",
+    baseFiles: { "src/old.ts": "old\n" },
+    deletedFiles: ["src/old.ts"],
+    headFiles: { "src/new.ts": "new\n" },
+  };
+  assert.throws(
+    () => loadFixture({ ...fixture, renamedFiles: [{ from: "src/missing.ts", to: "src/new.ts" }] }),
+    /renamedFiles from path is not deleted: src\/missing\.ts/
+  );
+  assert.throws(
+    () => loadFixture({ ...fixture, renamedFiles: [{ from: "src/old.ts", to: "src/missing.ts" }] }),
+    /renamedFiles to path is absent from headFiles: src\/missing\.ts/
+  );
+  assert.throws(
+    () => loadFixture({ ...fixture, renamedFiles: [{ from: "src/old.ts", to: "src/new.ts" }, { from: "src/old.ts", to: "src/other.ts" }] }),
+    /duplicate renamedFiles from path: src\/old\.ts/
+  );
+});
+
+test("loadFixture rejects overlapping explicit rename endpoints", () => {
+  assert.throws(
+    () => loadFixture({
+      ...posOverBlock,
+      id: "overlapping-renames",
+      baseFiles: { "src/a.ts": "a\n", "src/b.ts": "b\n" },
+      deletedFiles: ["src/a.ts", "src/b.ts"],
+      renamedFiles: [{ from: "src/a.ts", to: "src/b.ts" }, { from: "src/b.ts", to: "src/c.ts" }],
+      headFiles: { "src/b.ts": "a\n", "src/c.ts": "b\n" },
+    }),
+    /duplicate renamedFiles endpoint path: src\/b\.ts/
+  );
+});
+
+test("loadFixture rejects a rename source that remains in the head tree", () => {
+  assert.throws(
+    () => loadFixture({
+      ...posOverBlock,
+      id: "rename-source-retained",
+      baseFiles: { "src/old.ts": "old\n" },
+      deletedFiles: ["src/old.ts"],
+      renamedFiles: [{ from: "src/old.ts", to: "src/new.ts" }],
+      headFiles: { "src/old.ts": "old\n", "src/new.ts": "old\n" },
+    }),
+    /renamedFiles from path still exists in headFiles: src\/old\.ts/
   );
 });
 
@@ -474,6 +571,18 @@ test("fixtureSetHash: deletion order is canonical but deletion content remains s
   const different: FixtureSpec = { ...spec, deletedFiles: ["src/a.ts", "src/c.ts"] };
   assert.equal(fixtureSetHash([forward]), fixtureSetHash([reversed]));
   assert.notEqual(fixtureSetHash([forward]), fixtureSetHash([different]));
+});
+
+test("fixtureSetHash: rename metadata matters, while omission, emptiness, and order are canonical", () => {
+  const spec = holdoutSpec("rename-hash", false);
+  const first = { from: "src/a.ts", to: "src/b.ts" };
+  const second = { from: "src/c.ts", to: "src/d.ts" };
+  assert.equal(fixtureSetHash([spec]), fixtureSetHash([{ ...spec, renamedFiles: [] }]));
+  assert.notEqual(fixtureSetHash([spec]), fixtureSetHash([{ ...spec, renamedFiles: [first] }]));
+  assert.equal(
+    fixtureSetHash([{ ...spec, renamedFiles: [first, second] }]),
+    fixtureSetHash([{ ...spec, renamedFiles: [second, first] }])
+  );
 });
 
 test("resumeSlots: a legacy report without fixtureSetHash reuses zero draws", () => {

--- a/eval/leak.test.ts
+++ b/eval/leak.test.ts
@@ -1,9 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import type { FixtureSpec } from "./shared/types";
+import { fileURLToPath } from "node:url";
+import { loadFixtures } from "./run";
 
 // Anti-overfitting lint: the prompts under test must never reference the
 // exam. A prompt that names a fixture id or embeds a mustFind pattern is
@@ -11,23 +11,7 @@ import type { FixtureSpec } from "./shared/types";
 // quality. (Same class of ban as AGENTS.md "no target-repo customization".)
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const FIXTURES_DIR = path.join(__dirname, "fixtures");
 const PROMPTS_DIR = path.join(__dirname, "..", "prompts");
-
-async function loadAll(): Promise<FixtureSpec[]> {
-  const dirs = readdirSync(FIXTURES_DIR, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .map((d) => d.name)
-    .sort();
-  const specs: FixtureSpec[] = [];
-  for (const dir of dirs) {
-    const specPath = path.join(FIXTURES_DIR, dir, "spec.ts");
-    if (!existsSync(specPath)) continue;
-    const mod = await import(pathToFileURL(specPath).href);
-    if (mod.default) specs.push(mod.default as FixtureSpec);
-  }
-  return specs;
-}
 
 function promptTexts(): Array<[string, string]> {
   return readdirSync(PROMPTS_DIR)
@@ -36,7 +20,7 @@ function promptTexts(): Array<[string, string]> {
 }
 
 test("prompts never mention a fixture id", async () => {
-  const specs = await loadAll();
+  const specs = await loadFixtures(null);
   const prompts = promptTexts();
   for (const spec of specs) {
     for (const [file, text] of prompts) {
@@ -45,8 +29,16 @@ test("prompts never mention a fixture id", async () => {
   }
 });
 
+test("anti-leakage fixture source includes fixtures-real", async () => {
+  const specs = await loadFixtures(null);
+  assert.ok(
+    specs.some((spec) => spec.id === "real-pr1-token-leak"),
+    "eval/fixtures-real must be included in anti-leakage checks"
+  );
+});
+
 test("prompts never embed a mustFind/trap pattern verbatim", async () => {
-  const specs = await loadAll();
+  const specs = await loadFixtures(null);
   const prompts = promptTexts();
   for (const spec of specs) {
     const patterns = [...(spec.expected.mustFind ?? []), ...(spec.expected.trap ?? [])].map((m) => m.pattern);

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -264,7 +264,7 @@ async function runWork(
 export function fixtureSetHash(specs: readonly FixtureSpec[]): string {
   const canonical = [...specs]
     .sort((a, b) => a.id.localeCompare(b.id))
-    .map((s) => ({ id: s.id, kind: s.kind, tier: s.tier ?? null, baseFiles: s.baseFiles, ...(s.deletedFiles && s.deletedFiles.length > 0 ? { deletedFiles: s.deletedFiles } : {}), headFiles: s.headFiles, expected: s.expected, holdout: s.holdout ?? false, provenance: s.provenance }));
+    .map((s) => ({ id: s.id, kind: s.kind, tier: s.tier ?? null, baseFiles: s.baseFiles, ...(s.deletedFiles && s.deletedFiles.length > 0 ? { deletedFiles: [...s.deletedFiles].sort() } : {}), headFiles: s.headFiles, expected: s.expected, holdout: s.holdout ?? false, provenance: s.provenance }));
   return createHash("sha256").update(JSON.stringify(canonical)).digest("hex").slice(0, 16);
 }
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -182,7 +182,7 @@ function completedResults(slots: readonly (DrawResult | null)[]): DrawResult[] {
   return slots.filter((r): r is DrawResult => r !== null);
 }
 
-function resumeSlots(
+export function resumeSlots(
   args: RunArgs,
   specs: readonly FixtureSpec[],
   work: readonly DrawWork[]
@@ -201,7 +201,7 @@ function resumeSlots(
       return { slots, skipped };
     }
     const currentFixtureHash = fixtureSetHash(specs);
-    if (existing.fixtureSetHash !== undefined && existing.fixtureSetHash !== currentFixtureHash) {
+    if (existing.fixtureSetHash !== currentFixtureHash) {
       process.stderr.write(
         `resume: fixture set hash mismatch (${existing.fixtureSetHash} vs ${currentFixtureHash}), ignoring resume file\n`
       );

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -264,7 +264,7 @@ async function runWork(
 export function fixtureSetHash(specs: readonly FixtureSpec[]): string {
   const canonical = [...specs]
     .sort((a, b) => a.id.localeCompare(b.id))
-    .map((s) => ({ id: s.id, kind: s.kind, tier: s.tier ?? null, baseFiles: s.baseFiles, ...(s.deletedFiles && s.deletedFiles.length > 0 ? { deletedFiles: [...s.deletedFiles].sort() } : {}), headFiles: s.headFiles, expected: s.expected, holdout: s.holdout ?? false, provenance: s.provenance }));
+    .map((s) => ({ id: s.id, kind: s.kind, tier: s.tier ?? null, baseFiles: s.baseFiles, ...(s.deletedFiles && s.deletedFiles.length > 0 ? { deletedFiles: [...s.deletedFiles].sort() } : {}), ...(s.renamedFiles && s.renamedFiles.length > 0 ? { renamedFiles: s.renamedFiles.map(({ from, to }) => ({ from, to })).sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to)) } : {}), headFiles: s.headFiles, expected: s.expected, holdout: s.holdout ?? false, provenance: s.provenance }));
   return createHash("sha256").update(JSON.stringify(canonical)).digest("hex").slice(0, 16);
 }
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -264,7 +264,7 @@ async function runWork(
 export function fixtureSetHash(specs: readonly FixtureSpec[]): string {
   const canonical = [...specs]
     .sort((a, b) => a.id.localeCompare(b.id))
-    .map((s) => ({ id: s.id, kind: s.kind, tier: s.tier ?? null, baseFiles: s.baseFiles, headFiles: s.headFiles, expected: s.expected, holdout: s.holdout ?? false, provenance: s.provenance }));
+    .map((s) => ({ id: s.id, kind: s.kind, tier: s.tier ?? null, baseFiles: s.baseFiles, ...(s.deletedFiles && s.deletedFiles.length > 0 ? { deletedFiles: s.deletedFiles } : {}), headFiles: s.headFiles, expected: s.expected, holdout: s.holdout ?? false, provenance: s.provenance }));
   return createHash("sha256").update(JSON.stringify(canonical)).digest("hex").slice(0, 16);
 }
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -347,18 +347,20 @@ function writeReport(args: RunArgs, results: readonly DrawResult[], specs: reado
   return report;
 }
 
-function compare(baselinePath: string, candidate: Report): void {
+export function compare(baselinePath: string, candidate: Report): void {
   const baseline = JSON.parse(readFileSync(baselinePath, "utf8")) as Report;
   if (baseline.promptHash !== candidate.promptHash) {
     throw new Error(
       `prompt hash mismatch: baseline ${baseline.promptHash} vs candidate ${candidate.promptHash}. Re-run baseline after prompt changes.`
     );
   }
-  if (
-    baseline.fixtureSetHash !== undefined &&
-    candidate.fixtureSetHash !== undefined &&
-    baseline.fixtureSetHash !== candidate.fixtureSetHash
-  ) {
+  if (baseline.fixtureSetHash === undefined) {
+    throw new Error("baseline report is missing fixtureSetHash. Re-run baseline with the current eval harness.");
+  }
+  if (candidate.fixtureSetHash === undefined) {
+    throw new Error("candidate report is missing fixtureSetHash. Re-run candidate with the current eval harness.");
+  }
+  if (baseline.fixtureSetHash !== candidate.fixtureSetHash) {
     throw new Error(
       `fixture set hash mismatch: baseline ${baseline.fixtureSetHash} vs candidate ${candidate.fixtureSetHash}. Re-run baseline after fixture changes.`
     );

--- a/eval/shared/fixture.ts
+++ b/eval/shared/fixture.ts
@@ -24,10 +24,31 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-eval-"));
   try {
     const deletedFiles = spec.deletedFiles ?? [];
+    const renamedFiles = spec.renamedFiles ?? [];
     const seenDeletedFiles = new Set<string>();
     for (const rel of deletedFiles) {
       if (seenDeletedFiles.has(rel)) throw new Error(`duplicate deletedFiles path: ${rel}`);
       seenDeletedFiles.add(rel);
+    }
+    const seenRenameFrom = new Set<string>();
+    const seenRenameTo = new Set<string>();
+    const seenRenameEndpoints = new Set<string>();
+    for (const rename of renamedFiles) {
+      if (seenRenameFrom.has(rename.from)) throw new Error(`duplicate renamedFiles from path: ${rename.from}`);
+      if (seenRenameTo.has(rename.to)) throw new Error(`duplicate renamedFiles to path: ${rename.to}`);
+      if (seenRenameEndpoints.has(rename.from)) throw new Error(`duplicate renamedFiles endpoint path: ${rename.from}`);
+      if (seenRenameEndpoints.has(rename.to) || rename.to === rename.from) throw new Error(`duplicate renamedFiles endpoint path: ${rename.to}`);
+      seenRenameFrom.add(rename.from);
+      seenRenameTo.add(rename.to);
+      seenRenameEndpoints.add(rename.from);
+      seenRenameEndpoints.add(rename.to);
+    }
+    for (const rename of renamedFiles) {
+      if (!seenDeletedFiles.has(rename.from)) throw new Error(`renamedFiles from path is not deleted: ${rename.from}`);
+      if (!Object.hasOwn(spec.baseFiles, rename.from)) throw new Error(`renamedFiles from path is absent from baseFiles: ${rename.from}`);
+      if (Object.hasOwn(spec.headFiles, rename.from)) throw new Error(`renamedFiles from path still exists in headFiles: ${rename.from}`);
+      if (Object.hasOwn(spec.baseFiles, rename.to)) throw new Error(`renamedFiles to path already exists in baseFiles: ${rename.to}`);
+      if (!Object.hasOwn(spec.headFiles, rename.to)) throw new Error(`renamedFiles to path is absent from headFiles: ${rename.to}`);
     }
 
     git(["init", "--quiet"], tmp);
@@ -43,10 +64,26 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
 
     const baseSha = git(["rev-parse", "HEAD~1"], tmp);
     const headSha = git(["rev-parse", "HEAD"], tmp);
-    const patch = git(["diff", "-M", baseSha, headSha], tmp);
-    const patchStat = git(["diff", "-M", "--stat", baseSha, headSha], tmp);
-    const changedPaths = git(["diff", "-M", "--name-only", baseSha, headSha], tmp);
-    const files = changedFilesFromPaths(changedPaths.split("\n"));
+    const explicitRenamePaths = renamedFiles.flatMap((rename) => [rename.from, rename.to]);
+    const renderOrdinarySegment = (formatArgs: readonly string[]): string => {
+      const ordinaryPathspecs = explicitRenamePaths.map((rel) => `:(exclude)${rel}`);
+      return git(["diff", "--no-renames", ...formatArgs, baseSha, headSha, "--", ".", ...ordinaryPathspecs], tmp);
+    };
+    const renderRenameSegment = (rename: { readonly from: string; readonly to: string }, formatArgs: readonly string[]): string =>
+      git(["diff", "-M1%", ...formatArgs, baseSha, headSha, "--", rename.from, rename.to], tmp);
+    const renamePatchSegments = renamedFiles.map((rename) => {
+      const segment = renderRenameSegment(rename, []);
+      if (!/^rename from /m.test(segment) || !/^rename to /m.test(segment)) {
+        throw new Error(`explicit rename did not render as a rename: ${rename.from} -> ${rename.to}`);
+      }
+      return segment;
+    });
+    const patch = [renderOrdinarySegment([]), ...renamePatchSegments].filter(Boolean).join("\n");
+    const patchStat = [renderOrdinarySegment(["--stat"]), ...renamedFiles.map((rename) => renderRenameSegment(rename, ["--stat"]))].filter(Boolean).join("\n");
+    const changedPaths = [renderOrdinarySegment(["--name-only"]), ...renamedFiles.map((rename) => renderRenameSegment(rename, ["--name-only"]))]
+      .filter(Boolean)
+      .flatMap((segment) => segment.split("\n"));
+    const files = changedFilesFromPaths([...new Set(changedPaths)]);
 
     const bundle = makeBundle({
       repoPath: tmp,

--- a/eval/shared/fixture.ts
+++ b/eval/shared/fixture.ts
@@ -23,11 +23,18 @@ export interface LoadedFixture {
 export function loadFixture(spec: FixtureSpec): LoadedFixture {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-eval-"));
   try {
+    const deletedFiles = spec.deletedFiles ?? [];
+    const seenDeletedFiles = new Set<string>();
+    for (const rel of deletedFiles) {
+      if (seenDeletedFiles.has(rel)) throw new Error(`duplicate deletedFiles path: ${rel}`);
+      seenDeletedFiles.add(rel);
+    }
+
     git(["init", "--quiet"], tmp);
     writeFiles(tmp, spec.baseFiles);
     git(["add", "-A"], tmp);
-    git([...IDENTITY, "commit", "--quiet", "-m", "base"], tmp);
-    for (const rel of spec.deletedFiles ?? []) {
+    git([...IDENTITY, "commit", "--quiet", "--allow-empty", "-m", "base"], tmp);
+    for (const rel of deletedFiles) {
       rmSync(path.join(tmp, rel));
     }
     writeFiles(tmp, spec.headFiles);

--- a/eval/shared/fixture.ts
+++ b/eval/shared/fixture.ts
@@ -27,6 +27,9 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
     writeFiles(tmp, spec.baseFiles);
     git(["add", "-A"], tmp);
     git([...IDENTITY, "commit", "--quiet", "-m", "base"], tmp);
+    for (const rel of spec.deletedFiles ?? []) {
+      rmSync(path.join(tmp, rel), { force: true });
+    }
     writeFiles(tmp, spec.headFiles);
     git(["add", "-A"], tmp);
     git([...IDENTITY, "commit", "--quiet", "-m", "head"], tmp);

--- a/eval/shared/fixture.ts
+++ b/eval/shared/fixture.ts
@@ -71,11 +71,11 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
     const headSha = git(["rev-parse", "HEAD"], tmp);
     const explicitRenamePaths = renamedFiles.flatMap((rename) => [rename.from, rename.to]);
     const renderOrdinarySegment = (formatArgs: readonly string[]): string => {
-      const ordinaryPathspecs = explicitRenamePaths.map((rel) => `:(exclude)${rel}`);
+      const ordinaryPathspecs = explicitRenamePaths.map((rel) => `:(exclude,literal)${rel}`);
       return git(["diff", "--no-renames", ...formatArgs, baseSha, headSha, "--", ".", ...ordinaryPathspecs], tmp);
     };
     const renderRenameSegment = (rename: { readonly from: string; readonly to: string }, formatArgs: readonly string[]): string =>
-      git(["diff", "-M1%", ...formatArgs, baseSha, headSha, "--", rename.from, rename.to], tmp);
+      git(["diff", "-M1%", ...formatArgs, baseSha, headSha, "--", `:(literal)${rename.from}`, `:(literal)${rename.to}`], tmp);
     const renamePatchSegments = renamedFiles.map((rename) => {
       const segment = renderRenameSegment(rename, []);
       if (!/^rename from /m.test(segment) || !/^rename to /m.test(segment)) {

--- a/eval/shared/fixture.ts
+++ b/eval/shared/fixture.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { changedFiles, git, makeBundle } from "../../src/shared/repo";
+import { changedFilesFromPaths, git, makeBundle } from "../../src/shared/repo";
 import type { Bundle } from "../../src/shared/schema";
 import type { FixtureSpec } from "./types";
 
@@ -28,7 +28,7 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
     git(["add", "-A"], tmp);
     git([...IDENTITY, "commit", "--quiet", "-m", "base"], tmp);
     for (const rel of spec.deletedFiles ?? []) {
-      rmSync(path.join(tmp, rel), { force: true });
+      rmSync(path.join(tmp, rel));
     }
     writeFiles(tmp, spec.headFiles);
     git(["add", "-A"], tmp);
@@ -36,9 +36,10 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
 
     const baseSha = git(["rev-parse", "HEAD~1"], tmp);
     const headSha = git(["rev-parse", "HEAD"], tmp);
-    const patch = git(["diff", baseSha, headSha], tmp);
-    const patchStat = git(["diff", "--stat", baseSha, headSha], tmp);
-    const files = changedFiles(tmp, baseSha, headSha);
+    const patch = git(["diff", "-M", baseSha, headSha], tmp);
+    const patchStat = git(["diff", "-M", "--stat", baseSha, headSha], tmp);
+    const changedPaths = git(["diff", "-M", "--name-only", baseSha, headSha], tmp);
+    const files = changedFilesFromPaths(changedPaths.split("\n"));
 
     const bundle = makeBundle({
       repoPath: tmp,

--- a/eval/shared/fixture.ts
+++ b/eval/shared/fixture.ts
@@ -24,7 +24,9 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-eval-"));
   try {
     const deletedFiles = spec.deletedFiles ?? [];
-    const renamedFiles = spec.renamedFiles ?? [];
+    const renamedFiles = (spec.renamedFiles ?? [])
+      .map(({ from, to }) => ({ from, to }))
+      .sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to));
     const seenDeletedFiles = new Set<string>();
     for (const rel of deletedFiles) {
       if (seenDeletedFiles.has(rel)) throw new Error(`duplicate deletedFiles path: ${rel}`);
@@ -42,6 +44,9 @@ export function loadFixture(spec: FixtureSpec): LoadedFixture {
       seenRenameTo.add(rename.to);
       seenRenameEndpoints.add(rename.from);
       seenRenameEndpoints.add(rename.to);
+    }
+    for (const rel of deletedFiles) {
+      if (Object.hasOwn(spec.headFiles, rel)) throw new Error(`deletedFiles path still exists in headFiles: ${rel}`);
     }
     for (const rename of renamedFiles) {
       if (!seenDeletedFiles.has(rename.from)) throw new Error(`renamedFiles from path is not deleted: ${rename.from}`);

--- a/eval/shared/types.ts
+++ b/eval/shared/types.ts
@@ -62,6 +62,9 @@ export interface FixtureSpec {
   readonly defectClass: string;
   readonly description: string;
   readonly baseFiles: Readonly<Record<string, string>>;
+  // The only deletion signal. headFiles overlays the base tree; omission from
+  // headFiles means the base file is unchanged, not deleted.
+  readonly deletedFiles?: readonly string[];
   readonly headFiles: Readonly<Record<string, string>>;
   readonly expected: Expected;
   readonly holdout?: boolean;

--- a/eval/shared/types.ts
+++ b/eval/shared/types.ts
@@ -65,6 +65,10 @@ export interface FixtureSpec {
   // The only deletion signal. headFiles overlays the base tree; omission from
   // headFiles means the base file is unchanged, not deleted.
   readonly deletedFiles?: readonly string[];
+  readonly renamedFiles?: readonly {
+    readonly from: string;
+    readonly to: string;
+  }[];
   readonly headFiles: Readonly<Record<string, string>>;
   readonly expected: Expected;
   readonly holdout?: boolean;

--- a/eval/tools/pr2fixture.test.ts
+++ b/eval/tools/pr2fixture.test.ts
@@ -140,6 +140,7 @@ test("buildSpecSource: positive skeleton contains placeholder pattern and curato
     prUrl: "https://example.com/pr/42",
     baseFiles: { "src/a.ts": "old" },
     deletedFiles: [],
+    renamedFiles: [],
     headFiles: { "src/a.ts": "new" },
   });
   assert.match(src, /kind: "positive"/);
@@ -157,11 +158,57 @@ test("buildSpecSource: negative skeleton has noBlockingFindings, no curator patt
     prUrl: "https://example.com/pr/7",
     baseFiles: {},
     deletedFiles: [],
+    renamedFiles: [],
     headFiles: {},
   });
   assert.match(src, /kind: "negative"/);
   assert.match(src, /noBlockingFindings: true/);
   assert.ok(!src.includes("TODO-CURATOR-PATTERN"));
+});
+
+test("buildSpecSource: rejects invalid explicit rename tree shapes", () => {
+  const common = {
+    id: "invalid-rename", kind: "positive" as const,
+    provenance: { repo: "owner/name", pr: 42, kind: "review-finding" as const },
+    prTitle: "Invalid rename", prUrl: "https://example.com/pr/42",
+    deletedFiles: ["src/a.ts", "src/b.ts"],
+  };
+  assert.throws(
+    () => buildSpecSource({
+      ...common,
+      baseFiles: { "src/a.ts": "a", "src/b.ts": "b" },
+      renamedFiles: [{ from: "src/a.ts", to: "src/b.ts" }, { from: "src/b.ts", to: "src/c.ts" }],
+      headFiles: { "src/b.ts": "a", "src/c.ts": "b" },
+    }),
+    /duplicate renamedFiles endpoint path: src\/b\.ts/
+  );
+  assert.throws(
+    () => buildSpecSource({
+      ...common,
+      baseFiles: { "src/a.ts": "a", "src/b.ts": "b" },
+      renamedFiles: [{ from: "src/a.ts", to: "src/b.ts" }, { from: "src/b.ts", to: "src/a.ts" }],
+      headFiles: { "src/a.ts": "b", "src/b.ts": "a" },
+    }),
+    /duplicate renamedFiles endpoint path: src\/b\.ts/
+  );
+  assert.throws(
+    () => buildSpecSource({
+      ...common,
+      baseFiles: { "src/a.ts": "a", "src/b.ts": "preexisting" },
+      renamedFiles: [{ from: "src/a.ts", to: "src/b.ts" }],
+      headFiles: { "src/b.ts": "a" },
+    }),
+    /renamedFiles to path already exists in baseFiles: src\/b\.ts/
+  );
+  assert.throws(
+    () => buildSpecSource({
+      ...common,
+      baseFiles: { "src/a.ts": "a" },
+      renamedFiles: [{ from: "src/a.ts", to: "src/b.ts" }],
+      headFiles: { "src/a.ts": "a", "src/b.ts": "a" },
+    }),
+    /renamedFiles from path still exists in headFiles: src\/a\.ts/
+  );
 });
 
 interface ToolRun {
@@ -171,7 +218,7 @@ interface ToolRun {
   readonly source: string | null;
 }
 
-function runTool(mode: "success" | "flat-pages" | "empty-pages" | "404" | "500" | "invalid-json" | "binary-rename" | "all-binary" | "non-file" | "malformed-file"): ToolRun {
+function runTool(mode: "success" | "flat-pages" | "empty-pages" | "404" | "500" | "invalid-json" | "binary-rename" | "all-binary" | "non-file" | "malformed-file" | "copied"): ToolRun {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "pr2fixture-cli-test-"));
   const binDir = path.join(tmp, "bin");
   const outDir = path.join(tmp, "renamed-fixture");
@@ -187,7 +234,9 @@ if (endpoint === "repos/owner/name/pulls/7") {
     process.stderr.write("files request must use --paginate --slurp\\n");
     process.exit(2);
   }
-  const pages = [[{ filename: "src/new.ts", previous_filename: "src/old.ts", status: "renamed" }], [{ filename: "src/added.ts", status: "added" }, { filename: "src/removed.ts", status: "removed" }]];
+  const pages = mode === "copied"
+    ? [[{ filename: "src/copied.ts", previous_filename: "src/source.ts", status: "copied" }]]
+    : [[{ filename: "src/new.ts", previous_filename: "src/old.ts", status: "renamed" }], [{ filename: "src/added.ts", status: "added" }, { filename: "src/removed.ts", status: "removed" }]];
   process.stdout.write(JSON.stringify(mode === "flat-pages" ? pages.flat() : mode === "empty-pages" ? [[]] : pages));
 } else if (endpoint.includes("/contents/src/old.ts?ref=base")) {
   const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("old content");
@@ -209,6 +258,9 @@ if (endpoint === "repos/owner/name/pulls/7") {
   process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
 } else if (endpoint.includes("/contents/src/removed.ts?ref=base")) {
   const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("removed content");
+  process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
+} else if (endpoint.includes("/contents/src/copied.ts?ref=head")) {
+  const content = Buffer.from("copied content");
   process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
 } else {
   process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
@@ -240,6 +292,7 @@ test("CLI: slurps paginated files and preserves both paths for a rename", () => 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.source ?? "", /"src\/old\.ts": "old content"/);
   assert.match(result.source ?? "", /deletedFiles: \["src\/old\.ts","src\/removed\.ts"\]/);
+  assert.match(result.source ?? "", /renamedFiles: \[{"from":"src\/old\.ts","to":"src\/new\.ts"}\]/);
   assert.match(result.source ?? "", /"src\/new\.ts": "new content"/);
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
 });
@@ -249,6 +302,14 @@ test("CLI: accepts gh versions that return one merged array with pagination", ()
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.source ?? "", /"src\/old\.ts": "old content"/);
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
+});
+
+test("CLI: materializes a copied file like an addition without deleting its source", () => {
+  const result = runTool("copied");
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.source ?? "", /baseFiles: \{\s*\}/);
+  assert.doesNotMatch(result.source ?? "", /deletedFiles|renamedFiles|src\/source\.ts/);
+  assert.match(result.source ?? "", /"src\/copied\.ts": "copied content"/);
 });
 
 test("CLI: an empty paginated files response aborts without writing a fixture", () => {
@@ -269,6 +330,7 @@ test("CLI: a binary rename side omits the entire rename while keeping text chang
   const result = runTool("binary-rename");
   assert.equal(result.status, 0, result.stderr);
   assert.doesNotMatch(result.source ?? "", /src\/old\.ts|src\/new\.ts/);
+  assert.doesNotMatch(result.source ?? "", /renamedFiles/);
   assert.match(result.source ?? "", /deletedFiles: \["src\/removed\.ts"\]/);
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
   assert.match(result.source ?? "", /"src\/removed\.ts": "removed content"/);
@@ -279,6 +341,7 @@ test("CLI: a known non-file rename side is skipped atomically while text changes
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stderr, /skipping symlink: src\/new\.ts/);
   assert.doesNotMatch(result.source ?? "", /src\/old\.ts|src\/new\.ts/);
+  assert.doesNotMatch(result.source ?? "", /renamedFiles/);
   assert.match(result.source ?? "", /deletedFiles: \["src\/removed\.ts"\]/);
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
   assert.match(result.source ?? "", /"src\/removed\.ts": "removed content"/);

--- a/eval/tools/pr2fixture.test.ts
+++ b/eval/tools/pr2fixture.test.ts
@@ -171,7 +171,7 @@ interface ToolRun {
   readonly source: string | null;
 }
 
-function runTool(mode: "success" | "flat-pages" | "404" | "500" | "invalid-json" | "binary-rename" | "all-binary" | "non-file" | "malformed-file"): ToolRun {
+function runTool(mode: "success" | "flat-pages" | "empty-pages" | "404" | "500" | "invalid-json" | "binary-rename" | "all-binary" | "non-file" | "malformed-file"): ToolRun {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "pr2fixture-cli-test-"));
   const binDir = path.join(tmp, "bin");
   const outDir = path.join(tmp, "renamed-fixture");
@@ -188,7 +188,7 @@ if (endpoint === "repos/owner/name/pulls/7") {
     process.exit(2);
   }
   const pages = [[{ filename: "src/new.ts", previous_filename: "src/old.ts", status: "renamed" }], [{ filename: "src/added.ts", status: "added" }, { filename: "src/removed.ts", status: "removed" }]];
-  process.stdout.write(JSON.stringify(mode === "flat-pages" ? pages.flat() : pages));
+  process.stdout.write(JSON.stringify(mode === "flat-pages" ? pages.flat() : mode === "empty-pages" ? [[]] : pages));
 } else if (endpoint.includes("/contents/src/old.ts?ref=base")) {
   const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("old content");
   process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
@@ -249,6 +249,13 @@ test("CLI: accepts gh versions that return one merged array with pagination", ()
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.source ?? "", /"src\/old\.ts": "old content"/);
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
+});
+
+test("CLI: an empty paginated files response aborts without writing a fixture", () => {
+  const result = runTool("empty-pages");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /no reviewable text files/i);
+  assert.equal(result.specExists, false);
 });
 
 test("CLI: a missing required file aborts without writing a fixture", () => {

--- a/eval/tools/pr2fixture.test.ts
+++ b/eval/tools/pr2fixture.test.ts
@@ -171,7 +171,7 @@ interface ToolRun {
   readonly source: string | null;
 }
 
-function runTool(mode: "success" | "flat-pages" | "404" | "500" | "invalid-json" | "binary-rename" | "all-binary"): ToolRun {
+function runTool(mode: "success" | "flat-pages" | "404" | "500" | "invalid-json" | "binary-rename" | "all-binary" | "non-file" | "malformed-file"): ToolRun {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "pr2fixture-cli-test-"));
   const binDir = path.join(tmp, "bin");
   const outDir = path.join(tmp, "renamed-fixture");
@@ -191,23 +191,25 @@ if (endpoint === "repos/owner/name/pulls/7") {
   process.stdout.write(JSON.stringify(mode === "flat-pages" ? pages.flat() : pages));
 } else if (endpoint.includes("/contents/src/old.ts?ref=base")) {
   const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("old content");
-  process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
+  process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
 } else if (endpoint.includes("/contents/src/new.ts?ref=head")) {
   if (mode === "404" || mode === "500") {
     process.stderr.write(mode === "404" ? "gh: Not Found (HTTP 404)\\n" : "gh: server failed (HTTP 500)\\n");
     process.exit(1);
   }
   if (mode === "invalid-json") process.stdout.write("not json");
+  else if (mode === "non-file") process.stdout.write(JSON.stringify({ type: "symlink", target: "../outside" }));
+  else if (mode === "malformed-file") process.stdout.write(JSON.stringify({ type: "file", encoding: "utf-8", content: "new content" }));
   else {
     const content = mode === "binary-rename" || mode === "all-binary" ? Buffer.from([0]) : Buffer.from("new content");
-    process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
+    process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
   }
 } else if (endpoint.includes("/contents/src/added.ts?ref=head")) {
   const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("added content");
-  process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
+  process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
 } else if (endpoint.includes("/contents/src/removed.ts?ref=base")) {
   const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("removed content");
-  process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
+  process.stdout.write(JSON.stringify({ type: "file", encoding: "base64", content: content.toString("base64") }));
 } else {
   process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
   process.exit(3);
@@ -263,6 +265,23 @@ test("CLI: a binary rename side omits the entire rename while keeping text chang
   assert.match(result.source ?? "", /deletedFiles: \["src\/removed\.ts"\]/);
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
   assert.match(result.source ?? "", /"src\/removed\.ts": "removed content"/);
+});
+
+test("CLI: a known non-file rename side is skipped atomically while text changes remain", () => {
+  const result = runTool("non-file");
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /skipping symlink: src\/new\.ts/);
+  assert.doesNotMatch(result.source ?? "", /src\/old\.ts|src\/new\.ts/);
+  assert.match(result.source ?? "", /deletedFiles: \["src\/removed\.ts"\]/);
+  assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
+  assert.match(result.source ?? "", /"src\/removed\.ts": "removed content"/);
+});
+
+test("CLI: malformed file contents abort fixture generation", () => {
+  const result = runTool("malformed-file");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unexpected contents encoding for src\/new\.ts@head/);
+  assert.equal(result.specExists, false);
 });
 
 test("CLI: an all-binary PR aborts without writing an empty fixture", () => {

--- a/eval/tools/pr2fixture.test.ts
+++ b/eval/tools/pr2fixture.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
@@ -167,10 +167,11 @@ test("buildSpecSource: negative skeleton has noBlockingFindings, no curator patt
 interface ToolRun {
   readonly status: number | null;
   readonly stderr: string;
+  readonly specExists: boolean;
   readonly source: string | null;
 }
 
-function runTool(mode: "success" | "flat-pages" | "404" | "500" | "invalid-json"): ToolRun {
+function runTool(mode: "success" | "flat-pages" | "404" | "500" | "invalid-json" | "binary-rename" | "all-binary"): ToolRun {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "pr2fixture-cli-test-"));
   const binDir = path.join(tmp, "bin");
   const outDir = path.join(tmp, "renamed-fixture");
@@ -189,18 +190,24 @@ if (endpoint === "repos/owner/name/pulls/7") {
   const pages = [[{ filename: "src/new.ts", previous_filename: "src/old.ts", status: "renamed" }], [{ filename: "src/added.ts", status: "added" }, { filename: "src/removed.ts", status: "removed" }]];
   process.stdout.write(JSON.stringify(mode === "flat-pages" ? pages.flat() : pages));
 } else if (endpoint.includes("/contents/src/old.ts?ref=base")) {
-  process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("old content").toString("base64") }));
+  const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("old content");
+  process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
 } else if (endpoint.includes("/contents/src/new.ts?ref=head")) {
   if (mode === "404" || mode === "500") {
     process.stderr.write(mode === "404" ? "gh: Not Found (HTTP 404)\\n" : "gh: server failed (HTTP 500)\\n");
     process.exit(1);
   }
   if (mode === "invalid-json") process.stdout.write("not json");
-  else process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("new content").toString("base64") }));
+  else {
+    const content = mode === "binary-rename" || mode === "all-binary" ? Buffer.from([0]) : Buffer.from("new content");
+    process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
+  }
 } else if (endpoint.includes("/contents/src/added.ts?ref=head")) {
-  process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("added content").toString("base64") }));
+  const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("added content");
+  process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
 } else if (endpoint.includes("/contents/src/removed.ts?ref=base")) {
-  process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("removed content").toString("base64") }));
+  const content = mode === "all-binary" ? Buffer.from([0]) : Buffer.from("removed content");
+  process.stdout.write(JSON.stringify({ encoding: "base64", content: content.toString("base64") }));
 } else {
   process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
   process.exit(3);
@@ -218,7 +225,8 @@ if (endpoint === "repos/owner/name/pulls/7") {
     return {
       status: result.status,
       stderr: result.stderr,
-      source: result.status === 0 ? readFileSync(specPath, "utf8") : null,
+      specExists: existsSync(specPath),
+      source: existsSync(specPath) ? readFileSync(specPath, "utf8") : null,
     };
   } finally {
     rmSync(tmp, { recursive: true, force: true });
@@ -241,10 +249,27 @@ test("CLI: accepts gh versions that return one merged array with pagination", ()
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
 });
 
-test("CLI: a missing file response is skipped", () => {
+test("CLI: a missing required file aborts without writing a fixture", () => {
   const result = runTool("404");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /HTTP 404/);
+  assert.equal(result.specExists, false);
+});
+
+test("CLI: a binary rename side omits the entire rename while keeping text changes", () => {
+  const result = runTool("binary-rename");
   assert.equal(result.status, 0, result.stderr);
-  assert.doesNotMatch(result.source ?? "", /"src\/new\.ts"/);
+  assert.doesNotMatch(result.source ?? "", /src\/old\.ts|src\/new\.ts/);
+  assert.match(result.source ?? "", /deletedFiles: \["src\/removed\.ts"\]/);
+  assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
+  assert.match(result.source ?? "", /"src\/removed\.ts": "removed content"/);
+});
+
+test("CLI: an all-binary PR aborts without writing an empty fixture", () => {
+  const result = runTool("all-binary");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /no reviewable text files/i);
+  assert.equal(result.specExists, false);
 });
 
 test("CLI: non-404 gh failures abort fixture generation", () => {

--- a/eval/tools/pr2fixture.test.ts
+++ b/eval/tools/pr2fixture.test.ts
@@ -139,6 +139,7 @@ test("buildSpecSource: positive skeleton contains placeholder pattern and curato
     prTitle: "Fix the thing",
     prUrl: "https://example.com/pr/42",
     baseFiles: { "src/a.ts": "old" },
+    deletedFiles: [],
     headFiles: { "src/a.ts": "new" },
   });
   assert.match(src, /kind: "positive"/);
@@ -155,6 +156,7 @@ test("buildSpecSource: negative skeleton has noBlockingFindings, no curator patt
     prTitle: "Safe refactor",
     prUrl: "https://example.com/pr/7",
     baseFiles: {},
+    deletedFiles: [],
     headFiles: {},
   });
   assert.match(src, /kind: "negative"/);
@@ -184,7 +186,7 @@ if (endpoint === "repos/owner/name/pulls/7") {
     process.stderr.write("files request must use --paginate --slurp\\n");
     process.exit(2);
   }
-  const pages = [[{ filename: "src/new.ts", previous_filename: "src/old.ts", status: "renamed" }], [{ filename: "src/added.ts", status: "added" }]];
+  const pages = [[{ filename: "src/new.ts", previous_filename: "src/old.ts", status: "renamed" }], [{ filename: "src/added.ts", status: "added" }, { filename: "src/removed.ts", status: "removed" }]];
   process.stdout.write(JSON.stringify(mode === "flat-pages" ? pages.flat() : pages));
 } else if (endpoint.includes("/contents/src/old.ts?ref=base")) {
   process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("old content").toString("base64") }));
@@ -197,6 +199,8 @@ if (endpoint === "repos/owner/name/pulls/7") {
   else process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("new content").toString("base64") }));
 } else if (endpoint.includes("/contents/src/added.ts?ref=head")) {
   process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("added content").toString("base64") }));
+} else if (endpoint.includes("/contents/src/removed.ts?ref=base")) {
+  process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("removed content").toString("base64") }));
 } else {
   process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
   process.exit(3);
@@ -225,6 +229,7 @@ test("CLI: slurps paginated files and preserves both paths for a rename", () => 
   const result = runTool("success");
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.source ?? "", /"src\/old\.ts": "old content"/);
+  assert.match(result.source ?? "", /deletedFiles: \["src\/old\.ts","src\/removed\.ts"\]/);
   assert.match(result.source ?? "", /"src\/new\.ts": "new content"/);
   assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
 });

--- a/eval/tools/pr2fixture.test.ts
+++ b/eval/tools/pr2fixture.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -159,4 +160,96 @@ test("buildSpecSource: negative skeleton has noBlockingFindings, no curator patt
   assert.match(src, /kind: "negative"/);
   assert.match(src, /noBlockingFindings: true/);
   assert.ok(!src.includes("TODO-CURATOR-PATTERN"));
+});
+
+interface ToolRun {
+  readonly status: number | null;
+  readonly stderr: string;
+  readonly source: string | null;
+}
+
+function runTool(mode: "success" | "flat-pages" | "404" | "500" | "invalid-json"): ToolRun {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "pr2fixture-cli-test-"));
+  const binDir = path.join(tmp, "bin");
+  const outDir = path.join(tmp, "renamed-fixture");
+  try {
+    writeFileSync(path.join(tmp, "gh"), `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const endpoint = args[1] ?? "";
+const mode = ${JSON.stringify(mode)};
+if (endpoint === "repos/owner/name/pulls/7") {
+  process.stdout.write(JSON.stringify({ base: { sha: "base" }, head: { sha: "head" }, title: "Rename", html_url: "https://example.test/pr/7" }));
+} else if (endpoint.endsWith("/pulls/7/files")) {
+  if (!args.includes("--paginate") || !args.includes("--slurp")) {
+    process.stderr.write("files request must use --paginate --slurp\\n");
+    process.exit(2);
+  }
+  const pages = [[{ filename: "src/new.ts", previous_filename: "src/old.ts", status: "renamed" }], [{ filename: "src/added.ts", status: "added" }]];
+  process.stdout.write(JSON.stringify(mode === "flat-pages" ? pages.flat() : pages));
+} else if (endpoint.includes("/contents/src/old.ts?ref=base")) {
+  process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("old content").toString("base64") }));
+} else if (endpoint.includes("/contents/src/new.ts?ref=head")) {
+  if (mode === "404" || mode === "500") {
+    process.stderr.write(mode === "404" ? "gh: Not Found (HTTP 404)\\n" : "gh: server failed (HTTP 500)\\n");
+    process.exit(1);
+  }
+  if (mode === "invalid-json") process.stdout.write("not json");
+  else process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("new content").toString("base64") }));
+} else if (endpoint.includes("/contents/src/added.ts?ref=head")) {
+  process.stdout.write(JSON.stringify({ encoding: "base64", content: Buffer.from("added content").toString("base64") }));
+} else {
+  process.stderr.write("unexpected gh invocation: " + args.join(" ") + "\\n");
+  process.exit(3);
+}
+`);
+    mkdirSync(binDir);
+    renameSync(path.join(tmp, "gh"), path.join(binDir, "gh"));
+    chmodSync(path.join(binDir, "gh"), 0o755);
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", path.resolve("eval/tools/pr2fixture.ts"), "--repo", "owner/name", "--pr", "7", "--out", outDir, "--kind", "review-finding"],
+      { encoding: "utf8", env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` } }
+    );
+    const specPath = path.join(outDir, "spec.ts");
+    return {
+      status: result.status,
+      stderr: result.stderr,
+      source: result.status === 0 ? readFileSync(specPath, "utf8") : null,
+    };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+test("CLI: slurps paginated files and preserves both paths for a rename", () => {
+  const result = runTool("success");
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.source ?? "", /"src\/old\.ts": "old content"/);
+  assert.match(result.source ?? "", /"src\/new\.ts": "new content"/);
+  assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
+});
+
+test("CLI: accepts gh versions that return one merged array with pagination", () => {
+  const result = runTool("flat-pages");
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.source ?? "", /"src\/old\.ts": "old content"/);
+  assert.match(result.source ?? "", /"src\/added\.ts": "added content"/);
+});
+
+test("CLI: a missing file response is skipped", () => {
+  const result = runTool("404");
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.source ?? "", /"src\/new\.ts"/);
+});
+
+test("CLI: non-404 gh failures abort fixture generation", () => {
+  const result = runTool("500");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /HTTP 500/);
+});
+
+test("CLI: malformed contents JSON aborts fixture generation", () => {
+  const result = runTool("invalid-json");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unexpected token|JSON/);
 });

--- a/eval/tools/pr2fixture.ts
+++ b/eval/tools/pr2fixture.ts
@@ -224,6 +224,13 @@ function encodePath(filename: string): string {
 function fetchFileContent(repo: string, filename: string, ref: string): Buffer | null {
   const raw: unknown = JSON.parse(ghText(["api", `repos/${repo}/contents/${encodePath(filename)}?ref=${ref}`]));
   const obj = assertRecord(raw, "contents response");
+  if (obj.type === "symlink" || obj.type === "submodule") {
+    console.warn(`skipping ${obj.type}: ${filename}`);
+    return null;
+  }
+  if (obj.type !== "file") {
+    throw new Error(`unexpected contents type for ${filename}@${ref}`);
+  }
   if (obj.encoding !== "base64" || typeof obj.content !== "string") {
     throw new Error(`unexpected contents encoding for ${filename}@${ref}`);
   }

--- a/eval/tools/pr2fixture.ts
+++ b/eval/tools/pr2fixture.ts
@@ -107,6 +107,7 @@ export interface SpecSkeletonInput {
   readonly prTitle: string;
   readonly prUrl: string;
   readonly baseFiles: Readonly<Record<string, string>>;
+  readonly deletedFiles: readonly string[];
   readonly headFiles: Readonly<Record<string, string>>;
 }
 
@@ -157,7 +158,7 @@ const spec: FixtureSpec = {
   defectClass: "TODO-CURATOR-DEFECT-CLASS",
   description: ${JSON.stringify(description)},
   baseFiles: ${fileRecordSource(input.baseFiles)},
-  headFiles: ${fileRecordSource(input.headFiles)},
+${input.deletedFiles.length > 0 ? `  deletedFiles: ${JSON.stringify(input.deletedFiles)},\n` : ""}  headFiles: ${fileRecordSource(input.headFiles)},
   expected: ${expected},
   provenance: ${provenanceSource(input.provenance)},
 };
@@ -259,10 +260,19 @@ async function main(): Promise<void> {
   const files = fetchPrFiles(repo, pr);
 
   const baseFiles: Record<string, string> = {};
+  const deletedFiles: string[] = [];
   const headFiles: Record<string, string> = {};
   const capFiles: CapCheckFile[] = [];
 
   for (const file of files) {
+    if (file.status === "removed") {
+      deletedFiles.push(file.filename);
+    } else if (file.status === "renamed") {
+      if (file.previousFilename === undefined) {
+        throw new Error("renamed PR file entry missing previous_filename");
+      }
+      deletedFiles.push(file.previousFilename);
+    }
     if (file.status !== "added") {
       const baseFilename = file.previousFilename ?? file.filename;
       const buf = fetchFileContent(repo, baseFilename, prMeta.baseSha);
@@ -294,6 +304,7 @@ async function main(): Promise<void> {
     prTitle: prMeta.title,
     prUrl: prMeta.url,
     baseFiles,
+    deletedFiles,
     headFiles,
   });
 

--- a/eval/tools/pr2fixture.ts
+++ b/eval/tools/pr2fixture.ts
@@ -108,6 +108,7 @@ export interface SpecSkeletonInput {
   readonly prUrl: string;
   readonly baseFiles: Readonly<Record<string, string>>;
   readonly deletedFiles: readonly string[];
+  readonly renamedFiles: readonly { readonly from: string; readonly to: string }[];
   readonly headFiles: Readonly<Record<string, string>>;
 }
 
@@ -138,6 +139,17 @@ function provenanceSource(p: FixtureProvenance): string {
 
 // Pure string builder — no file I/O. Emits the literal spec.ts source text.
 export function buildSpecSource(input: SpecSkeletonInput): string {
+  const seenRenameEndpoints = new Set<string>();
+  for (const rename of input.renamedFiles) {
+    if (seenRenameEndpoints.has(rename.from)) throw new Error(`duplicate renamedFiles endpoint path: ${rename.from}`);
+    if (seenRenameEndpoints.has(rename.to) || rename.to === rename.from) throw new Error(`duplicate renamedFiles endpoint path: ${rename.to}`);
+    seenRenameEndpoints.add(rename.from);
+    seenRenameEndpoints.add(rename.to);
+  }
+  for (const rename of input.renamedFiles) {
+    if (Object.hasOwn(input.headFiles, rename.from)) throw new Error(`renamedFiles from path still exists in headFiles: ${rename.from}`);
+    if (Object.hasOwn(input.baseFiles, rename.to)) throw new Error(`renamedFiles to path already exists in baseFiles: ${rename.to}`);
+  }
   const description = `TODO-CURATOR: describe the defect and where it lives. Source: ${input.prUrl} — "${input.prTitle}".`;
   const expected =
     input.kind === "positive"
@@ -158,7 +170,7 @@ const spec: FixtureSpec = {
   defectClass: "TODO-CURATOR-DEFECT-CLASS",
   description: ${JSON.stringify(description)},
   baseFiles: ${fileRecordSource(input.baseFiles)},
-${input.deletedFiles.length > 0 ? `  deletedFiles: ${JSON.stringify(input.deletedFiles)},\n` : ""}  headFiles: ${fileRecordSource(input.headFiles)},
+${input.deletedFiles.length > 0 ? `  deletedFiles: ${JSON.stringify(input.deletedFiles)},\n` : ""}${input.renamedFiles.length > 0 ? `  renamedFiles: ${JSON.stringify(input.renamedFiles)},\n` : ""}  headFiles: ${fileRecordSource(input.headFiles)},
   expected: ${expected},
   provenance: ${provenanceSource(input.provenance)},
 };
@@ -258,15 +270,16 @@ async function main(): Promise<void> {
 
   const baseFiles: Record<string, string> = {};
   const deletedFiles: string[] = [];
+  const renamedFiles: { from: string; to: string }[] = [];
   const headFiles: Record<string, string> = {};
   const capFiles: CapCheckFile[] = [];
 
   for (const file of files) {
     const baseFilename = file.previousFilename ?? file.filename;
-    const baseBuf = file.status === "added" ? null : fetchFileContent(repo, baseFilename, prMeta.baseSha);
+    const baseBuf = file.status === "added" || file.status === "copied" ? null : fetchFileContent(repo, baseFilename, prMeta.baseSha);
     const headBuf = file.status === "removed" ? null : fetchFileContent(repo, file.filename, prMeta.headSha);
 
-    if ((file.status !== "added" && baseBuf === null) || (file.status !== "removed" && headBuf === null)) continue;
+    if ((file.status !== "added" && file.status !== "copied" && baseBuf === null) || (file.status !== "removed" && headBuf === null)) continue;
 
     if (baseBuf !== null) {
       baseFiles[baseFilename] = baseBuf.toString("utf8");
@@ -280,6 +293,7 @@ async function main(): Promise<void> {
       deletedFiles.push(file.filename);
     } else if (file.status === "renamed") {
       deletedFiles.push(baseFilename);
+      renamedFiles.push({ from: baseFilename, to: file.filename });
     }
   }
 
@@ -302,6 +316,7 @@ async function main(): Promise<void> {
     prUrl: prMeta.url,
     baseFiles,
     deletedFiles,
+    renamedFiles,
     headFiles,
   });
 

--- a/eval/tools/pr2fixture.ts
+++ b/eval/tools/pr2fixture.ts
@@ -171,6 +171,7 @@ export default spec;
 interface PrFile {
   readonly filename: string;
   readonly status: string;
+  readonly previousFilename?: string;
 }
 
 function assertRecord(value: unknown, what: string): Record<string, unknown> {
@@ -196,12 +197,19 @@ function fetchPrMeta(repo: string, pr: number): { baseSha: string; headSha: stri
 }
 
 function fetchPrFiles(repo: string, pr: number): PrFile[] {
-  const raw: unknown = JSON.parse(ghText(["api", `repos/${repo}/pulls/${pr}/files`, "--paginate"]));
+  const raw: unknown = JSON.parse(ghText(["api", `repos/${repo}/pulls/${pr}/files`, "--paginate", "--slurp"]));
   if (!Array.isArray(raw)) throw new Error("expected PR files response to be a JSON array");
-  return raw.map((entry) => {
+  const entries: unknown[] = raw.every(Array.isArray) ? raw.flat() : raw;
+  return entries.map((entry) => {
     const obj = assertRecord(entry, "PR file entry");
     if (typeof obj.filename !== "string" || typeof obj.status !== "string") {
       throw new Error("PR file entry missing filename/status");
+    }
+    if (obj.status === "renamed") {
+      if (typeof obj.previous_filename !== "string") {
+        throw new Error("renamed PR file entry missing previous_filename");
+      }
+      return { filename: obj.filename, status: obj.status, previousFilename: obj.previous_filename };
     }
     return { filename: obj.filename, status: obj.status };
   });
@@ -218,13 +226,15 @@ function fetchFileContent(repo: string, filename: string, ref: string): Buffer |
   try {
     raw = JSON.parse(ghText(["api", `repos/${repo}/contents/${encodePath(filename)}?ref=${ref}`]));
   } catch (err) {
-    console.warn(`skipping ${filename}@${ref}: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
+    if (err instanceof Error && /\bHTTP 404\b/.test(err.message)) {
+      console.warn(`skipping missing file: ${filename}@${ref}`);
+      return null;
+    }
+    throw err;
   }
   const obj = assertRecord(raw, "contents response");
   if (obj.encoding !== "base64" || typeof obj.content !== "string") {
-    console.warn(`skipping ${filename}@${ref}: unexpected contents encoding`);
-    return null;
+    throw new Error(`unexpected contents encoding for ${filename}@${ref}`);
   }
   const buf = Buffer.from(obj.content.replace(/\n/g, ""), "base64");
   if (isBinaryContent(buf)) {
@@ -254,10 +264,11 @@ async function main(): Promise<void> {
 
   for (const file of files) {
     if (file.status !== "added") {
-      const buf = fetchFileContent(repo, file.filename, prMeta.baseSha);
+      const baseFilename = file.previousFilename ?? file.filename;
+      const buf = fetchFileContent(repo, baseFilename, prMeta.baseSha);
       if (buf) {
-        baseFiles[file.filename] = buf.toString("utf8");
-        capFiles.push({ path: `${file.filename} (base)`, bytes: buf.length });
+        baseFiles[baseFilename] = buf.toString("utf8");
+        capFiles.push({ path: `${baseFilename} (base)`, bytes: buf.length });
       }
     }
     if (file.status !== "removed") {

--- a/eval/tools/pr2fixture.ts
+++ b/eval/tools/pr2fixture.ts
@@ -220,19 +220,9 @@ function encodePath(filename: string): string {
   return filename.split("/").map(encodeURIComponent).join("/");
 }
 
-// Returns the file's decoded content, or null if it doesn't exist at that ref
-// (404) or is binary (skipped).
+// Returns the file's decoded content, or null when it is binary (skipped).
 function fetchFileContent(repo: string, filename: string, ref: string): Buffer | null {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(ghText(["api", `repos/${repo}/contents/${encodePath(filename)}?ref=${ref}`]));
-  } catch (err) {
-    if (err instanceof Error && /\bHTTP 404\b/.test(err.message)) {
-      console.warn(`skipping missing file: ${filename}@${ref}`);
-      return null;
-    }
-    throw err;
-  }
+  const raw: unknown = JSON.parse(ghText(["api", `repos/${repo}/contents/${encodePath(filename)}?ref=${ref}`]));
   const obj = assertRecord(raw, "contents response");
   if (obj.encoding !== "base64" || typeof obj.content !== "string") {
     throw new Error(`unexpected contents encoding for ${filename}@${ref}`);
@@ -265,29 +255,29 @@ async function main(): Promise<void> {
   const capFiles: CapCheckFile[] = [];
 
   for (const file of files) {
+    const baseFilename = file.previousFilename ?? file.filename;
+    const baseBuf = file.status === "added" ? null : fetchFileContent(repo, baseFilename, prMeta.baseSha);
+    const headBuf = file.status === "removed" ? null : fetchFileContent(repo, file.filename, prMeta.headSha);
+
+    if ((file.status !== "added" && baseBuf === null) || (file.status !== "removed" && headBuf === null)) continue;
+
+    if (baseBuf !== null) {
+      baseFiles[baseFilename] = baseBuf.toString("utf8");
+      capFiles.push({ path: `${baseFilename} (base)`, bytes: baseBuf.length });
+    }
+    if (headBuf !== null) {
+      headFiles[file.filename] = headBuf.toString("utf8");
+      capFiles.push({ path: `${file.filename} (head)`, bytes: headBuf.length });
+    }
     if (file.status === "removed") {
       deletedFiles.push(file.filename);
     } else if (file.status === "renamed") {
-      if (file.previousFilename === undefined) {
-        throw new Error("renamed PR file entry missing previous_filename");
-      }
-      deletedFiles.push(file.previousFilename);
+      deletedFiles.push(baseFilename);
     }
-    if (file.status !== "added") {
-      const baseFilename = file.previousFilename ?? file.filename;
-      const buf = fetchFileContent(repo, baseFilename, prMeta.baseSha);
-      if (buf) {
-        baseFiles[baseFilename] = buf.toString("utf8");
-        capFiles.push({ path: `${baseFilename} (base)`, bytes: buf.length });
-      }
-    }
-    if (file.status !== "removed") {
-      const buf = fetchFileContent(repo, file.filename, prMeta.headSha);
-      if (buf) {
-        headFiles[file.filename] = buf.toString("utf8");
-        capFiles.push({ path: `${file.filename} (head)`, bytes: buf.length });
-      }
-    }
+  }
+
+  if (files.length > 0 && capFiles.length === 0) {
+    throw new Error("PR has no reviewable text files");
   }
 
   const capResult = checkCaps(capFiles);

--- a/eval/tools/pr2fixture.ts
+++ b/eval/tools/pr2fixture.ts
@@ -283,7 +283,7 @@ async function main(): Promise<void> {
     }
   }
 
-  if (files.length > 0 && capFiles.length === 0) {
+  if (capFiles.length === 0) {
     throw new Error("PR has no reviewable text files");
   }
 

--- a/eval/weekly-compare.test.ts
+++ b/eval/weekly-compare.test.ts
@@ -146,3 +146,31 @@ test("compareWeekly: prompt change skips regression comparison but keeps cheat a
   assert.equal(v.alert, false, "regression across prompt change is not comparable");
   assert.ok(v.reasons.some((r) => r.includes("prompt/fixture set changed")));
 });
+
+for (const [name, prevHash, latestHash] of [
+  ["previous hash missing", undefined, "fff"],
+  ["latest hash missing", "fff", undefined],
+  ["fixture hashes empty", "", ""],
+] as const) {
+  test(`compareWeekly: ${name} skips week-over-week comparison`, () => {
+    const prev = report([...drawsFor("a", [true, true, true]), ...drawsFor("b", [true, true, true])], {
+      fixtureSetHash: prevHash,
+    });
+    const latest = report([...drawsFor("a", [false, false, false]), ...drawsFor("b", [false, false, false])], {
+      fixtureSetHash: latestHash,
+    });
+    const v = compareWeekly(prev, latest);
+    assert.equal(v.alert, false, "incomparable reports must not emit a regression alert");
+    assert.ok(v.reasons.some((r) => r.includes("skipping regression comparison")));
+    assert.ok(v.reasons.every((r) => !r.includes("fixtures regressed")));
+  });
+}
+
+test("compareWeekly: latest-only checks still alert when a fixture hash is missing", () => {
+  const prev = report(drawsFor("t1-fix", [true, true, true]), { fixtureSetHash: undefined });
+  const latest = report(drawsFor("t1-fix", [false, false, false]), { fixtureTiers: { "t1-fix": 1 } });
+  const v = compareWeekly(prev, latest);
+  assert.equal(v.alert, true);
+  assert.ok(v.reasons.some((r) => r.includes("tier-1")));
+  assert.ok(v.reasons.some((r) => r.includes("skipping regression comparison")));
+});

--- a/eval/weekly-compare.ts
+++ b/eval/weekly-compare.ts
@@ -63,7 +63,12 @@ export function compareWeekly(prev: Report | null, latest: Report): WeeklyVerdic
   }
 
   if (prev) {
-    if (prev.promptHash !== latest.promptHash || (prev.fixtureSetHash && latest.fixtureSetHash && prev.fixtureSetHash !== latest.fixtureSetHash)) {
+    if (
+      prev.promptHash !== latest.promptHash ||
+      !prev.fixtureSetHash ||
+      !latest.fixtureSetHash ||
+      prev.fixtureSetHash !== latest.fixtureSetHash
+    ) {
       // Different prompt or fixture set: week-over-week deltas are meaningless.
       return { alert: reasons.length > 0, reasons: [...reasons, "note: prompt/fixture set changed since last week; skipping regression comparison"] };
     }

--- a/scripts/deploy-ubuntu.sh
+++ b/scripts/deploy-ubuntu.sh
@@ -40,11 +40,6 @@ if ! command -v pnpm >/dev/null 2>&1; then
 	corepack enable
 	corepack prepare "$pnpm_version" --activate
 fi
-command -v pi >/dev/null 2>&1 || npm install -g @mariozechner/pi
-if [ ! -f "$HOME/.pi/agent/auth.json" ]; then
-	echo "WARNING: pi runner needs ~/.pi/agent/auth.json with an openai-codex entry — see action.yml PI_AUTH_JSON pattern" >&2
-fi
-
 if [ -e "$release" ]; then
 	validate_release
 else

--- a/scripts/deploy-ubuntu.test.mjs
+++ b/scripts/deploy-ubuntu.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("deploy does not install an optional model runner", async () => {
+  const script = await readFile("scripts/deploy-ubuntu.sh", "utf8");
+
+  assert.doesNotMatch(script, /npm install -g @mariozechner\/pi/);
+});

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -9,16 +9,16 @@ function collectTests(dir) {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) {
       tests.push(...collectTests(path));
-    } else if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+    } else if (entry.isFile() && (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.mjs"))) {
       tests.push(path);
     }
   }
   return tests;
 }
 
-const files = [...collectTests("src"), ...collectTests("eval")].sort();
+const files = [...collectTests("src"), ...collectTests("eval"), ...collectTests("scripts")].sort();
 if (files.length === 0) {
-  process.stderr.write("No test files found under src or eval.\n");
+  process.stderr.write("No test files found under src, eval, or scripts.\n");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

Follow-up replacement for the review submitted after PR #13 was merged.

- preserve rename base paths and normalize paginated PR-file responses
- fail fixture mining on non-404 fetch and malformed content errors
- reject incomparable hashless eval reports
- include real-PR fixtures in leakage checks
- keep optional pi installation out of normal Ubuntu deploys
- add regression coverage for every corrected path

## Verification

- `pnpm check`
- changed-files ESLint
- `pnpm test` — 250 passed, 0 failed
- `sh -n scripts/deploy-ubuntu.sh`
- `git diff --check`

Original review: https://github.com/frankekn/needlefish/pull/13#pullrequestreview-4671054088