### PR TITLE
feat: add autonomous-loop gate scripts (brief-lint, gate-verdict)

### DIFF
--- a/eval/run.ts
+++ b/eval/run.ts
@@ -322,12 +322,16 @@ function aggregate(results: readonly DrawResult[], specs: readonly FixtureSpec[]
   };
 }
 
-function writeReport(args: RunArgs, results: readonly DrawResult[], specs: readonly FixtureSpec[]): Report {
+function writeReport(
+  args: RunArgs,
+  results: readonly DrawResult[],
+  specs: readonly FixtureSpec[]
+): Report & { readonly fixtures: readonly string[] } {
   const fixtureTiers: Record<string, number> = {};
   for (const s of specs) {
     if (s.kind === "positive") fixtureTiers[s.id] = s.tier ?? 2;
   }
-  const report: Report = {
+  const report = {
     promptHash: promptHash(),
     runner: args.runner,
     model: args.model,
@@ -341,7 +345,8 @@ function writeReport(args: RunArgs, results: readonly DrawResult[], specs: reado
     gitSha: repoGitSha(),
     fixtureSetHash: fixtureSetHash(specs),
     fixtureTiers,
-  };
+    fixtures: specs.map((spec) => spec.id),
+  } satisfies Report & { readonly fixtures: readonly string[] };
   mkdirSync(path.dirname(path.resolve(args.report)), { recursive: true });
   writeFileSync(args.report, JSON.stringify(report, null, 2));
   return report;

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -12,6 +12,7 @@ import { score } from "./shared/score";
 import type {
   Aggregates,
   DrawResult,
+  FixtureKind,
   FixtureSpec,
   HoldoutMode,
   Report,
@@ -326,10 +327,15 @@ function writeReport(
   args: RunArgs,
   results: readonly DrawResult[],
   specs: readonly FixtureSpec[]
-): Report & { readonly fixtures: readonly string[] } {
+): Report & {
+  readonly fixtures: readonly string[];
+  readonly fixtureKinds: Readonly<Record<string, FixtureKind>>;
+} {
   const fixtureTiers: Record<string, number> = {};
+  const fixtureKinds: Record<string, FixtureKind> = {};
   for (const s of specs) {
     if (s.kind === "positive") fixtureTiers[s.id] = s.tier ?? 2;
+    fixtureKinds[s.id] = s.kind;
   }
   const report = {
     promptHash: promptHash(),
@@ -346,7 +352,11 @@ function writeReport(
     fixtureSetHash: fixtureSetHash(specs),
     fixtureTiers,
     fixtures: specs.map((spec) => spec.id),
-  } satisfies Report & { readonly fixtures: readonly string[] };
+    fixtureKinds,
+  } satisfies Report & {
+    readonly fixtures: readonly string[];
+    readonly fixtureKinds: Readonly<Record<string, FixtureKind>>;
+  };
   mkdirSync(path.dirname(path.resolve(args.report)), { recursive: true });
   writeFileSync(args.report, JSON.stringify(report, null, 2));
   return report;

--- a/scripts/brief-lint-holdouts.mjs
+++ b/scripts/brief-lint-holdouts.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+async function collect(repoPath) {
+  const holdouts = [];
+  for (const relativeRoot of [join("eval", "fixtures"), join("eval", "fixtures-real")]) {
+    const root = join(repoPath, relativeRoot);
+    let entries;
+    try {
+      entries = await readdir(root, { withFileTypes: true });
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const specPath = join(root, entry.name, "spec.ts");
+      try {
+        if (!(await stat(specPath)).isFile()) throw new Error("invalid spec path");
+      } catch (error) {
+        throw error;
+      }
+      const module = await import(pathToFileURL(specPath).href);
+      const spec = module.default ?? module.spec;
+      if (spec === null || typeof spec !== "object" || Array.isArray(spec)) {
+        throw new Error("invalid spec export");
+      }
+      if (typeof spec.id !== "string" || spec.id.trim().length === 0) {
+        throw new Error("invalid spec id");
+      }
+      if (spec.holdout === true) holdouts.push(spec.id);
+    }
+  }
+  return holdouts;
+}
+
+try {
+  process.stdout.write(`${JSON.stringify(await collect(process.argv[2]))}\n`);
+} catch {
+  process.exitCode = 1;
+}

--- a/scripts/brief-lint-holdouts.mjs
+++ b/scripts/brief-lint-holdouts.mjs
@@ -1,8 +1,103 @@
 #!/usr/bin/env node
 
-import { readdir, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+function hasModifier(node, kind) {
+  return node.modifiers?.some((modifier) => modifier.kind === kind) === true;
+}
+
+function literalPropertyName(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return undefined;
+}
+
+function resolveExportedObjects(sourceFile) {
+  const declarations = new Map();
+  const exported = [];
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name) && declaration.initializer !== undefined) {
+          const existing = declarations.get(declaration.name.text) ?? [];
+          existing.push(declaration.initializer);
+          declarations.set(declaration.name.text, existing);
+          if (
+            declaration.name.text === "spec" &&
+            hasModifier(statement, ts.SyntaxKind.ExportKeyword)
+          ) {
+            exported.push(declaration.initializer);
+          }
+        }
+      }
+      continue;
+    }
+
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
+      if (ts.isObjectLiteralExpression(statement.expression)) {
+        exported.push(statement.expression);
+      } else if (ts.isIdentifier(statement.expression)) {
+        const matches = declarations.get(statement.expression.text);
+        if (matches === undefined || matches.length !== 1) throw new Error("ambiguous spec export");
+        exported.push(matches[0]);
+      } else {
+        throw new Error("invalid spec export");
+      }
+    }
+  }
+
+  const objects = [...new Set(exported)];
+  if (objects.length === 0 || objects.some((node) => !ts.isObjectLiteralExpression(node))) {
+    throw new Error("invalid spec export");
+  }
+  return objects;
+}
+
+function classifySpec(object) {
+  const ids = [];
+  let holdout = false;
+  let ambiguous = false;
+
+  for (const member of object.properties) {
+    if (ts.isSpreadAssignment(member) || member.name === undefined) {
+      ambiguous = true;
+      continue;
+    }
+    const name = literalPropertyName(member.name);
+    if (name === undefined) {
+      ambiguous = true;
+      continue;
+    }
+    if (!ts.isPropertyAssignment(member)) {
+      if (name === "id" || name === "holdout") ambiguous = true;
+      continue;
+    }
+    if (name === "id") {
+      if (!ts.isStringLiteral(member.initializer) || member.initializer.text.trim().length === 0) {
+        throw new Error("invalid spec id");
+      }
+      ids.push(member.initializer.text);
+    }
+    if (name === "holdout" && member.initializer.kind !== ts.SyntaxKind.FalseKeyword) holdout = true;
+  }
+
+  if (ids.length !== 1) throw new Error("ambiguous spec id");
+  return { id: ids[0], holdout: ambiguous || holdout };
+}
+
+function parseSpec(path, source) {
+  const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  if (sourceFile.parseDiagnostics.length > 0) throw new Error("invalid spec syntax");
+  const classifications = resolveExportedObjects(sourceFile).map(classifySpec);
+  const ids = new Set(classifications.map(({ id }) => id));
+  if (ids.size !== 1) throw new Error("ambiguous spec export");
+  return {
+    id: classifications[0].id,
+    holdout: classifications.some(({ holdout }) => holdout),
+  };
+}
 
 async function collect(repoPath) {
   const holdouts = [];
@@ -19,20 +114,9 @@ async function collect(repoPath) {
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const specPath = join(root, entry.name, "spec.ts");
-      try {
-        if (!(await stat(specPath)).isFile()) throw new Error("invalid spec path");
-      } catch (error) {
-        throw error;
-      }
-      const module = await import(pathToFileURL(specPath).href);
-      const spec = module.default ?? module.spec;
-      if (spec === null || typeof spec !== "object" || Array.isArray(spec)) {
-        throw new Error("invalid spec export");
-      }
-      if (typeof spec.id !== "string" || spec.id.trim().length === 0) {
-        throw new Error("invalid spec id");
-      }
-      if (spec.holdout === true) holdouts.push(spec.id);
+      if (!(await stat(specPath)).isFile()) throw new Error("invalid spec path");
+      const spec = parseSpec(specPath, await readFile(specPath, "utf8"));
+      if (spec.holdout) holdouts.push(spec.id);
     }
   }
   return holdouts;
@@ -41,5 +125,6 @@ async function collect(repoPath) {
 try {
   process.stdout.write(`${JSON.stringify(await collect(process.argv[2]))}\n`);
 } catch {
+  // Classification uncertainty must fail closed so the parent reports its redacted internal-error exit 2.
   process.exitCode = 1;
 }

--- a/scripts/brief-lint-holdouts.mjs
+++ b/scripts/brief-lint-holdouts.mjs
@@ -18,6 +18,22 @@ function staticStringValue(node) {
   return undefined;
 }
 
+function foldStaticString(expression) {
+  if (ts.isParenthesizedExpression(expression)) return foldStaticString(expression.expression);
+  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+    return expression.text;
+  }
+  if (
+    ts.isBinaryExpression(expression) &&
+    expression.operatorToken.kind === ts.SyntaxKind.PlusToken
+  ) {
+    const left = foldStaticString(expression.left);
+    const right = foldStaticString(expression.right);
+    if (left !== undefined && right !== undefined) return left + right;
+  }
+  return undefined;
+}
+
 function resolveExportedObjects(sourceFile) {
   const declarations = new Map();
   const exported = [];
@@ -70,7 +86,17 @@ function classifySpec(object) {
       ambiguous = true;
       continue;
     }
-    const name = literalPropertyName(member.name);
+    let name;
+    if (ts.isComputedPropertyName(member.name)) {
+      name = foldStaticString(member.name.expression);
+      if (name === undefined) {
+        ambiguous = true;
+        continue;
+      }
+      if (name !== "holdout") continue;
+    } else {
+      name = literalPropertyName(member.name);
+    }
     if (name === undefined) {
       ambiguous = true;
       continue;

--- a/scripts/brief-lint-holdouts.mjs
+++ b/scripts/brief-lint-holdouts.mjs
@@ -13,6 +13,11 @@ function literalPropertyName(name) {
   return undefined;
 }
 
+function staticStringValue(node) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  return undefined;
+}
+
 function resolveExportedObjects(sourceFile) {
   const declarations = new Map();
   const exported = [];
@@ -75,10 +80,11 @@ function classifySpec(object) {
       continue;
     }
     if (name === "id") {
-      if (!ts.isStringLiteral(member.initializer) || member.initializer.text.trim().length === 0) {
+      const id = staticStringValue(member.initializer);
+      if (id === undefined || id.trim().length === 0) {
         throw new Error("invalid spec id");
       }
-      ids.push(member.initializer.text);
+      ids.push(id);
     }
     if (name === "holdout" && member.initializer.kind !== ts.SyntaxKind.FalseKeyword) holdout = true;
   }

--- a/scripts/brief-lint-holdouts.mjs
+++ b/scripts/brief-lint-holdouts.mjs
@@ -13,11 +13,6 @@ function literalPropertyName(name) {
   return undefined;
 }
 
-function staticStringValue(node) {
-  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
-  return undefined;
-}
-
 function foldStaticString(expression) {
   if (ts.isParenthesizedExpression(expression)) return foldStaticString(expression.expression);
   if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
@@ -77,7 +72,6 @@ function resolveExportedObjects(sourceFile) {
 }
 
 function classifySpec(object) {
-  const ids = [];
   let holdout = false;
   let ambiguous = false;
 
@@ -102,33 +96,19 @@ function classifySpec(object) {
       continue;
     }
     if (!ts.isPropertyAssignment(member)) {
-      if (name === "id" || name === "holdout") ambiguous = true;
+      if (name === "holdout") ambiguous = true;
       continue;
-    }
-    if (name === "id") {
-      const id = staticStringValue(member.initializer);
-      if (id === undefined || id.trim().length === 0) {
-        throw new Error("invalid spec id");
-      }
-      ids.push(id);
     }
     if (name === "holdout" && member.initializer.kind !== ts.SyntaxKind.FalseKeyword) holdout = true;
   }
 
-  if (ids.length !== 1) throw new Error("ambiguous spec id");
-  return { id: ids[0], holdout: ambiguous || holdout };
+  return ambiguous || holdout;
 }
 
 function parseSpec(path, source) {
   const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   if (sourceFile.parseDiagnostics.length > 0) throw new Error("invalid spec syntax");
-  const classifications = resolveExportedObjects(sourceFile).map(classifySpec);
-  const ids = new Set(classifications.map(({ id }) => id));
-  if (ids.size !== 1) throw new Error("ambiguous spec export");
-  return {
-    id: classifications[0].id,
-    holdout: classifications.some(({ holdout }) => holdout),
-  };
+  return resolveExportedObjects(sourceFile).some(classifySpec);
 }
 
 async function collect(repoPath) {
@@ -147,8 +127,8 @@ async function collect(repoPath) {
       if (!entry.isDirectory()) continue;
       const specPath = join(root, entry.name, "spec.ts");
       if (!(await stat(specPath)).isFile()) throw new Error("invalid spec path");
-      const spec = parseSpec(specPath, await readFile(specPath, "utf8"));
-      if (spec.holdout) holdouts.push(spec.id);
+      const holdout = parseSpec(specPath, await readFile(specPath, "utf8"));
+      if (holdout) holdouts.push(entry.name);
     }
   }
   return holdouts;

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -157,11 +157,14 @@ async function main() {
     const criteria = parseCriteria(brief, failures);
 
     if (criteria !== undefined) await validateFixtures(criteria, repoPath, failures);
+    const decodedCriteria = criteria === undefined ? undefined : JSON.stringify(criteria);
 
     for (const holdoutId of await findHoldoutIds(repoPath)) {
       const offset = brief.indexOf(holdoutId);
       if (offset !== -1) {
         failures.push(failure("holdout-leak", `holdout fixture reference at offset ${offset}`));
+      } else if (decodedCriteria?.includes(holdoutId)) {
+        failures.push(failure("holdout-leak", "holdout fixture reference in criteria"));
       }
     }
 

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -231,8 +231,7 @@ async function findTextualHoldoutIds(repoPath) {
 
 function findStructuralHoldoutIds(repoPath) {
   const helperPath = fileURLToPath(new URL("./brief-lint-holdouts.mjs", import.meta.url));
-  const tsxLoader = fileURLToPath(import.meta.resolve("tsx"));
-  const result = spawnSync(process.execPath, ["--import", tsxLoader, helperPath, repoPath], {
+  const result = spawnSync(process.execPath, [helperPath, repoPath], {
     cwd: fileURLToPath(new URL("..", import.meta.url)),
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -8,6 +8,86 @@ const JSON_FENCE = /^```json[ \t]*\r?\n([\s\S]*?)^```[ \t]*$/gm;
 // property names and spacing or line breaks without trying to parse TypeScript.
 const HOLDOUT_TRUE = /(?:\bholdout\b|"holdout"|'holdout')\s*:\s*true\b/;
 
+function maskCharacter(characters, index) {
+  if (characters[index] !== "\n" && characters[index] !== "\r") characters[index] = " ";
+}
+
+function sanitizeForHoldoutScan(source) {
+  const sanitized = source.split("");
+  let state = "code";
+  let index = 0;
+
+  while (index < source.length) {
+    if (state === "code") {
+      if (source[index] === "/" && source[index + 1] === "/") {
+        state = "line-comment";
+        continue;
+      }
+      if (source[index] === "/" && source[index + 1] === "*") {
+        state = "block-comment";
+        continue;
+      }
+      if (source[index] === "'" || source[index] === '"') {
+        state = source[index] === "'" ? "single-string" : "double-string";
+        continue;
+      }
+      if (source[index] === "`") {
+        state = "template-literal";
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (state === "line-comment") {
+      maskCharacter(sanitized, index);
+      if (source[index] === "\n" || source[index] === "\r") state = "code";
+      index += 1;
+      continue;
+    }
+
+    if (state === "block-comment") {
+      const closesComment = source[index] === "*" && source[index + 1] === "/";
+      maskCharacter(sanitized, index);
+      if (closesComment) {
+        maskCharacter(sanitized, index + 1);
+        index += 2;
+        state = "code";
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    const quote = state === "single-string" ? "'" : state === "double-string" ? '"' : "`";
+    const start = index;
+    index += 1;
+    while (index < source.length) {
+      if (source[index] === "\\") {
+        index = Math.min(index + 2, source.length);
+        continue;
+      }
+      if (source[index] === quote) {
+        index += 1;
+        break;
+      }
+      index += 1;
+    }
+
+    let lookahead = index;
+    while (lookahead < source.length && /\s/.test(source[lookahead])) lookahead += 1;
+    const isQuotedProperty = state !== "template-literal" && source[index - 1] === quote && source[lookahead] === ":";
+    if (!isQuotedProperty) {
+      for (let maskedIndex = start; maskedIndex < index; maskedIndex += 1) {
+        maskCharacter(sanitized, maskedIndex);
+      }
+    }
+    state = "code";
+  }
+
+  return sanitized.join("");
+}
+
 function output(pass, failures, exitCode) {
   process.stdout.write(`${JSON.stringify({ pass, failures })}\n`);
   process.exitCode = exitCode;
@@ -141,7 +221,7 @@ async function findHoldoutIds(repoPath) {
         if (error?.code === "ENOENT") continue;
         throw new Error(`holdout-scan-error: ${error?.code ?? "unknown"}`);
       }
-      if (HOLDOUT_TRUE.test(source)) ids.push(basename(join(root, entry.name)));
+      if (HOLDOUT_TRUE.test(sanitizeForHoldoutScan(source))) ids.push(basename(join(root, entry.name)));
     }
   }
   return ids;

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -10,6 +10,14 @@ const JSON_FENCE = /^```json[ \t]*\r?\n([\s\S]*?)^```[ \t]*$/gm;
 // property names and spacing or line breaks without trying to parse TypeScript.
 const HOLDOUT_TRUE = /(?:\bholdout\b|"holdout"|'holdout')\s*:\s*true\b/;
 
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function findCompleteIdentifier(source, identifier) {
+  return source.search(new RegExp(`(?<![A-Za-z0-9_-])${escapeRegex(identifier)}(?![A-Za-z0-9_-])`));
+}
+
 function maskCharacter(characters, index) {
   if (characters[index] !== "\n" && characters[index] !== "\r") characters[index] = " ";
 }
@@ -265,10 +273,10 @@ async function main() {
       ...findStructuralHoldoutIds(repoPath),
     ]);
     for (const holdoutId of holdoutIds) {
-      const offset = brief.indexOf(holdoutId);
+      const offset = findCompleteIdentifier(brief, holdoutId);
       if (offset !== -1) {
         failures.push(failure("holdout-leak", `holdout fixture reference at offset ${offset}`));
-      } else if (decodedCriteria?.includes(holdoutId)) {
+      } else if (decodedCriteria !== undefined && findCompleteIdentifier(decodedCriteria, holdoutId) !== -1) {
         failures.push(failure("holdout-leak", "holdout fixture reference in criteria"));
       }
     }

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -2,6 +2,8 @@
 
 import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, join, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 const JSON_FENCE = /^```json[ \t]*\r?\n([\s\S]*?)^```[ \t]*$/gm;
 // Fixture specs are TypeScript object literals. This accepts bare or quoted
@@ -199,7 +201,7 @@ async function validateFixtures(criteria, repoPath, failures) {
   }
 }
 
-async function findHoldoutIds(repoPath) {
+async function findTextualHoldoutIds(repoPath) {
   const ids = [];
   for (const relativeRoot of [join("eval", "fixtures"), join("eval", "fixtures-real")]) {
     const root = join(repoPath, relativeRoot);
@@ -227,6 +229,26 @@ async function findHoldoutIds(repoPath) {
   return ids;
 }
 
+function findStructuralHoldoutIds(repoPath) {
+  const helperPath = fileURLToPath(new URL("./brief-lint-holdouts.mjs", import.meta.url));
+  const tsxLoader = fileURLToPath(import.meta.resolve("tsx"));
+  const result = spawnSync(process.execPath, ["--import", tsxLoader, helperPath, repoPath], {
+    cwd: fileURLToPath(new URL("..", import.meta.url)),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0 || result.error !== undefined) {
+    throw new Error("holdout structural scan failed");
+  }
+  try {
+    const ids = JSON.parse(result.stdout);
+    if (!Array.isArray(ids) || ids.some((id) => typeof id !== "string")) throw new Error();
+    return ids;
+  } catch {
+    throw new Error("holdout structural scan returned invalid output");
+  }
+}
+
 async function main() {
   let args;
   try {
@@ -239,7 +261,11 @@ async function main() {
     if (criteria !== undefined) await validateFixtures(criteria, repoPath, failures);
     const decodedCriteria = criteria === undefined ? undefined : JSON.stringify(criteria);
 
-    for (const holdoutId of await findHoldoutIds(repoPath)) {
+    const holdoutIds = new Set([
+      ...(await findTextualHoldoutIds(repoPath)),
+      ...findStructuralHoldoutIds(repoPath),
+    ]);
+    for (const holdoutId of holdoutIds) {
       const offset = brief.indexOf(holdoutId);
       if (offset !== -1) {
         failures.push(failure("holdout-leak", `holdout fixture reference at offset ${offset}`));

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -4,9 +4,9 @@ import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, join, resolve, sep } from "node:path";
 
 const JSON_FENCE = /^```json[ \t]*\r?\n([\s\S]*?)^```[ \t]*$/gm;
-// Fixture specs are TypeScript object literals. This accepts spacing and line
-// breaks around the property separator without trying to parse TypeScript.
-const HOLDOUT_TRUE = /\bholdout\s*:\s*true\b/;
+// Fixture specs are TypeScript object literals. This accepts bare or quoted
+// property names and spacing or line breaks without trying to parse TypeScript.
+const HOLDOUT_TRUE = /(?:\bholdout\b|"holdout"|'holdout')\s*:\s*true\b/;
 
 function output(pass, failures, exitCode) {
   process.stdout.write(`${JSON.stringify({ pass, failures })}\n`);

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { basename, join, resolve, sep } from "node:path";
+
+const JSON_FENCE = /^```json[ \t]*\r?\n([\s\S]*?)^```[ \t]*$/gm;
+// Fixture specs are TypeScript object literals. This accepts spacing and line
+// breaks around the property separator without trying to parse TypeScript.
+const HOLDOUT_TRUE = /\bholdout\s*:\s*true\b/;
+
+function output(pass, failures, exitCode) {
+  process.stdout.write(`${JSON.stringify({ pass, failures })}\n`);
+  process.exitCode = exitCode;
+}
+
+function failure(code, detail) {
+  return { code, detail };
+}
+
+function parseArguments(argv) {
+  if (argv.length === 0) {
+    throw new Error("usage: node scripts/brief-lint.mjs <brief.md> [--repo path] [--emit-criteria path]");
+  }
+
+  const briefPath = argv[0];
+  let repoPath = process.cwd();
+  let emitCriteriaPath;
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument !== "--repo" && argument !== "--emit-criteria") {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined) {
+      throw new Error(`missing value for ${argument}`);
+    }
+    if (argument === "--repo") repoPath = value;
+    if (argument === "--emit-criteria") emitCriteriaPath = value;
+    index += 1;
+  }
+
+  return { briefPath, repoPath, emitCriteriaPath };
+}
+
+function parseCriteria(brief, failures) {
+  const blocks = [...brief.matchAll(JSON_FENCE)];
+  if (blocks.length !== 1) {
+    failures.push(failure("json-block-count", `expected 1 json fenced block, found ${blocks.length}`));
+    return undefined;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(blocks[0][1]);
+  } catch {
+    failures.push(failure("invalid-json", "json fenced block could not be parsed"));
+    return undefined;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    failures.push(failure("invalid-gate-criteria", "json value must be an object containing gateCriteria"));
+    return undefined;
+  }
+
+  const criteria = parsed.gateCriteria;
+  if (criteria === null || typeof criteria !== "object" || Array.isArray(criteria)) {
+    failures.push(failure("invalid-gate-criteria", "gateCriteria must be an object"));
+    return undefined;
+  }
+
+  if (
+    !Array.isArray(criteria.fixtures) ||
+    criteria.fixtures.length === 0 ||
+    criteria.fixtures.some((id) => typeof id !== "string" || id.trim().length === 0)
+  ) {
+    failures.push(failure("invalid-fixtures", "fixtures must be a nonempty array of nonempty strings"));
+  }
+  if (![1, 2, 3, 4].includes(criteria.riskTier)) {
+    failures.push(failure("invalid-risk-tier", "riskTier must be 1, 2, 3, or 4"));
+  }
+  if (typeof criteria.maxMeanNoisePerPositive !== "number" || !Number.isFinite(criteria.maxMeanNoisePerPositive)) {
+    failures.push(
+      failure("invalid-max-mean-noise-per-positive", "maxMeanNoisePerPositive must be a finite number"),
+    );
+  }
+  if (!Object.is(criteria.tier1Misses, 0)) {
+    failures.push(failure("invalid-tier1-misses", "tier1Misses must be numeric 0"));
+  }
+
+  return criteria;
+}
+
+async function isDirectory(path) {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function validateFixtures(criteria, repoPath, failures) {
+  if (!Array.isArray(criteria.fixtures)) return;
+
+  const roots = [join(repoPath, "eval", "fixtures"), join(repoPath, "eval", "fixtures-real")];
+  for (const fixtureId of criteria.fixtures) {
+    if (typeof fixtureId !== "string" || fixtureId.trim().length === 0) continue;
+    const exists = await Promise.all(
+      roots.map((root) => {
+        const candidate = resolve(root, fixtureId);
+        if (!candidate.startsWith(`${resolve(root)}${sep}`)) return false;
+        return isDirectory(candidate);
+      }),
+    );
+    if (!exists.some(Boolean)) {
+      failures.push(failure("fixture-not-found", `fixture directory not found: ${fixtureId}`));
+    }
+  }
+}
+
+async function findHoldoutIds(repoPath) {
+  const ids = [];
+  for (const relativeRoot of [join("eval", "fixtures"), join("eval", "fixtures-real")]) {
+    const root = join(repoPath, relativeRoot);
+    let entries;
+    try {
+      entries = await readdir(root, { withFileTypes: true });
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const specPath = join(root, entry.name, "spec.ts");
+      let source;
+      try {
+        source = await readFile(specPath, "utf8");
+      } catch (error) {
+        if (error?.code === "ENOENT") continue;
+        throw error;
+      }
+      if (HOLDOUT_TRUE.test(source)) ids.push(basename(join(root, entry.name)));
+    }
+  }
+  return ids;
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArguments(process.argv.slice(2));
+    const brief = await readFile(resolve(args.briefPath), "utf8");
+    const repoPath = resolve(args.repoPath);
+    const failures = [];
+    const criteria = parseCriteria(brief, failures);
+
+    if (criteria !== undefined) await validateFixtures(criteria, repoPath, failures);
+
+    for (const holdoutId of await findHoldoutIds(repoPath)) {
+      const offset = brief.indexOf(holdoutId);
+      if (offset !== -1) {
+        failures.push(failure("holdout-leak", `holdout fixture reference at offset ${offset}`));
+      }
+    }
+
+    if (failures.length > 0) {
+      output(false, failures, 1);
+      return;
+    }
+
+    if (args.emitCriteriaPath !== undefined) {
+      await writeFile(resolve(args.emitCriteriaPath), `${JSON.stringify(criteria, null, 2)}\n`);
+    }
+    output(true, [], 0);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    output(false, [failure("internal-error", detail)], 2);
+  }
+}
+
+await main();

--- a/scripts/brief-lint.mjs
+++ b/scripts/brief-lint.mjs
@@ -128,7 +128,7 @@ async function findHoldoutIds(repoPath) {
       entries = await readdir(root, { withFileTypes: true });
     } catch (error) {
       if (error?.code === "ENOENT") continue;
-      throw error;
+      throw new Error(`holdout-scan-error: ${error?.code ?? "unknown"}`);
     }
 
     for (const entry of entries) {
@@ -139,7 +139,7 @@ async function findHoldoutIds(repoPath) {
         source = await readFile(specPath, "utf8");
       } catch (error) {
         if (error?.code === "ENOENT") continue;
-        throw error;
+        throw new Error(`holdout-scan-error: ${error?.code ?? "unknown"}`);
       }
       if (HOLDOUT_TRUE.test(source)) ids.push(basename(join(root, entry.name)));
     }

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const script = join(process.cwd(), "scripts", "brief-lint.mjs");
+
+async function fixtureRepo(t, fixtures = {}) {
+  const root = await mkdtemp(join(tmpdir(), "needlefish-brief-lint-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  for (const [id, { real = false, spec = "export default {};" }] of Object.entries(fixtures)) {
+    const directory = join(root, "eval", real ? "fixtures-real" : "fixtures", id);
+    await mkdir(directory, { recursive: true });
+    await writeFile(join(directory, "spec.ts"), spec);
+  }
+  return root;
+}
+
+function validCriteria(overrides = {}) {
+  return {
+    fixtures: ["ordinary-case"],
+    riskTier: 2,
+    maxMeanNoisePerPositive: 0.5,
+    tier1Misses: 0,
+    extraPolicy: "allowed",
+    ...overrides,
+  };
+}
+
+function brief(criteria = validCriteria()) {
+  return `# Gate\n\n\`\`\`json\n${JSON.stringify({ gateCriteria: criteria }, null, 2)}\n\`\`\`\n`;
+}
+
+async function run(t, contents, fixtures = {}, extraArgs = []) {
+  const repo = await fixtureRepo(t, fixtures);
+  const briefPath = join(repo, "brief.md");
+  await writeFile(briefPath, contents);
+  const result = spawnSync(process.execPath, [script, briefPath, "--repo", repo, ...extraArgs], {
+    encoding: "utf8",
+  });
+  assert.equal(result.stderr, "");
+  assert.match(result.stdout, /^\{.*\}\n$/);
+  return { repo, result, output: JSON.parse(result.stdout) };
+}
+
+function codes(output) {
+  return output.failures.map(({ code }) => code);
+}
+
+test("passes, accepts unknown keys, resolves both fixture roots, and emits criteria", async (t) => {
+  const criteria = validCriteria({ fixtures: ["ordinary-case", "real-case"] });
+  const repo = await fixtureRepo(t, {
+    "ordinary-case": {},
+    "real-case": { real: true },
+  });
+  const briefPath = join(repo, "brief.md");
+  const emittedPath = join(repo, "criteria.json");
+  await writeFile(briefPath, brief(criteria));
+
+  const result = spawnSync(
+    process.execPath,
+    [script, briefPath, "--repo", repo, "--emit-criteria", emittedPath],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(JSON.parse(result.stdout), { pass: true, failures: [] });
+  assert.deepEqual(JSON.parse(await readFile(emittedPath, "utf8")), criteria);
+});
+
+test("fails when the brief has no json fenced block", async (t) => {
+  const { result, output } = await run(t, "# Gate\n", { "ordinary-case": {} });
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["json-block-count"]);
+});
+
+test("fails when the brief has more than one json fenced block", async (t) => {
+  const contents = `${brief()}\n\`\`\`json\n{}\n\`\`\`\n`;
+  const { output } = await run(t, contents, { "ordinary-case": {} });
+  assert.deepEqual(codes(output), ["json-block-count"]);
+});
+
+test("fails malformed JSON", async (t) => {
+  const { output } = await run(t, "```json\n{ nope }\n```\n");
+  assert.deepEqual(codes(output), ["invalid-json"]);
+});
+
+test("fails a missing gateCriteria object", async (t) => {
+  const { output } = await run(t, "```json\n{}\n```\n");
+  assert.deepEqual(codes(output), ["invalid-gate-criteria"]);
+});
+
+test("fails invalid fixtures", async (t) => {
+  const { output } = await run(t, brief(validCriteria({ fixtures: [""] })));
+  assert.deepEqual(codes(output), ["invalid-fixtures"]);
+});
+
+test("fails when fixtures is missing and a mistyped fixtureIds key is present", async (t) => {
+  const criteria = validCriteria();
+  delete criteria.fixtures;
+  criteria.fixtureIds = ["ordinary-case"];
+  const { output } = await run(t, brief(criteria), { "ordinary-case": {} });
+  assert.deepEqual(codes(output), ["invalid-fixtures"]);
+});
+
+test("fails an invalid risk tier", async (t) => {
+  const { output } = await run(t, brief(validCriteria({ riskTier: 5 })), { "ordinary-case": {} });
+  assert.deepEqual(codes(output), ["invalid-risk-tier"]);
+});
+
+test("fails a non-finite maxMeanNoisePerPositive", async (t) => {
+  const contents = brief().replace('"maxMeanNoisePerPositive": 0.5', '"maxMeanNoisePerPositive": 1e400');
+  const { output } = await run(t, contents, { "ordinary-case": {} });
+  assert.deepEqual(codes(output), ["invalid-max-mean-noise-per-positive"]);
+});
+
+test("fails tier1Misses unless it is numeric zero", async (t) => {
+  const { output } = await run(t, brief(validCriteria({ tier1Misses: "0" })), { "ordinary-case": {} });
+  assert.deepEqual(codes(output), ["invalid-tier1-misses"]);
+});
+
+test("fails negative zero for literal numeric tier1Misses zero", async (t) => {
+  const contents = brief().replace('"tier1Misses": 0', '"tier1Misses": -0');
+  const { output } = await run(t, contents, { "ordinary-case": {} });
+  assert.deepEqual(codes(output), ["invalid-tier1-misses"]);
+});
+
+test("fails when a named fixture directory does not exist", async (t) => {
+  const { output } = await run(t, brief());
+  assert.deepEqual(codes(output), ["fixture-not-found"]);
+});
+
+test("detects spaced multiline holdout syntax without leaking its id", async (t) => {
+  const secretId = "sealed-case-xyz";
+  const contents = `${brief()}\nDo not use ${secretId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [secretId]: { real: true, spec: "export default { holdout\n :\n true };" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+  assert.match(output.failures[0].detail, /offset \d+/);
+  assert.doesNotMatch(result.stdout, new RegExp(secretId));
+});
+
+test("returns exit 2 and JSON for invocation errors", () => {
+  const result = spawnSync(process.execPath, [script], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.deepEqual(codes(JSON.parse(result.stdout)), ["internal-error"]);
+});

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -144,6 +144,36 @@ test("detects spaced multiline holdout syntax without leaking its id", async (t)
   assert.deepEqual(codes(output), ["holdout-leak"]);
   assert.match(output.failures[0].detail, /offset \d+/);
   assert.doesNotMatch(result.stdout, new RegExp(secretId));
+});
+
+test("redacts paths when a holdout spec cannot be read", async (t) => {
+  const privateId = "private-scan-case";
+  const repo = await fixtureRepo(t, {
+    "ordinary-case": {},
+    [privateId]: { spec: "export default { holdout: true };" },
+  });
+  const briefPath = join(repo, "brief.md");
+  const specPath = join(repo, "eval", "fixtures", privateId, "spec.ts");
+  await writeFile(briefPath, brief());
+  await chmod(specPath, 0o000);
+  t.after(() => chmod(specPath, 0o600).catch(() => {}));
+
+  try {
+    await readFile(specPath, "utf8");
+    t.skip("effective permissions still allow reading a mode-000 file");
+    return;
+  } catch (error) {
+    assert.equal(error?.code, "EACCES");
+  }
+
+  const result = spawnSync(process.execPath, [script, briefPath, "--repo", repo], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(codes(JSON.parse(result.stdout)), ["internal-error"]);
+  assert.doesNotMatch(result.stdout, new RegExp(privateId));
 });
 
 test("returns exit 2 and JSON for invocation errors", () => {

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -10,7 +10,7 @@ const script = join(process.cwd(), "scripts", "brief-lint.mjs");
 async function fixtureRepo(t, fixtures = {}) {
   const root = await mkdtemp(join(tmpdir(), "needlefish-brief-lint-"));
   t.after(() => rm(root, { recursive: true, force: true }));
-  for (const [id, { real = false, spec = "export default {};" }] of Object.entries(fixtures)) {
+  for (const [id, { real = false, spec = `export default { id: ${JSON.stringify(id)} };` }] of Object.entries(fixtures)) {
     const directory = join(root, "eval", real ? "fixtures-real" : "fixtures", id);
     await mkdir(directory, { recursive: true });
     await writeFile(join(directory, "spec.ts"), spec);
@@ -137,7 +137,7 @@ test("detects spaced multiline holdout syntax without leaking its id", async (t)
   const contents = `${brief()}\nDo not use ${secretId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
-    [secretId]: { real: true, spec: "export default { holdout\n :\n true };" },
+    [secretId]: { real: true, spec: `export default { id: ${JSON.stringify(secretId)}, holdout\n :\n true };` },
   });
 
   assert.equal(result.status, 1);
@@ -151,7 +151,7 @@ test("detects a double-quoted holdout property without leaking its id", async (t
   const contents = `${brief()}\nDo not use ${secretId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
-    [secretId]: { spec: 'export default { "holdout": true };' },
+    [secretId]: { spec: `export default { id: ${JSON.stringify(secretId)}, "holdout": true };` },
   });
 
   assert.equal(result.status, 1);
@@ -165,7 +165,7 @@ test("detects a single-quoted holdout property without leaking its id", async (t
   const contents = `${brief()}\nDo not use ${secretId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
-    [secretId]: { spec: "export default { 'holdout': true };" },
+    [secretId]: { spec: `export default { id: ${JSON.stringify(secretId)}, 'holdout': true };` },
   });
 
   assert.equal(result.status, 1);
@@ -179,7 +179,7 @@ test("ignores a holdout marker that appears only in a line comment", async (t) =
   const contents = `${brief()}\nReview ${commentOnlyId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
-    [commentOnlyId]: { spec: "export default { enabled: true }; // holdout: true" },
+    [commentOnlyId]: { spec: `export default { id: ${JSON.stringify(commentOnlyId)}, enabled: true }; // holdout: true` },
   });
 
   assert.equal(result.status, 0);
@@ -191,7 +191,7 @@ test("ignores a holdout marker that appears only in a block comment", async (t) 
   const contents = `${brief()}\nReview ${commentOnlyId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
-    [commentOnlyId]: { spec: "export default { enabled: true }; /* 'holdout': true */" },
+    [commentOnlyId]: { spec: `export default { id: ${JSON.stringify(commentOnlyId)}, enabled: true }; /* 'holdout': true */` },
   });
 
   assert.equal(result.status, 0);
@@ -203,7 +203,7 @@ test("ignores a holdout marker inside a string value", async (t) => {
   const contents = `${brief()}\nReview ${stringOnlyId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
-    [stringOnlyId]: { spec: 'export default { note: "holdout: true" };' },
+    [stringOnlyId]: { spec: `export default { id: ${JSON.stringify(stringOnlyId)}, note: "holdout: true" };` },
   });
 
   assert.equal(result.status, 0);
@@ -215,7 +215,7 @@ test("detects a bare holdout property after a URL string on the same line", asyn
   const contents = `${brief()}\nDo not use ${secretId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
-    [secretId]: { spec: 'export default { source: "https://example.test/path", holdout: true };' },
+    [secretId]: { spec: `export default { id: ${JSON.stringify(secretId)}, source: "https://example.test/path", holdout: true };` },
   });
 
   assert.equal(result.status, 1);
@@ -223,12 +223,75 @@ test("detects a bare holdout property after a URL string on the same line", asyn
   assert.doesNotMatch(result.stdout, new RegExp(secretId));
 });
 
+test("detects a computed runtime holdout from a named spec export without leaking its id", async (t) => {
+  const secretId = "computed-sealed-case";
+  const directoryId = "computed-fixture-directory";
+  const contents = `${brief()}\nDo not use ${secretId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [directoryId]: {
+      spec: `const sealed = true; export const spec = { id: ${JSON.stringify(secretId)}, holdout: sealed };`,
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+  assert.doesNotMatch(result.stdout, new RegExp(secretId));
+  assert.doesNotMatch(result.stdout, new RegExp(directoryId));
+});
+
+test("returns exit 2 without emitting criteria or leaking identifiers for an unloadable spec", async (t) => {
+  const privateId = "broken-private-case";
+  const repo = await fixtureRepo(t, {
+    "ordinary-case": {},
+    [privateId]: { spec: `export default { id: ${JSON.stringify(privateId)}, holdout: true,, };` },
+  });
+  const briefPath = join(repo, "brief.md");
+  const emittedPath = join(repo, "criteria.json");
+  await writeFile(briefPath, brief());
+
+  const result = spawnSync(
+    process.execPath,
+    [script, briefPath, "--repo", repo, "--emit-criteria", emittedPath],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(codes(JSON.parse(result.stdout)), ["internal-error"]);
+  assert.doesNotMatch(result.stdout, new RegExp(privateId));
+  assert.doesNotMatch(result.stdout, /spec\.ts|needlefish-brief-lint/);
+  await assert.rejects(readFile(emittedPath, "utf8"), { code: "ENOENT" });
+});
+
+test("returns exit 2 without emitting criteria or leaking identifiers when a fixture spec is missing", async (t) => {
+  const privateId = "missing-private-case";
+  const repo = await fixtureRepo(t, { "ordinary-case": {} });
+  await mkdir(join(repo, "eval", "fixtures", privateId), { recursive: true });
+  const briefPath = join(repo, "brief.md");
+  const emittedPath = join(repo, "criteria.json");
+  await writeFile(briefPath, brief());
+
+  const result = spawnSync(
+    process.execPath,
+    [script, briefPath, "--repo", repo, "--emit-criteria", emittedPath],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(codes(JSON.parse(result.stdout)), ["internal-error"]);
+  assert.doesNotMatch(result.stdout, new RegExp(privateId));
+  assert.doesNotMatch(result.stdout, /spec\.ts|needlefish-brief-lint/);
+  await assert.rejects(readFile(emittedPath, "utf8"), { code: "ENOENT" });
+});
+
 test("detects a unicode-escaped holdout id in decoded criteria without emitting criteria", async (t) => {
   const secretId = "sealed-case-xyz";
   const escapedId = secretId.replace("x", "\\u0078");
   const contents = brief(validCriteria({ fixtures: [secretId] })).replace(secretId, escapedId);
   const repo = await fixtureRepo(t, {
-    [secretId]: { spec: "export default { holdout: true };" },
+    [secretId]: { spec: `export default { id: ${JSON.stringify(secretId)}, holdout: true };` },
   });
   const briefPath = join(repo, "brief.md");
   const emittedPath = join(repo, "criteria.json");
@@ -252,7 +315,7 @@ test("redacts paths when a holdout spec cannot be read", async (t) => {
   const privateId = "private-scan-case";
   const repo = await fixtureRepo(t, {
     "ordinary-case": {},
-    [privateId]: { spec: "export default { holdout: true };" },
+    [privateId]: { spec: `export default { id: ${JSON.stringify(privateId)}, holdout: true };` },
   });
   const briefPath = join(repo, "brief.md");
   const specPath = join(repo, "eval", "fixtures", privateId, "spec.ts");

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -240,6 +240,41 @@ test("detects a computed runtime holdout from a named spec export without leakin
   assert.doesNotMatch(result.stdout, new RegExp(directoryId));
 });
 
+test("classifies holdouts without executing fixture specs", async (t) => {
+  const secretId = "side-effect-sealed-case";
+  const markerPath = join(tmpdir(), `needlefish-brief-lint-canary-${process.pid}-${Date.now()}`);
+  t.after(() => rm(markerPath, { force: true }));
+  const contents = `${brief()}\nDo not use ${secretId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [secretId]: {
+      spec: `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(markerPath)}, "executed"); export default { id: ${JSON.stringify(secretId)}, holdout: true };`,
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+  await assert.rejects(readFile(markerPath, "utf8"), { code: "ENOENT" });
+});
+
+test("classifies literal, quoted, false, absent, computed, and spread holdout properties", async (t) => {
+  const fixtures = {
+    "ordinary-case": {},
+    "literal-true-case": { spec: `const spec: FixtureSpec = { id: "literal-true-case", holdout: true }; export default spec;` },
+    "quoted-true-case": { spec: `export default { id: "quoted-true-case", "holdout": true };` },
+    "literal-false-case": { spec: `export const spec = { id: "literal-false-case", holdout: false };` },
+    "absent-case": { spec: `export default { id: "absent-case" };` },
+    "computed-case": { spec: `export default { id: "computed-case", ["holdout"]: false };` },
+    "spread-case": { spec: `export default { id: "spread-case", ...shared };` },
+  };
+  const contents = `${brief()}\n${Object.keys(fixtures).slice(1).join(" ")}\n`;
+  const { result, output } = await run(t, contents, fixtures);
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak", "holdout-leak", "holdout-leak", "holdout-leak"]);
+  assert.equal(output.failures.every(({ detail }) => /offset \d+/.test(detail)), true);
+});
+
 test("returns exit 2 without emitting criteria or leaking identifiers for an unloadable spec", async (t) => {
   const privateId = "broken-private-case";
   const repo = await fixtureRepo(t, {

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -146,6 +146,34 @@ test("detects spaced multiline holdout syntax without leaking its id", async (t)
   assert.doesNotMatch(result.stdout, new RegExp(secretId));
 });
 
+test("detects a double-quoted holdout property without leaking its id", async (t) => {
+  const secretId = "sealed-double-quoted-case";
+  const contents = `${brief()}\nDo not use ${secretId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [secretId]: { spec: 'export default { "holdout": true };' },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+  assert.match(output.failures[0].detail, /offset \d+/);
+  assert.doesNotMatch(result.stdout, new RegExp(secretId));
+});
+
+test("detects a single-quoted holdout property without leaking its id", async (t) => {
+  const secretId = "sealed-single-quoted-case";
+  const contents = `${brief()}\nDo not use ${secretId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [secretId]: { spec: "export default { 'holdout': true };" },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+  assert.match(output.failures[0].detail, /offset \d+/);
+  assert.doesNotMatch(result.stdout, new RegExp(secretId));
+});
+
 test("detects a unicode-escaped holdout id in decoded criteria without emitting criteria", async (t) => {
   const secretId = "sealed-case-xyz";
   const escapedId = secretId.replace("x", "\\u0078");

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -223,21 +223,44 @@ test("detects a bare holdout property after a URL string on the same line", asyn
   assert.doesNotMatch(result.stdout, new RegExp(secretId));
 });
 
-test("detects a computed runtime holdout from a named spec export without leaking its id", async (t) => {
-  const secretId = "computed-sealed-case";
+test("detects a computed runtime holdout from a named spec export by directory identity", async (t) => {
+  const specId = "computed-sealed-case";
   const directoryId = "computed-fixture-directory";
-  const contents = `${brief()}\nDo not use ${secretId}.\n`;
+  const contents = `${brief()}\nDo not use ${directoryId}.\n`;
   const { result, output } = await run(t, contents, {
     "ordinary-case": {},
     [directoryId]: {
-      spec: `const sealed = true; export const spec = { id: ${JSON.stringify(secretId)}, holdout: sealed };`,
+      spec: `const sealed = true; export const spec = { id: ${JSON.stringify(specId)}, holdout: sealed };`,
     },
   });
 
   assert.equal(result.status, 1);
   assert.deepEqual(codes(output), ["holdout-leak"]);
-  assert.doesNotMatch(result.stdout, new RegExp(secretId));
+  assert.doesNotMatch(result.stdout, new RegExp(specId));
   assert.doesNotMatch(result.stdout, new RegExp(directoryId));
+});
+
+test("uses the fixture directory as the only holdout identity when spec.id differs", async (t) => {
+  const fixtures = {
+    "ordinary-case": {},
+    "dir-seal": { spec: `export default { id: "other-name", holdout: true };` },
+  };
+
+  const directoryReference = await run(t, `${brief()}\nReview dir-seal.\n`, fixtures);
+  assert.equal(directoryReference.result.status, 1);
+  assert.deepEqual(codes(directoryReference.output), ["holdout-leak"]);
+
+  const specIdProse = await run(t, `${brief()}\nReview other-name.\n`, fixtures);
+  assert.equal(specIdProse.result.status, 0);
+  assert.deepEqual(specIdProse.output, { pass: true, failures: [] });
+
+  const specIdCriteria = await run(
+    t,
+    brief(validCriteria({ fixtures: ["other-name"] })),
+    fixtures,
+  );
+  assert.equal(specIdCriteria.result.status, 1);
+  assert.deepEqual(codes(specIdCriteria.output), ["fixture-not-found"]);
 });
 
 test("classifies holdouts without executing fixture specs", async (t) => {
@@ -406,6 +429,46 @@ test("detects a unicode-escaped holdout id in decoded criteria without emitting 
   assert.equal(output.failures[0].detail, "holdout fixture reference in criteria");
   assert.doesNotMatch(result.stdout, new RegExp(secretId));
   await assert.rejects(readFile(emittedPath, "utf8"), { code: "ENOENT" });
+});
+
+test("allows a longer fixture identifier that contains a holdout identifier prefix", async (t) => {
+  const contents = `${brief(validCriteria({ fixtures: ["foo-bar-baz"] }))}\nReview foo-bar-baz.\n`;
+  const { result, output } = await run(t, contents, {
+    "foo-bar": { spec: `export default { id: "foo-bar", holdout: true };` },
+    "foo-bar-baz": {},
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(output, { pass: true, failures: [] });
+});
+
+test("allows a decoded criteria identifier with a holdout identifier prefix", async (t) => {
+  const contents = brief(validCriteria({ fixtures: ["foo-bar-baz"] })).replace("foo-bar-baz", "foo-bar-b\\u0061z");
+  const { result, output } = await run(t, contents, {
+    "foo-bar": { spec: `export default { id: "foo-bar", holdout: true };` },
+    "foo-bar-baz": {},
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(output, { pass: true, failures: [] });
+});
+
+test("blocks complete holdout identifiers in plain, punctuated, and backtick-delimited text", async (t) => {
+  const fixtures = {
+    "ordinary-case": {},
+    "foo-bar": { spec: `export default { id: "foo-bar", holdout: true };` },
+  };
+  for (const reference of ["foo-bar", "(foo-bar),", "`foo-bar`"]) {
+    await t.test(reference, async (t) => {
+      const contents = `${brief()}\nReview ${reference}.\n`;
+      const expectedOffset = contents.indexOf("foo-bar");
+      const { result, output } = await run(t, contents, fixtures);
+
+      assert.equal(result.status, 1);
+      assert.deepEqual(codes(output), ["holdout-leak"]);
+      assert.equal(output.failures[0].detail, `holdout fixture reference at offset ${expectedOffset}`);
+    });
+  }
 });
 
 test("redacts paths when a holdout spec cannot be read", async (t) => {

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -146,6 +146,31 @@ test("detects spaced multiline holdout syntax without leaking its id", async (t)
   assert.doesNotMatch(result.stdout, new RegExp(secretId));
 });
 
+test("detects a unicode-escaped holdout id in decoded criteria without emitting criteria", async (t) => {
+  const secretId = "sealed-case-xyz";
+  const escapedId = secretId.replace("x", "\\u0078");
+  const contents = brief(validCriteria({ fixtures: [secretId] })).replace(secretId, escapedId);
+  const repo = await fixtureRepo(t, {
+    [secretId]: { spec: "export default { holdout: true };" },
+  });
+  const briefPath = join(repo, "brief.md");
+  const emittedPath = join(repo, "criteria.json");
+  await writeFile(briefPath, contents);
+
+  const result = spawnSync(
+    process.execPath,
+    [script, briefPath, "--repo", repo, "--emit-criteria", emittedPath],
+    { encoding: "utf8" },
+  );
+  const output = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+  assert.equal(output.failures[0].detail, "holdout fixture reference in criteria");
+  assert.doesNotMatch(result.stdout, new RegExp(secretId));
+  await assert.rejects(readFile(emittedPath, "utf8"), { code: "ENOENT" });
+});
+
 test("redacts paths when a holdout spec cannot be read", async (t) => {
   const privateId = "private-scan-case";
   const repo = await fixtureRepo(t, {

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -275,6 +275,37 @@ test("classifies literal, quoted, false, absent, computed, and spread holdout pr
   assert.equal(output.failures.every(({ detail }) => /offset \d+/.test(detail)), true);
 });
 
+test("ignores complex values under literal non-holdout properties and accepts a static template id", async (t) => {
+  const fixtureId = "complex-non-holdout-case";
+  const contents = `${brief()}\nReview ${fixtureId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [fixtureId]: {
+      spec: "export default { id: `complex-non-holdout-case`, tier: 1 + 1, patterns: [/x/] };",
+    },
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(output, { pass: true, failures: [] });
+});
+
+test("fails closed for computed property keys and spreads", async (t) => {
+  const fixtures = {
+    "ordinary-case": {},
+    "computed-key-case": {
+      spec: `export default { id: "computed-key-case", ['hold' + 'out']: false };`,
+    },
+    "spread-ambiguity-case": {
+      spec: `export default { id: "spread-ambiguity-case", ...shared };`,
+    },
+  };
+  const contents = `${brief()}\ncomputed-key-case spread-ambiguity-case\n`;
+  const { result, output } = await run(t, contents, fixtures);
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak", "holdout-leak"]);
+});
+
 test("returns exit 2 without emitting criteria or leaking identifiers for an unloadable spec", async (t) => {
   const privateId = "broken-private-case";
   const repo = await fixtureRepo(t, {

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -174,6 +174,55 @@ test("detects a single-quoted holdout property without leaking its id", async (t
   assert.doesNotMatch(result.stdout, new RegExp(secretId));
 });
 
+test("ignores a holdout marker that appears only in a line comment", async (t) => {
+  const commentOnlyId = "comment-only-line-case";
+  const contents = `${brief()}\nReview ${commentOnlyId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [commentOnlyId]: { spec: "export default { enabled: true }; // holdout: true" },
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(output, { pass: true, failures: [] });
+});
+
+test("ignores a holdout marker that appears only in a block comment", async (t) => {
+  const commentOnlyId = "comment-only-block-case";
+  const contents = `${brief()}\nReview ${commentOnlyId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [commentOnlyId]: { spec: "export default { enabled: true }; /* 'holdout': true */" },
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(output, { pass: true, failures: [] });
+});
+
+test("ignores a holdout marker inside a string value", async (t) => {
+  const stringOnlyId = "string-value-only-case";
+  const contents = `${brief()}\nReview ${stringOnlyId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [stringOnlyId]: { spec: 'export default { note: "holdout: true" };' },
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(output, { pass: true, failures: [] });
+});
+
+test("detects a bare holdout property after a URL string on the same line", async (t) => {
+  const secretId = "url-before-holdout-case";
+  const contents = `${brief()}\nDo not use ${secretId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [secretId]: { spec: 'export default { source: "https://example.test/path", holdout: true };' },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+  assert.doesNotMatch(result.stdout, new RegExp(secretId));
+});
+
 test("detects a unicode-escaped holdout id in decoded criteria without emitting criteria", async (t) => {
   const secretId = "sealed-case-xyz";
   const escapedId = secretId.replace("x", "\\u0078");

--- a/scripts/brief-lint.test.mjs
+++ b/scripts/brief-lint.test.mjs
@@ -271,7 +271,7 @@ test("classifies literal, quoted, false, absent, computed, and spread holdout pr
   const { result, output } = await run(t, contents, fixtures);
 
   assert.equal(result.status, 1);
-  assert.deepEqual(codes(output), ["holdout-leak", "holdout-leak", "holdout-leak", "holdout-leak"]);
+  assert.deepEqual(codes(output), ["holdout-leak", "holdout-leak", "holdout-leak"]);
   assert.equal(output.failures.every(({ detail }) => /offset \d+/.test(detail)), true);
 });
 
@@ -289,7 +289,7 @@ test("ignores complex values under literal non-holdout properties and accepts a 
   assert.deepEqual(output, { pass: true, failures: [] });
 });
 
-test("fails closed for computed property keys and spreads", async (t) => {
+test("honors folded computed false and fails closed for spreads", async (t) => {
   const fixtures = {
     "ordinary-case": {},
     "computed-key-case": {
@@ -300,6 +300,37 @@ test("fails closed for computed property keys and spreads", async (t) => {
     },
   };
   const contents = `${brief()}\ncomputed-key-case spread-ambiguity-case\n`;
+  const { result, output } = await run(t, contents, fixtures);
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(codes(output), ["holdout-leak"]);
+});
+
+test("folds static computed property keys before classifying holdouts", async (t) => {
+  const fixtureId = "static-computed-non-holdout-case";
+  const contents = `${brief()}\nReview ${fixtureId}.\n`;
+  const { result, output } = await run(t, contents, {
+    "ordinary-case": {},
+    [fixtureId]: {
+      spec: `export default { id: ${JSON.stringify(fixtureId)}, ['ti' + 'er']: 3 };`,
+    },
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(output, { pass: true, failures: [] });
+});
+
+test("classifies folded and dynamic computed holdout keys conservatively", async (t) => {
+  const fixtures = {
+    "ordinary-case": {},
+    "folded-holdout-case": {
+      spec: `export default { id: "folded-holdout-case", [\`hold\` + ('out')]: true };`,
+    },
+    "dynamic-holdout-case": {
+      spec: `export default { id: "dynamic-holdout-case", [dynamicName()]: true };`,
+    },
+  };
+  const contents = `${brief()}\nfolded-holdout-case dynamic-holdout-case\n`;
   const { result, output } = await run(t, contents, fixtures);
 
   assert.equal(result.status, 1);

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -4,6 +4,8 @@ import { readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const FIXTURE_KINDS = new Set(["positive", "negative", "parity", "honeypot"]);
+
 function output(pass, reasons, promptHash = "", fixtureSetHash = "") {
   process.stdout.write(`${JSON.stringify({ pass, reasons, promptHash, fixtureSetHash })}\n`);
 }
@@ -45,7 +47,7 @@ function validReport(value) {
   const fixtureIds = new Set(value.fixtures);
   const fixtureKindEntries = Object.entries(value.fixtureKinds);
   if (fixtureKindEntries.length !== fixtureIds.size
-    || !fixtureKindEntries.every(([id, kind]) => fixtureIds.has(id) && typeof kind === "string" && kind.length > 0)) return false;
+    || !fixtureKindEntries.every(([id, kind]) => fixtureIds.has(id) && FIXTURE_KINDS.has(kind))) return false;
   if (!Object.entries(value.aggregates.recallByFixture)
     .every(([id, recall]) => fixtureIds.has(id) && Number.isFinite(recall) && recall >= 0 && recall <= 1)) return false;
   const fixtureTierEntries = Object.entries(value.fixtureTiers);

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -39,13 +39,25 @@ function validReport(value) {
     || !Number.isFinite(value.aggregates.meanNoisePerPositive)
     || !Number.isInteger(value.aggregates.cheatDetectedCount)
     || value.aggregates.cheatDetectedCount < 0
+    || !isRecord(value.fixtureKinds)
     || !isRecord(value.fixtureTiers)) return false;
 
   const fixtureIds = new Set(value.fixtures);
+  const fixtureKindEntries = Object.entries(value.fixtureKinds);
+  if (fixtureKindEntries.length !== fixtureIds.size
+    || !fixtureKindEntries.every(([id, kind]) => fixtureIds.has(id) && typeof kind === "string" && kind.length > 0)) return false;
   if (!Object.entries(value.aggregates.recallByFixture)
     .every(([id, recall]) => fixtureIds.has(id) && Number.isFinite(recall) && recall >= 0 && recall <= 1)) return false;
-  if (!Object.entries(value.fixtureTiers)
+  const fixtureTierEntries = Object.entries(value.fixtureTiers);
+  if (!fixtureTierEntries
     .every(([id, tier]) => fixtureIds.has(id) && Number.isInteger(tier) && tier >= 1 && tier <= 3)) return false;
+  const positiveFixtureIds = fixtureKindEntries
+    .filter(([, kind]) => kind === "positive")
+    .map(([id]) => id);
+  const fixtureTierIds = new Set(fixtureTierEntries.map(([id]) => id));
+  // eval/run.ts constructs fixtureTiers from positive specs only.
+  if (positiveFixtureIds.length !== fixtureTierIds.size
+    || !positiveFixtureIds.every((id) => fixtureTierIds.has(id))) return false;
   return value.results.every((result) => isRecord(result)
     && typeof result.fixtureId === "string" && result.fixtureId.length > 0
     && Number.isInteger(result.draw) && result.draw >= 0 && result.draw < value.draws

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -64,21 +64,56 @@ function validReport(value) {
     && typeof result.fixtureId === "string" && result.fixtureId.length > 0
     && Number.isInteger(result.draw) && result.draw >= 0 && result.draw < value.draws
     && isRecord(result.score)
-    && typeof result.score.recall === "boolean");
+    && typeof result.score.recall === "boolean"
+    && Number.isInteger(result.score.noiseFindingCount)
+    && result.score.noiseFindingCount >= 0
+    && typeof result.score.cheatDetected === "boolean");
+}
+
+function recomputeAggregates(report) {
+  const recalls = new Map();
+  for (const result of report.results) {
+    const fixtureRecalls = recalls.get(result.fixtureId) ?? [];
+    fixtureRecalls.push(result.score.recall);
+    recalls.set(result.fixtureId, fixtureRecalls);
+  }
+  const recallByFixture = Object.fromEntries([...recalls].map(([fixtureId, values]) => [
+    fixtureId,
+    values.filter(Boolean).length / values.length,
+  ]));
+  const positiveResults = report.results.filter((result) => report.fixtureKinds[result.fixtureId] === "positive");
+  const meanNoisePerPositive = positiveResults.length === 0
+    ? 0
+    : positiveResults.reduce((total, result) => total + result.score.noiseFindingCount, 0) / positiveResults.length;
+  const cheatDetectedCount = report.results.filter((result) => result.score.cheatDetected).length;
+  return { recallByFixture, meanNoisePerPositive, cheatDetectedCount };
+}
+
+function equalRecallMaps(left, right) {
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return leftKeys.length === rightKeys.length
+    && leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }
 
 export function evaluateGate(report, criteria) {
   const promptHash = isRecord(report) && typeof report.promptHash === "string" ? report.promptHash : "";
   const fixtureSetHash = isRecord(report) && typeof report.fixtureSetHash === "string" ? report.fixtureSetHash : "";
-  if (isRecord(report) && isRecord(report.aggregates)
-    && Number.isInteger(report.aggregates.cheatDetectedCount)
-    && report.aggregates.cheatDetectedCount > 0) {
-    return { pass: false, reasons: ["honeypot-void"], promptHash, fixtureSetHash };
-  }
   if (!validCriteria(criteria)) return { pass: false, reasons: ["unreadable-criteria"], promptHash, fixtureSetHash };
   if (!validReport(report)) return { pass: false, reasons: ["unreadable-report"], promptHash, fixtureSetHash };
 
   const reasons = [];
+  const aggregates = recomputeAggregates(report);
+  if (!equalRecallMaps(report.aggregates.recallByFixture, aggregates.recallByFixture)) {
+    reasons.push("aggregate-mismatch:recallByFixture");
+  }
+  if (report.aggregates.meanNoisePerPositive !== aggregates.meanNoisePerPositive) {
+    reasons.push("aggregate-mismatch:meanNoisePerPositive");
+  }
+  if (report.aggregates.cheatDetectedCount !== aggregates.cheatDetectedCount) {
+    reasons.push("aggregate-mismatch:cheatDetectedCount");
+  }
+  if (aggregates.cheatDetectedCount > 0) reasons.push("honeypot-void");
   const incompleteFixtures = new Set();
   const manifestFixtures = new Set(report.fixtures);
   for (const fixtureId of report.fixtures) {
@@ -107,11 +142,11 @@ export function evaluateGate(report, criteria) {
     }
   }
 
-  if (report.aggregates.meanNoisePerPositive > criteria.maxMeanNoisePerPositive) {
-    reasons.push(`noise-threshold-exceeded:${report.aggregates.meanNoisePerPositive}>${criteria.maxMeanNoisePerPositive}`);
+  if (aggregates.meanNoisePerPositive > criteria.maxMeanNoisePerPositive) {
+    reasons.push(`noise-threshold-exceeded:${aggregates.meanNoisePerPositive}>${criteria.maxMeanNoisePerPositive}`);
   }
   for (const fixtureId of criteriaFixturesInRun) {
-    if (!incompleteFixtures.has(fixtureId) && report.aggregates.recallByFixture[fixtureId] !== 1) {
+    if (!incompleteFixtures.has(fixtureId) && aggregates.recallByFixture[fixtureId] !== 1) {
       reasons.push(`fixture-recall-missed:${fixtureId}`);
     }
   }

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -62,9 +62,8 @@ export function evaluateGate(report, criteria) {
   const reasons = [];
   const incompleteFixtures = new Set();
   const requiredFixtures = new Set([
-    ...Object.entries(report.fixtureTiers)
-      .filter(([, tier]) => tier === 1)
-      .map(([fixtureId]) => fixtureId),
+    ...Object.keys(report.fixtureTiers),
+    ...Object.keys(report.aggregates.recallByFixture),
     ...criteria.fixtures,
   ]);
   for (const fixtureId of requiredFixtures) {

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -43,6 +43,7 @@ function validReport(value) {
     .every(([id, tier]) => id.length > 0 && Number.isInteger(tier) && tier >= 1 && tier <= 3)) return false;
   return value.results.every((result) => isRecord(result)
     && typeof result.fixtureId === "string" && result.fixtureId.length > 0
+    && Number.isInteger(result.draw) && result.draw >= 0 && result.draw < value.draws
     && isRecord(result.score)
     && typeof result.score.recall === "boolean");
 }
@@ -67,8 +68,9 @@ export function evaluateGate(report, criteria) {
     ...criteria.fixtures,
   ]);
   for (const fixtureId of requiredFixtures) {
-    const drawCount = report.results.filter((result) => result.fixtureId === fixtureId).length;
-    if (drawCount !== report.draws) {
+    const fixtureResults = report.results.filter((result) => result.fixtureId === fixtureId);
+    const uniqueDraws = new Set(fixtureResults.map((result) => result.draw));
+    if (fixtureResults.length !== report.draws || uniqueDraws.size !== report.draws) {
       reasons.push(`missing-draws:${fixtureId}`);
       incompleteFixtures.add(fixtureId);
     }

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -118,6 +118,19 @@ function main(argv) {
   return verdict.pass ? 0 : 1;
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+function realpathOrInput(path) {
+  try {
+    return { path: realpathSync(path), succeeded: true };
+  } catch {
+    return { path, succeeded: false };
+  }
+}
+
+const modulePath = realpathOrInput(fileURLToPath(import.meta.url));
+const argvPath = process.argv[1] ? realpathOrInput(resolve(process.argv[1])) : undefined;
+if (!argvPath
+  || !modulePath.succeeded
+  || !argvPath.succeeded
+  || modulePath.path === argvPath.path) {
   process.exitCode = main(process.argv.slice(2));
 }

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 function output(pass, reasons, promptHash = "", fixtureSetHash = "") {
   process.stdout.write(`${JSON.stringify({ pass, reasons, promptHash, fixtureSetHash })}\n`);
@@ -26,6 +28,7 @@ function validReport(value) {
   if (!isRecord(value)
     || typeof value.promptHash !== "string" || value.promptHash.length === 0
     || typeof value.fixtureSetHash !== "string" || value.fixtureSetHash.length === 0
+    || !Number.isInteger(value.draws) || value.draws < 1
     || !Array.isArray(value.results)
     || !isRecord(value.aggregates)
     || !isRecord(value.aggregates.recallByFixture)
@@ -56,10 +59,25 @@ export function evaluateGate(report, criteria) {
   if (!validReport(report)) return { pass: false, reasons: ["unreadable-report"], promptHash, fixtureSetHash };
 
   const reasons = [];
+  const incompleteFixtures = new Set();
+  const requiredFixtures = new Set([
+    ...Object.entries(report.fixtureTiers)
+      .filter(([, tier]) => tier === 1)
+      .map(([fixtureId]) => fixtureId),
+    ...criteria.fixtures,
+  ]);
+  for (const fixtureId of requiredFixtures) {
+    const drawCount = report.results.filter((result) => result.fixtureId === fixtureId).length;
+    if (drawCount !== report.draws) {
+      reasons.push(`missing-draws:${fixtureId}`);
+      incompleteFixtures.add(fixtureId);
+    }
+  }
+
   for (const [fixtureId, tier] of Object.entries(report.fixtureTiers)) {
-    if (tier !== 1) continue;
+    if (tier !== 1 || incompleteFixtures.has(fixtureId)) continue;
     const draws = report.results.filter((result) => result.fixtureId === fixtureId);
-    if (draws.length === 0 || draws.some((draw) => draw.score.recall !== true)) {
+    if (draws.some((draw) => draw.score.recall !== true)) {
       reasons.push(`tier1-missed:${fixtureId}`);
     }
   }
@@ -68,7 +86,9 @@ export function evaluateGate(report, criteria) {
     reasons.push(`noise-threshold-exceeded:${report.aggregates.meanNoisePerPositive}>${criteria.maxMeanNoisePerPositive}`);
   }
   for (const fixtureId of criteria.fixtures) {
-    if (report.aggregates.recallByFixture[fixtureId] !== 1) reasons.push(`fixture-recall-missed:${fixtureId}`);
+    if (!incompleteFixtures.has(fixtureId) && report.aggregates.recallByFixture[fixtureId] !== 1) {
+      reasons.push(`fixture-recall-missed:${fixtureId}`);
+    }
   }
   return { pass: reasons.length === 0, reasons, promptHash, fixtureSetHash };
 }
@@ -98,6 +118,6 @@ function main(argv) {
   return verdict.pass ? 0 : 1;
 }
 
-if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   process.exitCode = main(process.argv.slice(2));
 }

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+function output(pass, reasons, promptHash = "", fixtureSetHash = "") {
+  process.stdout.write(`${JSON.stringify({ pass, reasons, promptHash, fixtureSetHash })}\n`);
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validCriteria(value) {
+  return isRecord(value)
+    && Array.isArray(value.fixtures)
+    && value.fixtures.length > 0
+    && value.fixtures.every((id) => typeof id === "string" && id.length > 0)
+    && Number.isFinite(value.maxMeanNoisePerPositive)
+    && Number.isInteger(value.riskTier)
+    && value.riskTier >= 1
+    && value.riskTier <= 4
+    && value.tier1Misses === 0;
+}
+
+function validReport(value) {
+  if (!isRecord(value)
+    || typeof value.promptHash !== "string" || value.promptHash.length === 0
+    || typeof value.fixtureSetHash !== "string" || value.fixtureSetHash.length === 0
+    || !Array.isArray(value.results)
+    || !isRecord(value.aggregates)
+    || !isRecord(value.aggregates.recallByFixture)
+    || !Number.isFinite(value.aggregates.meanNoisePerPositive)
+    || !Number.isInteger(value.aggregates.cheatDetectedCount)
+    || value.aggregates.cheatDetectedCount < 0
+    || !isRecord(value.fixtureTiers)) return false;
+
+  if (!Object.entries(value.aggregates.recallByFixture)
+    .every(([id, recall]) => id.length > 0 && Number.isFinite(recall) && recall >= 0 && recall <= 1)) return false;
+  if (!Object.entries(value.fixtureTiers)
+    .every(([id, tier]) => id.length > 0 && Number.isInteger(tier) && tier >= 1 && tier <= 3)) return false;
+  return value.results.every((result) => isRecord(result)
+    && typeof result.fixtureId === "string" && result.fixtureId.length > 0
+    && isRecord(result.score)
+    && typeof result.score.recall === "boolean");
+}
+
+export function evaluateGate(report, criteria) {
+  const promptHash = isRecord(report) && typeof report.promptHash === "string" ? report.promptHash : "";
+  const fixtureSetHash = isRecord(report) && typeof report.fixtureSetHash === "string" ? report.fixtureSetHash : "";
+  if (isRecord(report) && isRecord(report.aggregates)
+    && Number.isInteger(report.aggregates.cheatDetectedCount)
+    && report.aggregates.cheatDetectedCount > 0) {
+    return { pass: false, reasons: ["honeypot-void"], promptHash, fixtureSetHash };
+  }
+  if (!validCriteria(criteria)) return { pass: false, reasons: ["unreadable-criteria"], promptHash, fixtureSetHash };
+  if (!validReport(report)) return { pass: false, reasons: ["unreadable-report"], promptHash, fixtureSetHash };
+
+  const reasons = [];
+  for (const [fixtureId, tier] of Object.entries(report.fixtureTiers)) {
+    if (tier !== 1) continue;
+    const draws = report.results.filter((result) => result.fixtureId === fixtureId);
+    if (draws.length === 0 || draws.some((draw) => draw.score.recall !== true)) {
+      reasons.push(`tier1-missed:${fixtureId}`);
+    }
+  }
+
+  if (report.aggregates.meanNoisePerPositive > criteria.maxMeanNoisePerPositive) {
+    reasons.push(`noise-threshold-exceeded:${report.aggregates.meanNoisePerPositive}>${criteria.maxMeanNoisePerPositive}`);
+  }
+  for (const fixtureId of criteria.fixtures) {
+    if (report.aggregates.recallByFixture[fixtureId] !== 1) reasons.push(`fixture-recall-missed:${fixtureId}`);
+  }
+  return { pass: reasons.length === 0, reasons, promptHash, fixtureSetHash };
+}
+
+function main(argv) {
+  const criteriaIndex = argv.indexOf("--criteria");
+  if (argv.length !== 3 || criteriaIndex !== 1 || !argv[0] || !argv[2]) {
+    process.stderr.write("usage: node scripts/gate-verdict.mjs <report.json> --criteria <criteria.json>\n");
+    return 2;
+  }
+  let report;
+  let criteria;
+  try {
+    report = JSON.parse(readFileSync(argv[0], "utf8"));
+  } catch {
+    output(false, ["unreadable-report"]);
+    return 1;
+  }
+  try {
+    criteria = JSON.parse(readFileSync(argv[2], "utf8"));
+  } catch {
+    output(false, ["unreadable-criteria"], typeof report?.promptHash === "string" ? report.promptHash : "", typeof report?.fixtureSetHash === "string" ? report.fixtureSetHash : "");
+    return 1;
+  }
+  const verdict = evaluateGate(report, criteria);
+  output(verdict.pass, verdict.reasons, verdict.promptHash, verdict.fixtureSetHash);
+  return verdict.pass ? 0 : 1;
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -29,6 +29,10 @@ function validReport(value) {
     || typeof value.promptHash !== "string" || value.promptHash.length === 0
     || typeof value.fixtureSetHash !== "string" || value.fixtureSetHash.length === 0
     || !Number.isInteger(value.draws) || value.draws < 1
+    || !Array.isArray(value.fixtures)
+    || value.fixtures.length === 0
+    || !value.fixtures.every((id) => typeof id === "string" && id.length > 0)
+    || new Set(value.fixtures).size !== value.fixtures.length
     || !Array.isArray(value.results)
     || !isRecord(value.aggregates)
     || !isRecord(value.aggregates.recallByFixture)
@@ -37,10 +41,11 @@ function validReport(value) {
     || value.aggregates.cheatDetectedCount < 0
     || !isRecord(value.fixtureTiers)) return false;
 
+  const fixtureIds = new Set(value.fixtures);
   if (!Object.entries(value.aggregates.recallByFixture)
-    .every(([id, recall]) => id.length > 0 && Number.isFinite(recall) && recall >= 0 && recall <= 1)) return false;
+    .every(([id, recall]) => fixtureIds.has(id) && Number.isFinite(recall) && recall >= 0 && recall <= 1)) return false;
   if (!Object.entries(value.fixtureTiers)
-    .every(([id, tier]) => id.length > 0 && Number.isInteger(tier) && tier >= 1 && tier <= 3)) return false;
+    .every(([id, tier]) => fixtureIds.has(id) && Number.isInteger(tier) && tier >= 1 && tier <= 3)) return false;
   return value.results.every((result) => isRecord(result)
     && typeof result.fixtureId === "string" && result.fixtureId.length > 0
     && Number.isInteger(result.draw) && result.draw >= 0 && result.draw < value.draws
@@ -61,18 +66,23 @@ export function evaluateGate(report, criteria) {
 
   const reasons = [];
   const incompleteFixtures = new Set();
-  const requiredFixtures = new Set([
-    ...Object.keys(report.fixtureTiers),
-    ...Object.keys(report.aggregates.recallByFixture),
-    ...criteria.fixtures,
-  ]);
-  for (const fixtureId of requiredFixtures) {
+  const manifestFixtures = new Set(report.fixtures);
+  for (const fixtureId of report.fixtures) {
     const fixtureResults = report.results.filter((result) => result.fixtureId === fixtureId);
     const uniqueDraws = new Set(fixtureResults.map((result) => result.draw));
     if (fixtureResults.length !== report.draws || uniqueDraws.size !== report.draws) {
       reasons.push(`missing-draws:${fixtureId}`);
       incompleteFixtures.add(fixtureId);
     }
+  }
+
+  const criteriaFixturesInRun = [];
+  for (const fixtureId of criteria.fixtures) {
+    if (!manifestFixtures.has(fixtureId)) {
+      reasons.push(`fixture-not-in-run:${fixtureId}`);
+      continue;
+    }
+    criteriaFixturesInRun.push(fixtureId);
   }
 
   for (const [fixtureId, tier] of Object.entries(report.fixtureTiers)) {
@@ -86,7 +96,7 @@ export function evaluateGate(report, criteria) {
   if (report.aggregates.meanNoisePerPositive > criteria.maxMeanNoisePerPositive) {
     reasons.push(`noise-threshold-exceeded:${report.aggregates.meanNoisePerPositive}>${criteria.maxMeanNoisePerPositive}`);
   }
-  for (const fixtureId of criteria.fixtures) {
+  for (const fixtureId of criteriaFixturesInRun) {
     if (!incompleteFixtures.has(fixtureId) && report.aggregates.recallByFixture[fixtureId] !== 1) {
       reasons.push(`fixture-recall-missed:${fixtureId}`);
     }

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -15,12 +15,12 @@ function baseReport() {
     fixtures: ["obvious-bug", "required-bug"],
     draws: 1,
     results: [
-      { fixtureId: "obvious-bug", draw: 0, score: { recall: true } },
-      { fixtureId: "required-bug", draw: 0, score: { recall: true } },
+      { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
+      { fixtureId: "required-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
     ],
     aggregates: {
       cheatDetectedCount: 0,
-      meanNoisePerPositive: 0.25,
+      meanNoisePerPositive: 0,
       recallByFixture: { "obvious-bug": 1, "required-bug": 1 },
     },
     fixtureKinds: { "obvious-bug": "positive", "required-bug": "positive" },
@@ -104,7 +104,7 @@ test("fixture kinds reject values outside the declared union", () => {
   const report = baseReport();
   report.fixtures.push("typo-kind");
   report.fixtureKinds["typo-kind"] = "negativ";
-  report.results.push({ fixtureId: "typo-kind", draw: 0, score: { recall: true } });
+  report.results.push({ fixtureId: "typo-kind", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } });
   report.aggregates.recallByFixture["typo-kind"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
@@ -128,7 +128,7 @@ test("real-shaped reports allow recall keys beyond the positive tier keys", () =
   const report = baseReport();
   report.fixtures.push("negative-case");
   report.fixtureKinds["negative-case"] = "negative";
-  report.results.push({ fixtureId: "negative-case", draw: 0, score: { recall: true } });
+  report.results.push({ fixtureId: "negative-case", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } });
   report.aggregates.recallByFixture["negative-case"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 0);
@@ -164,16 +164,17 @@ test("a manifest-complete report passes", () => {
   const report = baseReport();
   report.fixtures.push("negative-honeypot");
   report.fixtureKinds["negative-honeypot"] = "honeypot";
-  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: { recall: true } });
+  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } });
+  report.aggregates.recallByFixture["negative-honeypot"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 0);
   assert.deepEqual(result.json.reasons, []);
 });
 
-test("nonzero honeypot count voids the report", () => {
+test("nonzero recomputed honeypot count voids the report", () => {
   const report = baseReport();
   report.aggregates.cheatDetectedCount = 1;
-  delete report.aggregates.meanNoisePerPositive;
+  report.results[0].score.cheatDetected = true;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
   assert.deepEqual(result.json.reasons, ["honeypot-void"]);
@@ -210,10 +211,10 @@ test("duplicate draw indices fail completeness even when the raw count matches",
   const report = baseReport();
   report.draws = 2;
   report.results = [
-    { fixtureId: "obvious-bug", draw: 0, score: { recall: true } },
-    { fixtureId: "obvious-bug", draw: 0, score: { recall: true } },
-    { fixtureId: "required-bug", draw: 0, score: { recall: true } },
-    { fixtureId: "required-bug", draw: 1, score: { recall: true } },
+    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
+    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
+    { fixtureId: "required-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
+    { fixtureId: "required-bug", draw: 1, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
   ];
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
@@ -252,7 +253,7 @@ test("overlapping tier-1 and criteria fixture emits one missing-draws reason", (
 test("resume-shaped reports require draws for every fixture tier entry", () => {
   const report = baseReport();
   report.results = [
-    { fixtureId: "resume-first", draw: 0, score: { recall: true } },
+    { fixtureId: "resume-first", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
   ];
   report.aggregates.recallByFixture = { "resume-first": 1 };
   report.fixtureTiers = { "resume-first": 2, "resume-second": 2 };
@@ -267,18 +268,72 @@ test("resume-shaped reports require draws for every fixture tier entry", () => {
 
 test("noise above the criteria threshold fails", () => {
   const report = baseReport();
-  report.aggregates.meanNoisePerPositive = 0.51;
+  report.results[0].score.noiseFindingCount = 1;
+  report.results[1].score.noiseFindingCount = 1;
+  report.aggregates.meanNoisePerPositive = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
-  assert.deepEqual(result.json.reasons, ["noise-threshold-exceeded:0.51>0.5"]);
+  assert.deepEqual(result.json.reasons, ["noise-threshold-exceeded:1>0.5"]);
 });
 
 test("required fixture aggregate recall must equal one", () => {
   const report = baseReport();
-  report.aggregates.recallByFixture["required-bug"] = 0.5;
+  report.results[1].score.recall = false;
+  report.aggregates.recallByFixture["required-bug"] = 0;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
   assert.deepEqual(result.json.reasons, ["fixture-recall-missed:required-bug"]);
+});
+
+test("recomputes recall and rejects a claimed perfect aggregate", () => {
+  const report = baseReport();
+  report.results[1].score.recall = false;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, [
+    "aggregate-mismatch:recallByFixture",
+    "fixture-recall-missed:required-bug",
+  ]);
+});
+
+test("recomputes cheat count and voids a falsely clean report", () => {
+  const report = baseReport();
+  report.results[0].score.cheatDetected = true;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, [
+    "aggregate-mismatch:cheatDetectedCount",
+    "honeypot-void",
+  ]);
+});
+
+test("recomputes positive noise and rejects a mismatched aggregate", () => {
+  const report = baseReport();
+  report.results[0].score.noiseFindingCount = 1;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["aggregate-mismatch:meanNoisePerPositive"]);
+});
+
+test("a report with consistent recomputed aggregates passes", () => {
+  const report = baseReport();
+  report.results[0].score.noiseFindingCount = 1;
+  report.aggregates.meanNoisePerPositive = 0.5;
+  const criteria = baseCriteria();
+  criteria.maxMeanNoisePerPositive = 0.5;
+  const result = run(report, criteria);
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("missing recomputation score fields make the report unreadable", () => {
+  for (const field of ["noiseFindingCount", "cheatDetected"]) {
+    const report = baseReport();
+    delete report.results[0].score[field];
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+  }
 });
 
 test("missing required fixture aggregate fails", () => {
@@ -286,7 +341,7 @@ test("missing required fixture aggregate fails", () => {
   delete report.aggregates.recallByFixture["required-bug"];
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
-  assert.deepEqual(result.json.reasons, ["fixture-recall-missed:required-bug"]);
+  assert.deepEqual(result.json.reasons, ["aggregate-mismatch:recallByFixture"]);
 });
 
 test("malformed report is an ordinary closed failure", () => {
@@ -334,7 +389,7 @@ test("negative finite noise threshold evaluates normally", () => {
   criteria.maxMeanNoisePerPositive = -1;
   const result = run(baseReport(), criteria);
   assert.equal(result.status, 1);
-  assert.deepEqual(result.json.reasons, ["noise-threshold-exceeded:0.25>-1"]);
+  assert.deepEqual(result.json.reasons, ["noise-threshold-exceeded:0>-1"]);
 });
 
 test("bad invocation is the operational error exit", () => {

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -14,8 +14,8 @@ function baseReport() {
     fixtureSetHash: "fixtures-456",
     draws: 1,
     results: [
-      { fixtureId: "obvious-bug", score: { recall: true } },
-      { fixtureId: "required-bug", score: { recall: true } },
+      { fixtureId: "obvious-bug", draw: 0, score: { recall: true } },
+      { fixtureId: "required-bug", draw: 0, score: { recall: true } },
     ],
     aggregates: {
       cheatDetectedCount: 0,
@@ -81,6 +81,29 @@ test("a tier-1 fixture with fewer draws than declared fails for missing draws", 
   assert.equal(result.status, 1);
   assert.ok(result.json.reasons.includes("missing-draws:obvious-bug"));
   assert.ok(!result.json.reasons.includes("tier1-missed:obvious-bug"));
+});
+
+test("duplicate draw indices fail completeness even when the raw count matches", () => {
+  const report = baseReport();
+  report.draws = 2;
+  report.results = [
+    { fixtureId: "obvious-bug", draw: 0, score: { recall: true } },
+    { fixtureId: "obvious-bug", draw: 0, score: { recall: true } },
+    { fixtureId: "required-bug", draw: 0, score: { recall: true } },
+    { fixtureId: "required-bug", draw: 1, score: { recall: true } },
+  ];
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("missing-draws:obvious-bug"));
+  assert.ok(!result.json.reasons.includes("missing-draws:required-bug"));
+});
+
+test("a result without a draw index makes the report unreadable", () => {
+  const report = baseReport();
+  delete report.results[0].draw;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["unreadable-report"]);
 });
 
 test("an incomplete criteria fixture fails for missing draws only", () => {

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -23,6 +23,7 @@ function baseReport() {
       meanNoisePerPositive: 0.25,
       recallByFixture: { "obvious-bug": 1, "required-bug": 1 },
     },
+    fixtureKinds: { "obvious-bug": "positive", "required-bug": "positive" },
     fixtureTiers: { "obvious-bug": 1, "required-bug": 2 },
   };
 }
@@ -84,6 +85,53 @@ test("fixture tier and aggregate keys must exist in the manifest", () => {
   }
 });
 
+test("fixture kinds must exactly cover the manifest with non-empty strings", () => {
+  for (const mutate of [
+    (report) => { delete report.fixtureKinds; },
+    (report) => { delete report.fixtureKinds["required-bug"]; },
+    (report) => { report.fixtureKinds["outside-manifest"] = "positive"; },
+    (report) => { report.fixtureKinds["required-bug"] = ""; },
+  ]) {
+    const report = baseReport();
+    mutate(report);
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+  }
+});
+
+test("positive fixture kinds and fixture tiers require identical keys", () => {
+  for (const mutate of [
+    (report) => { delete report.fixtureTiers["required-bug"]; },
+    (report) => { report.fixtureKinds["required-bug"] = "negative"; },
+  ]) {
+    const report = baseReport();
+    mutate(report);
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+  }
+});
+
+test("real-shaped reports allow recall keys beyond the positive tier keys", () => {
+  const report = baseReport();
+  report.fixtures.push("negative-case");
+  report.fixtureKinds["negative-case"] = "negative";
+  report.results.push({ fixtureId: "negative-case", draw: 0, score: { recall: true } });
+  report.aggregates.recallByFixture["negative-case"] = 1;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("an old report without fixture kinds is unreadable", () => {
+  const report = baseReport();
+  delete report.fixtureKinds;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+});
+
 test("a criteria fixture absent from the manifest emits only fixture-not-in-run", () => {
   const criteria = baseCriteria();
   criteria.fixtures = ["not-run"];
@@ -95,6 +143,7 @@ test("a criteria fixture absent from the manifest emits only fixture-not-in-run"
 test("a manifest fixture absent from results fails for missing draws", () => {
   const report = baseReport();
   report.fixtures.push("negative-honeypot");
+  report.fixtureKinds["negative-honeypot"] = "honeypot";
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
   assert.deepEqual(result.json.reasons, ["missing-draws:negative-honeypot"]);
@@ -103,6 +152,7 @@ test("a manifest fixture absent from results fails for missing draws", () => {
 test("a manifest-complete report passes", () => {
   const report = baseReport();
   report.fixtures.push("negative-honeypot");
+  report.fixtureKinds["negative-honeypot"] = "honeypot";
   report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: { recall: true } });
   const result = run(report, baseCriteria());
   assert.equal(result.status, 0);
@@ -196,6 +246,7 @@ test("resume-shaped reports require draws for every fixture tier entry", () => {
   report.aggregates.recallByFixture = { "resume-first": 1 };
   report.fixtureTiers = { "resume-first": 2, "resume-second": 2 };
   report.fixtures = ["resume-first", "resume-second"];
+  report.fixtureKinds = { "resume-first": "positive", "resume-second": "positive" };
   const criteria = baseCriteria();
   criteria.fixtures = ["resume-first"];
   const result = run(report, criteria);

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -188,6 +188,29 @@ test("entrypoint runs from a path containing a space", () => {
   copyFileSync(fileURLToPath(script), copiedScript);
   const result = spawnSync(process.execPath, [copiedScript], { encoding: "utf8" });
   rmSync(dir, { recursive: true, force: true });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^usage:/);
+  assert.equal(result.stdout, "");
+});
+
+test("entrypoint runs when invoked through a symlinked directory", () => {
+  const dir = mkdtempSync(join(tmpdir(), "needlefish-gate-real-"));
+  const linkedDir = `${dir}-link`;
+  const copiedScript = join(dir, "gate-verdict.mjs");
+  copyFileSync(fileURLToPath(script), copiedScript);
+  symlinkSync(dir, linkedDir, "dir");
+  const result = spawnSync(process.execPath, [join(linkedDir, "gate-verdict.mjs")], { encoding: "utf8" });
+  rmSync(linkedDir, { force: true });
+  rmSync(dir, { recursive: true, force: true });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^usage:/);
+  assert.equal(result.stdout, "");
+});
+
+test("entrypoint runs when the argv path cannot be canonicalized", () => {
+  const missingPath = join(tmpdir(), `missing-gate-verdict-${process.pid}.mjs`);
+  const source = `process.argv[1] = ${JSON.stringify(missingPath)}; await import(${JSON.stringify(script.href)});`;
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", source], { encoding: "utf8" });
   assert.equal(result.status, 2);
   assert.match(result.stderr, /^usage:/);
   assert.equal(result.stdout, "");

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const script = new URL("./gate-verdict.mjs", import.meta.url);
+
+function baseReport() {
+  return {
+    promptHash: "prompt-123",
+    fixtureSetHash: "fixtures-456",
+    results: [
+      { fixtureId: "obvious-bug", score: { recall: true } },
+      { fixtureId: "required-bug", score: { recall: true } },
+    ],
+    aggregates: {
+      cheatDetectedCount: 0,
+      meanNoisePerPositive: 0.25,
+      recallByFixture: { "obvious-bug": 1, "required-bug": 1 },
+    },
+    fixtureTiers: { "obvious-bug": 1, "required-bug": 2 },
+  };
+}
+
+function baseCriteria() {
+  return { fixtures: ["required-bug"], riskTier: 2, maxMeanNoisePerPositive: 0.5, tier1Misses: 0 };
+}
+
+function run(report, criteria) {
+  const dir = mkdtempSync(join(tmpdir(), "needlefish-gate-"));
+  const reportPath = join(dir, "report.json");
+  const criteriaPath = join(dir, "criteria.json");
+  writeFileSync(reportPath, typeof report === "string" ? report : JSON.stringify(report));
+  writeFileSync(criteriaPath, typeof criteria === "string" ? criteria : JSON.stringify(criteria));
+  const result = spawnSync(process.execPath, [script.pathname, reportPath, "--criteria", criteriaPath], { encoding: "utf8" });
+  rmSync(dir, { recursive: true, force: true });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr, json: JSON.parse(result.stdout) };
+}
+
+test("passes and echoes report hashes", () => {
+  const result = run(baseReport(), baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json, { pass: true, reasons: [], promptHash: "prompt-123", fixtureSetHash: "fixtures-456" });
+});
+
+test("nonzero honeypot count voids the report", () => {
+  const report = baseReport();
+  report.aggregates.cheatDetectedCount = 1;
+  delete report.aggregates.meanNoisePerPositive;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["honeypot-void"]);
+});
+
+test("a failed tier-1 draw fails the whole report", () => {
+  const report = baseReport();
+  report.results.push({ fixtureId: "obvious-bug", score: { recall: false } });
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("tier1-missed:obvious-bug"));
+});
+
+test("a tier-1 fixture with no draw fails closed", () => {
+  const report = baseReport();
+  report.results = report.results.filter((result) => result.fixtureId !== "obvious-bug");
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("tier1-missed:obvious-bug"));
+});
+
+test("noise above the criteria threshold fails", () => {
+  const report = baseReport();
+  report.aggregates.meanNoisePerPositive = 0.51;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["noise-threshold-exceeded:0.51>0.5"]);
+});
+
+test("required fixture aggregate recall must equal one", () => {
+  const report = baseReport();
+  report.aggregates.recallByFixture["required-bug"] = 0.5;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["fixture-recall-missed:required-bug"]);
+});
+
+test("missing required fixture aggregate fails", () => {
+  const report = baseReport();
+  delete report.aggregates.recallByFixture["required-bug"];
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["fixture-recall-missed:required-bug"]);
+});
+
+test("malformed report is an ordinary closed failure", () => {
+  const result = run("{not-json", baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json, { pass: false, reasons: ["unreadable-report"], promptHash: "", fixtureSetHash: "" });
+});
+
+test("missing report metrics fail closed without crashing", () => {
+  const report = baseReport();
+  delete report.aggregates.cheatDetectedCount;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+});
+
+test("malformed criteria fails closed", () => {
+  const criteria = baseCriteria();
+  criteria.fixtures = [];
+  const result = run(baseReport(), criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["unreadable-criteria"]);
+});
+
+test("duplicate fixture criteria remain readable", () => {
+  const criteria = baseCriteria();
+  criteria.fixtures = ["required-bug", "required-bug"];
+  const result = run(baseReport(), criteria);
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("negative finite noise threshold evaluates normally", () => {
+  const criteria = baseCriteria();
+  criteria.maxMeanNoisePerPositive = -1;
+  const result = run(baseReport(), criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["noise-threshold-exceeded:0.25>-1"]);
+});
+
+test("bad invocation is the operational error exit", () => {
+  const result = spawnSync(process.execPath, [script.pathname], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^usage:/);
+  assert.equal(result.stdout, "");
+});

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -126,6 +126,20 @@ test("overlapping tier-1 and criteria fixture emits one missing-draws reason", (
   assert.equal(result.json.reasons.filter((reason) => reason === "missing-draws:obvious-bug").length, 1);
 });
 
+test("resume-shaped reports require draws for every fixture tier entry", () => {
+  const report = baseReport();
+  report.results = [
+    { fixtureId: "resume-first", draw: 0, score: { recall: true } },
+  ];
+  report.aggregates.recallByFixture = { "resume-first": 1 };
+  report.fixtureTiers = { "resume-first": 2, "resume-second": 2 };
+  const criteria = baseCriteria();
+  criteria.fixtures = ["resume-first"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["missing-draws:resume-second"]);
+});
+
 test("noise above the criteria threshold fails", () => {
   const report = baseReport();
   report.aggregates.meanNoisePerPositive = 0.51;

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 const script = new URL("./gate-verdict.mjs", import.meta.url);
 
@@ -11,6 +12,7 @@ function baseReport() {
   return {
     promptHash: "prompt-123",
     fixtureSetHash: "fixtures-456",
+    draws: 1,
     results: [
       { fixtureId: "obvious-bug", score: { recall: true } },
       { fixtureId: "required-bug", score: { recall: true } },
@@ -56,18 +58,49 @@ test("nonzero honeypot count voids the report", () => {
 
 test("a failed tier-1 draw fails the whole report", () => {
   const report = baseReport();
-  report.results.push({ fixtureId: "obvious-bug", score: { recall: false } });
+  report.results[0].score.recall = false;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
   assert.ok(result.json.reasons.includes("tier1-missed:obvious-bug"));
 });
 
-test("a tier-1 fixture with no draw fails closed", () => {
+test("an incomplete tier-1 fixture fails for missing draws only", () => {
   const report = baseReport();
+  report.draws = 3;
   report.results = report.results.filter((result) => result.fixtureId !== "obvious-bug");
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
-  assert.ok(result.json.reasons.includes("tier1-missed:obvious-bug"));
+  assert.ok(result.json.reasons.includes("missing-draws:obvious-bug"));
+  assert.ok(!result.json.reasons.includes("tier1-missed:obvious-bug"));
+});
+
+test("a tier-1 fixture with fewer draws than declared fails for missing draws", () => {
+  const report = baseReport();
+  report.draws = 3;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("missing-draws:obvious-bug"));
+  assert.ok(!result.json.reasons.includes("tier1-missed:obvious-bug"));
+});
+
+test("an incomplete criteria fixture fails for missing draws only", () => {
+  const report = baseReport();
+  report.draws = 2;
+  report.aggregates.recallByFixture["required-bug"] = 0.5;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("missing-draws:required-bug"));
+  assert.ok(!result.json.reasons.includes("fixture-recall-missed:required-bug"));
+});
+
+test("overlapping tier-1 and criteria fixture emits one missing-draws reason", () => {
+  const report = baseReport();
+  report.draws = 2;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["obvious-bug"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.equal(result.json.reasons.filter((reason) => reason === "missing-draws:obvious-bug").length, 1);
 });
 
 test("noise above the criteria threshold fails", () => {
@@ -108,6 +141,16 @@ test("missing report metrics fail closed without crashing", () => {
   assert.deepEqual(result.json.reasons, ["unreadable-report"]);
 });
 
+test("draws must be a positive integer", () => {
+  for (const draws of [0, 1.5]) {
+    const report = baseReport();
+    report.draws = draws;
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+  }
+});
+
 test("malformed criteria fails closed", () => {
   const criteria = baseCriteria();
   criteria.fixtures = [];
@@ -134,6 +177,17 @@ test("negative finite noise threshold evaluates normally", () => {
 
 test("bad invocation is the operational error exit", () => {
   const result = spawnSync(process.execPath, [script.pathname], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^usage:/);
+  assert.equal(result.stdout, "");
+});
+
+test("entrypoint runs from a path containing a space", () => {
+  const dir = mkdtempSync(join(process.cwd(), ".needlefish gate "));
+  const copiedScript = join(dir, "gate verdict.mjs");
+  copyFileSync(fileURLToPath(script), copiedScript);
+  const result = spawnSync(process.execPath, [copiedScript], { encoding: "utf8" });
+  rmSync(dir, { recursive: true, force: true });
   assert.equal(result.status, 2);
   assert.match(result.stderr, /^usage:/);
   assert.equal(result.stdout, "");

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -12,6 +12,7 @@ function baseReport() {
   return {
     promptHash: "prompt-123",
     fixtureSetHash: "fixtures-456",
+    fixtures: ["obvious-bug", "required-bug"],
     draws: 1,
     results: [
       { fixtureId: "obvious-bug", draw: 0, score: { recall: true } },
@@ -45,6 +46,67 @@ test("passes and echoes report hashes", () => {
   const result = run(baseReport(), baseCriteria());
   assert.equal(result.status, 0);
   assert.deepEqual(result.json, { pass: true, reasons: [], promptHash: "prompt-123", fixtureSetHash: "fixtures-456" });
+});
+
+test("a report without a fixture manifest is unreadable", () => {
+  const report = baseReport();
+  delete report.fixtures;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+});
+
+test("an old real report without a fixture manifest is unreadable", () => {
+  const report = readFileSync(new URL("../eval/results/2026-07-10-realpr-full-gpt-5.5.json", import.meta.url), "utf8");
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+});
+
+test("fixture manifests require unique non-empty strings", () => {
+  for (const fixtures of [[], ["obvious-bug", ""], ["obvious-bug", "obvious-bug"]]) {
+    const report = baseReport();
+    report.fixtures = fixtures;
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+  }
+});
+
+test("fixture tier and aggregate keys must exist in the manifest", () => {
+  for (const field of ["fixtureTiers", "recallByFixture"]) {
+    const report = baseReport();
+    const target = field === "fixtureTiers" ? report.fixtureTiers : report.aggregates.recallByFixture;
+    target["outside-manifest"] = field === "fixtureTiers" ? 2 : 1;
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+  }
+});
+
+test("a criteria fixture absent from the manifest emits only fixture-not-in-run", () => {
+  const criteria = baseCriteria();
+  criteria.fixtures = ["not-run"];
+  const result = run(baseReport(), criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["fixture-not-in-run:not-run"]);
+});
+
+test("a manifest fixture absent from results fails for missing draws", () => {
+  const report = baseReport();
+  report.fixtures.push("negative-honeypot");
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["missing-draws:negative-honeypot"]);
+});
+
+test("a manifest-complete report passes", () => {
+  const report = baseReport();
+  report.fixtures.push("negative-honeypot");
+  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: { recall: true } });
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
 });
 
 test("nonzero honeypot count voids the report", () => {
@@ -133,6 +195,7 @@ test("resume-shaped reports require draws for every fixture tier entry", () => {
   ];
   report.aggregates.recallByFixture = { "resume-first": 1 };
   report.fixtureTiers = { "resume-first": 2, "resume-second": 2 };
+  report.fixtures = ["resume-first", "resume-second"];
   const criteria = baseCriteria();
   criteria.fixtures = ["resume-first"];
   const result = run(report, criteria);

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -100,6 +100,17 @@ test("fixture kinds must exactly cover the manifest with non-empty strings", () 
   }
 });
 
+test("fixture kinds reject values outside the declared union", () => {
+  const report = baseReport();
+  report.fixtures.push("typo-kind");
+  report.fixtureKinds["typo-kind"] = "negativ";
+  report.results.push({ fixtureId: "typo-kind", draw: 0, score: { recall: true } });
+  report.aggregates.recallByFixture["typo-kind"] = 1;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+});
+
 test("positive fixture kinds and fixture tiers require identical keys", () => {
   for (const mutate of [
     (report) => { delete report.fixtureTiers["required-bug"]; },


### PR DESCRIPTION
## What

Two machine-gate CLI scripts for the autonomous improvement loop (S1/S3 in plans/autonomous-workflow.md):

- `scripts/brief-lint.mjs` — validates a dispatch brief before any work starts: exactly one `gateCriteria` JSON block with numeric acceptance criteria, every referenced fixture exists under `eval/fixtures*/`, and no sealed holdout fixture is named anywhere in the brief (failure reports only a character offset, never the leaked name). `--emit-criteria` writes the parsed criteria for the gate step.
- `scripts/gate-verdict.mjs` — converts an eval report JSON + criteria into a single machine verdict: honeypot `cheatDetectedCount > 0` voids the run before anything else; zero tier-1 misses across all draws; `meanNoisePerPositive` ceiling; per-fixture recall; echoes `promptHash`/`fixtureSetHash`. Unreadable report or criteria fails closed.

Both output single-line JSON, exit 0 only on pass, and use Node built-ins only (no new dependencies).

## Why

Gate verdicts should be script-produced, never model-authored prose. These make the workflow's brief lint (S1) and eval gate (S3) executable.

## Verification

- `pnpm check` and `pnpm test` exit 0 after the final commit (rerun by a non-author context).
- Live branch checks: holdout-leak brief rejected without echoing the name; unknown fixture rejected; real report (`eval/results/tune-2-sol-full.json`) evaluated fail-closed with hashes echoed.
- Mutation check: disabling the honeypot branch turns the test suite red; restored, green.