### PR TITLE
Review methodology v2 Phase 1: red-reason contract, round comments, coverage line

### DIFF
--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -48,6 +48,10 @@ type FixtureOptions = {
 	// Make POSTs to the check-runs endpoint exit 1 (after logging the attempt)
 	// to exercise independence of the failure check and the error comment.
 	readonly failCheckRunPosts?: boolean;
+	// Login the stub reports for `gh api user` AND stamps on posted issue
+	// comments — set to a plain user login to simulate a PAT-authenticated
+	// runner. Defaults to a bot-shaped login.
+	readonly authorLogin?: string;
 };
 
 function isPost(raw: unknown): raw is Post {
@@ -215,7 +219,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"    const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
 			"    const parsed = JSON.parse(payload);",
 			"    const nextId = issueComments.length + 1;",
-			"    issueComments.push({ id: nextId, node_id: 'IC_node_' + nextId, body: parsed.body || '', user: { login: 'github-actions[bot]' } });",
+			`    issueComments.push({ id: nextId, node_id: 'IC_node_' + nextId, body: parsed.body || '', user: { login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} } });`,
 			"    fs.writeFileSync(issueCommentsPath, JSON.stringify(issueComments));",
 			"  }",
 			"  process.stdout.write('{}');",
@@ -256,6 +260,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  process.stdout.write(JSON.stringify(issueComments));",
 			"  process.exit(0);",
 			"}",
+			`if (args[1] === 'user') { process.stdout.write(JSON.stringify({ login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} })); process.exit(0); }`,
 			"if (args[1] === 'graphql') {",
 			`  fs.appendFileSync(${JSON.stringify(postLog)}, JSON.stringify({ args, payload: '' }) + '\\n');`,
 			"  process.stdout.write('{}');",
@@ -1074,6 +1079,38 @@ test("runGithub posts a re-review round comment with counts on the second round"
 	assert.match(
 		String(checkPayload.output?.title ?? ""),
 		/^Needlefish: changes_requested — persisting/,
+	);
+});
+
+test("round comments posted under a PAT login are still minimized", async (t) => {
+	// Self-hosted runners authenticate gh with a PAT: round comments are
+	// authored by a plain user login, not a bot-shaped one. They must still
+	// be recognized as ours (via `gh api user`) and minimized on later rounds.
+	const fixture = setupFixture(t, {
+		prNumber: 46,
+		authorLogin: "frank-pat",
+		rawReview: JSON.stringify({
+			summary: "one finding",
+			findings: [mkFinding({ title: "persisting", lineStart: 1 })],
+			checked: ["checked"],
+			residual_risks: [],
+		}),
+	});
+
+	await runGithub(fixture.repo, 46, { timeoutMs: 1000 });
+	await runGithub(fixture.repo, 46, { timeoutMs: 1000 }, true);
+	const beforeRound3 = readPosts(fixture.postLog).length;
+
+	await runGithub(fixture.repo, 46, { timeoutMs: 1000 }, true);
+	const round3Posts = readPosts(fixture.postLog).slice(beforeRound3);
+	const minimized = round3Posts.some(
+		(p) =>
+			p.args.some((a) => a.includes("minimizeComment")) &&
+			p.args.some((a) => a === "id=IC_node_1"),
+	);
+	assert.ok(
+		minimized,
+		"round 3 must minimize the PAT-authored round-2 comment",
 	);
 });
 

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -45,6 +45,9 @@ type FixtureOptions = {
 	// Make POSTs to the issue-comments endpoint exit 1 (after logging the
 	// attempt) to exercise the fail-soft paths around cosmetic comments.
 	readonly failIssueCommentPosts?: boolean;
+	// Make POSTs to the check-runs endpoint exit 1 (after logging the attempt)
+	// to exercise independence of the failure check and the error comment.
+	readonly failCheckRunPosts?: boolean;
 };
 
 function isPost(raw: unknown): raw is Post {
@@ -206,6 +209,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  }",
 			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
 			`  const issueCommentsEndpoint = ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)};`,
+			`  if (apiPath === 'repos/frankekn/needlefish/check-runs' && method === 'POST' && ${JSON.stringify(opts.failCheckRunPosts === true)} === true) { process.stderr.write('simulated check POST failure'); process.exit(1); }`,
 			"  if (apiPath === issueCommentsEndpoint && method === 'POST') {",
 			`    if (${JSON.stringify(opts.failIssueCommentPosts === true)} === true) { process.stderr.write('simulated comment POST failure'); process.exit(1); }`,
 			"    const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
@@ -943,6 +947,31 @@ test("runGithub posts a FAILED TO RUN PR comment when the review errors", async 
 	);
 	assert.match(body, /FAILED TO RUN/);
 	assert.match(body, /<!-- needlefish-error -->/);
+});
+
+test("a failing check-run POST does not suppress the FAILED TO RUN comment", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 44,
+		rawReview: "definitely not json",
+		failCheckRunPosts: true,
+	});
+	await runGithub(fixture.repo, 44, { timeoutMs: 1000 });
+	const posts = readPosts(fixture.postLog);
+	const issueCommentPost = posts.find(
+		(p) =>
+			p.args.includes("POST") &&
+			p.args.some((a) => a === "repos/frankekn/needlefish/issues/44/comments"),
+	);
+	assert.ok(
+		issueCommentPost,
+		"error comment must post even when the check-run POST fails",
+	);
+	const body = String(
+		(parseJson(issueCommentPost.payload) as { body?: unknown }).body ?? "",
+	);
+	assert.match(body, /FAILED TO RUN/);
+	assert.equal(process.exitCode, 1, "exit code must still be set");
+	process.exitCode = undefined;
 });
 
 // --- S5 invariant: re-review posts a round comment ---

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -127,6 +127,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 	const claude = path.join(fakeBin, "claude");
 	const postLog = path.join(tmp, "posts.jsonl");
 	const reviewsState = path.join(tmp, "reviews-state.json");
+	const issueCommentsState = path.join(tmp, "issue-comments-state.json");
 	const previous = {
 		path: process.env.PATH,
 		repository: process.env.GITHUB_REPOSITORY,
@@ -200,6 +201,15 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"    if (review) review.body = parsed.body || '';",
 			"    fs.writeFileSync(reviewsPath, JSON.stringify(reviews));",
 			"  }",
+			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
+			`  const issueCommentsEndpoint = ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)};`,
+			"  if (apiPath === issueCommentsEndpoint && method === 'POST') {",
+			"    const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
+			"    const parsed = JSON.parse(payload);",
+			"    const nextId = issueComments.length + 1;",
+			"    issueComments.push({ id: nextId, node_id: 'IC_node_' + nextId, body: parsed.body || '', user: { login: 'github-actions[bot]' } });",
+			"    fs.writeFileSync(issueCommentsPath, JSON.stringify(issueComments));",
+			"  }",
 			"  process.stdout.write('{}');",
 			"  process.exit(0);",
 			"}",
@@ -224,6 +234,13 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  process.exit(0);",
 			"}",
 			"if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
+		`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)}) {`,
+		`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
+		"  const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
+		"  process.stdout.write(JSON.stringify(issueComments));",
+		"  process.exit(0);",
+		"}",
+		"if (args[1] === 'graphql') { process.stdout.write('{}'); process.exit(0); }",
 			"process.stderr.write(`unexpected gh args ${args.join(' ')}`);",
 			"process.exit(2);",
 		].join("\n"),
@@ -887,4 +904,79 @@ test("runGithub re-reviews same head when recheck is true", async (t) => {
 		putPost,
 		"round 2 with --recheck should still review and PUT-update",
 	);
+});
+
+// --- S5 invariant: error path posts a PR comment ---
+
+test("runGithub posts a FAILED TO RUN PR comment when the review errors", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 40,
+		rawReview: "definitely not json",
+	});
+
+	await runGithub(fixture.repo, 40, { timeoutMs: 1000 });
+
+	const issueCommentPost = readPosts(fixture.postLog).find(
+		(p) =>
+			p.args.includes("POST") &&
+			p.args.some(
+				(a) => a === "repos/frankekn/needlefish/issues/40/comments",
+			),
+	);
+	assert.ok(issueCommentPost, "error path should post an issue comment");
+	const body = String((parseJson(issueCommentPost.payload) as { body?: unknown }).body ?? "");
+	assert.match(body, /FAILED TO RUN/);
+	assert.match(body, /<!-- needlefish-error -->/);
+});
+
+// --- S5 invariant: re-review posts a round comment ---
+
+test("runGithub posts a re-review round comment with counts on the second round", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 41,
+		rawReview: JSON.stringify({
+			summary: "two findings",
+			findings: [
+				mkFinding({ title: "persisting", lineStart: 1 }),
+				mkFinding({ title: "to-be-fixed", lineStart: 1 }),
+			],
+			checked: ["checked"],
+			residual_risks: [],
+		}),
+	});
+
+	await runGithub(fixture.repo, 41, { timeoutMs: 1000 });
+	const round1Count = readPosts(fixture.postLog).length;
+
+	writeFileSync(
+		fixture.reviewOutput,
+		JSON.stringify({
+			summary: "one fixed and one new",
+			findings: [
+				mkFinding({ title: "persisting", lineStart: 1 }),
+				mkFinding({ title: "new issue", lineStart: 1 }),
+			],
+			checked: ["checked"],
+			residual_risks: [],
+		}),
+	);
+
+	await runGithub(fixture.repo, 41, { timeoutMs: 1000 }, true);
+	const round2Posts = readPosts(fixture.postLog).slice(round1Count);
+
+	const roundCommentPost = round2Posts.find(
+		(p) =>
+			p.args.includes("POST") &&
+			p.args.some(
+				(a) => a === "repos/frankekn/needlefish/issues/41/comments",
+			),
+	);
+	assert.ok(roundCommentPost, "re-review should post a round comment");
+	const body = String((parseJson(roundCommentPost.payload) as { body?: unknown }).body ?? "");
+	assert.match(body, /Needlefish re-review/);
+	// 1 resolved (to-be-fixed), 1 still open (persisting), 1 new (new issue).
+	assert.match(body, /✅ 1 resolved/);
+	assert.match(body, /❌ 1 still open/);
+	assert.match(body, /🆕 1 new/);
+	assert.match(body, /<!-- needlefish-round -->/);
 });

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -42,6 +42,9 @@ type FixtureOptions = {
 	readonly prNumber: number;
 	readonly rawReview: string;
 	readonly staleHeadAfterReview?: boolean;
+	// Make POSTs to the issue-comments endpoint exit 1 (after logging the
+	// attempt) to exercise the fail-soft paths around cosmetic comments.
+	readonly failIssueCommentPosts?: boolean;
 };
 
 function isPost(raw: unknown): raw is Post {
@@ -204,6 +207,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
 			`  const issueCommentsEndpoint = ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)};`,
 			"  if (apiPath === issueCommentsEndpoint && method === 'POST') {",
+			`    if (${JSON.stringify(opts.failIssueCommentPosts === true)} === true) { process.stderr.write('simulated comment POST failure'); process.exit(1); }`,
 			"    const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
 			"    const parsed = JSON.parse(payload);",
 			"    const nextId = issueComments.length + 1;",
@@ -234,7 +238,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  process.exit(0);",
 			"}",
 			"if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
-			`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)}) {`,
+			`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)} || (args[1] === '--paginate' && args[2] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)})) {`,
 			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
 			"  const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
 			"  process.stdout.write(JSON.stringify(issueComments));",
@@ -1019,4 +1023,52 @@ test("runGithub posts a re-review round comment with counts on the second round"
 		minimizeIdx < roundCommentIdx,
 		"minimize must run before the new round comment is posted",
 	);
+
+	// Check-run title carries the red reason (top blocking finding title).
+	const checkPost = round3Posts.find(
+		(p) =>
+			p.args.includes("POST") &&
+			p.args.some((a) => a === "repos/frankekn/needlefish/check-runs"),
+	);
+	assert.ok(checkPost, "round 3 should post a check run");
+	const checkPayload = parseJson(checkPost.payload) as {
+		output?: { title?: unknown };
+	};
+	assert.match(
+		String(checkPayload.output?.title ?? ""),
+		/^Needlefish: changes_requested — persisting/,
+	);
+});
+
+test("a failing round-comment POST does not replace the verdict check with a failure", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 43,
+		rawReview: JSON.stringify({
+			summary: "clean",
+			findings: [],
+			checked: ["checked"],
+			residual_risks: [],
+		}),
+		failIssueCommentPosts: true,
+	});
+
+	await runGithub(fixture.repo, 43, { timeoutMs: 1000 });
+	const round1Count = readPosts(fixture.postLog).length;
+	await runGithub(fixture.repo, 43, { timeoutMs: 1000 }, true);
+	const round2Posts = readPosts(fixture.postLog).slice(round1Count);
+
+	const checkPosts = round2Posts.filter(
+		(p) =>
+			p.args.includes("POST") &&
+			p.args.some((a) => a === "repos/frankekn/needlefish/check-runs"),
+	);
+	assert.equal(checkPosts.length, 1, "exactly one check run posted");
+	const payload = parseJson(checkPosts[0].payload) as {
+		conclusion?: unknown;
+		output?: { title?: unknown };
+	};
+	// The cosmetic comment failed, but the computed verdict must survive:
+	// success conclusion, not a red "review failed" check.
+	assert.equal(payload.conclusion, "success");
+	assert.doesNotMatch(String(payload.output?.title ?? ""), /review failed/);
 });

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -234,13 +234,17 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  process.exit(0);",
 			"}",
 			"if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
-		`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)}) {`,
-		`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
-		"  const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
-		"  process.stdout.write(JSON.stringify(issueComments));",
-		"  process.exit(0);",
-		"}",
-		"if (args[1] === 'graphql') { process.stdout.write('{}'); process.exit(0); }",
+			`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)}) {`,
+			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
+			"  const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
+			"  process.stdout.write(JSON.stringify(issueComments));",
+			"  process.exit(0);",
+			"}",
+			"if (args[1] === 'graphql') {",
+			`  fs.appendFileSync(${JSON.stringify(postLog)}, JSON.stringify({ args, payload: '' }) + '\\n');`,
+			"  process.stdout.write('{}');",
+			"  process.exit(0);",
+			"}",
 			"process.stderr.write(`unexpected gh args ${args.join(' ')}`);",
 			"process.exit(2);",
 		].join("\n"),
@@ -919,12 +923,12 @@ test("runGithub posts a FAILED TO RUN PR comment when the review errors", async 
 	const issueCommentPost = readPosts(fixture.postLog).find(
 		(p) =>
 			p.args.includes("POST") &&
-			p.args.some(
-				(a) => a === "repos/frankekn/needlefish/issues/40/comments",
-			),
+			p.args.some((a) => a === "repos/frankekn/needlefish/issues/40/comments"),
 	);
 	assert.ok(issueCommentPost, "error path should post an issue comment");
-	const body = String((parseJson(issueCommentPost.payload) as { body?: unknown }).body ?? "");
+	const body = String(
+		(parseJson(issueCommentPost.payload) as { body?: unknown }).body ?? "",
+	);
 	assert.match(body, /FAILED TO RUN/);
 	assert.match(body, /<!-- needlefish-error -->/);
 });
@@ -967,16 +971,52 @@ test("runGithub posts a re-review round comment with counts on the second round"
 	const roundCommentPost = round2Posts.find(
 		(p) =>
 			p.args.includes("POST") &&
-			p.args.some(
-				(a) => a === "repos/frankekn/needlefish/issues/41/comments",
-			),
+			p.args.some((a) => a === "repos/frankekn/needlefish/issues/41/comments"),
 	);
 	assert.ok(roundCommentPost, "re-review should post a round comment");
-	const body = String((parseJson(roundCommentPost.payload) as { body?: unknown }).body ?? "");
+	const body = String(
+		(parseJson(roundCommentPost.payload) as { body?: unknown }).body ?? "",
+	);
 	assert.match(body, /Needlefish re-review/);
 	// 1 resolved (to-be-fixed), 1 still open (persisting), 1 new (new issue).
 	assert.match(body, /✅ 1 resolved/);
 	assert.match(body, /❌ 1 still open/);
 	assert.match(body, /🆕 1 new/);
 	assert.match(body, /<!-- needlefish-round -->/);
+
+	// Round 2 had no prior round comment, so nothing may be minimized — a
+	// minimize call here means the round swept up its own fresh comment.
+	const round2Minimize = round2Posts.filter((p) =>
+		p.args.some((a) => a.includes("minimizeComment")),
+	);
+	assert.equal(round2Minimize.length, 0, "round 2 must not minimize anything");
+
+	// Round 3: the round-2 comment (IC_node_1) must be minimized, and the
+	// minimize must happen BEFORE this round's comment is posted (posting
+	// first would minimize the fresh comment on the next round's scan).
+	await runGithub(fixture.repo, 41, { timeoutMs: 1000 }, true);
+	const round3Posts = readPosts(fixture.postLog).slice(
+		round1Count + round2Posts.length,
+	);
+	const minimizeIdx = round3Posts.findIndex(
+		(p) =>
+			p.args.some((a) => a.includes("minimizeComment")) &&
+			p.args.some((a) => a === "id=IC_node_1"),
+	);
+	const roundCommentIdx = round3Posts.findIndex(
+		(p) =>
+			p.args.includes("POST") &&
+			p.args.some(
+				(a) => a === "repos/frankekn/needlefish/issues/41/comments",
+			) &&
+			String(
+				(parseJson(p.payload) as { body?: unknown }).body ?? "",
+			).includes("<!-- needlefish-round -->"),
+	);
+	assert.ok(minimizeIdx >= 0, "round 3 should minimize the round-2 comment");
+	assert.ok(roundCommentIdx >= 0, "round 3 should post a round comment");
+	assert.ok(
+		minimizeIdx < roundCommentIdx,
+		"minimize must run before the new round comment is posted",
+	);
 });

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -238,7 +238,15 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  process.exit(0);",
 			"}",
 			"if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
-			`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)} || (args[1] === '--paginate' && args[2] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)})) {`,
+			// Paginated GET must come with --slurp (page-wrapped array of arrays);
+			// the stub emulates the slurped shape to pin the flat(1) handling.
+			`if (args[1] === '--paginate' && args[2] === '--slurp' && args[3] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)}) {`,
+			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
+			"  const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
+			"  process.stdout.write(JSON.stringify([issueComments]));",
+			"  process.exit(0);",
+			"}",
+			`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)}) {`,
 			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
 			"  const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
 			"  process.stdout.write(JSON.stringify(issueComments));",

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -435,6 +435,151 @@ function postCheck(
 	);
 }
 
+const SEV_RANK: Record<Finding["severity"], number> = {
+	P0: 0,
+	P1: 1,
+	P2: 2,
+	P3: 3,
+};
+
+const VERDICT_HEADLINE_WORD: Record<Verdict, string> = {
+	pass: "LGTM",
+	changes_requested: "CHANGES REQUESTED",
+	needs_human: "NEEDS HUMAN",
+};
+
+function oneLine(text: string): string {
+	return text.replace(/\s*\r?\n\s*/g, " ");
+}
+
+function truncateLine(text: string, max: number): string {
+	return text.length > max ? text.slice(0, max) : text;
+}
+
+function sortBySeverity(findings: readonly Finding[]): Finding[] {
+	return [...findings].sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity]);
+}
+
+function topBlockingFinding(
+	findings: readonly Finding[],
+): Finding | undefined {
+	return sortBySeverity(findings).find((f) => f.severity !== "P3");
+}
+
+function firstBlockingResidual(
+	result: ReviewResult,
+): string | undefined {
+	return result.residualRisks.find((r) => r.blocks)?.text;
+}
+
+// Check-run title carries the reason on red verdicts: the top blocking finding
+// title (changes_requested) or the first blocking residual (needs_human).
+// pass keeps the plain `Needlefish: pass` title.
+function checkRunTitle(result: ReviewResult): string {
+	const base = `Needlefish: ${result.verdict}`;
+	if (result.verdict === "changes_requested") {
+		const top = topBlockingFinding(result.findings);
+		if (top) return truncateLine(`${base} — ${oneLine(top.title)}`, 120);
+	} else if (result.verdict === "needs_human") {
+		const text = firstBlockingResidual(result);
+		if (text) return truncateLine(`${base} — ${oneLine(text)}`, 120);
+	}
+	return base;
+}
+
+function postIssueComment(repo: string, prNumber: number, body: string): void {
+	ghJson(
+		[
+			"api",
+			"-X",
+			"POST",
+			`repos/${repo}/issues/${prNumber}/comments`,
+			"--input",
+			"-",
+		],
+		JSON.stringify({ body }),
+	);
+}
+
+// S3: infra-failure comment posted alongside the red check so a red X always
+// has something to read in the PR timeline. Fail-soft: never blocks the check.
+function postErrorComment(repo: string, prNumber: number, msg: string): void {
+	const body =
+		`⚠️ **Needlefish review FAILED TO RUN** — this red check is an infra failure, not a code verdict.\n\n` +
+		"```\n" +
+		`${msg.slice(0, 2000)}\n` +
+		"```\n\n" +
+		"Re-trigger: push a new commit or re-run with --recheck.\n" +
+		"<!-- needlefish-error -->";
+	try {
+		postIssueComment(repo, prNumber, body);
+	} catch (commentErr) {
+		const cm = commentErr instanceof Error ? commentErr.message : String(commentErr);
+		process.stderr.write(`needlefish: could not post error comment: ${cm}\n`);
+	}
+}
+
+// S4.1: round comment notifies the PR timeline on re-review (GitHub does not
+// notify on review-body edits). Rendered from the full result so the reason
+// line stays in sync with the review body's S1 first line.
+function buildRoundCommentBody(
+	result: ReviewResult,
+	headSha: string,
+	resolvedCount: number,
+	open: readonly Finding[],
+	newCount: number,
+): string {
+	const lines: string[] = [];
+	lines.push(
+		`**Needlefish re-review** @ ${headSha.slice(0, 7)} — ✅ ${resolvedCount} resolved · ❌ ${open.length} still open · 🆕 ${newCount} new → ${VERDICT_HEADLINE_WORD[result.verdict]}`,
+	);
+	if (open.length > 0) {
+		const top = sortBySeverity(open)[0];
+		const loc = top.file ? ` (${top.file}:${top.lineStart})` : "";
+		lines.push(`Top open: ${top.severity} ${truncateLine(oneLine(top.title), 120)}${loc}`);
+	}
+	if (result.verdict !== "pass") {
+		lines.push(renderMarkdown(result).split("\n")[0]);
+	}
+	lines.push("<!-- needlefish-round -->");
+	return lines.join("\n");
+}
+
+function postRoundComment(
+	repo: string,
+	prNumber: number,
+	body: string,
+): void {
+	postIssueComment(repo, prNumber, body);
+}
+
+function isBotAuthor(item: JsonRecord): boolean {
+	const login = nestedString(item, "user", "login");
+	return login.includes("github-actions") || /\[bot\]$/.test(login);
+}
+
+// S4.2: minimize prior round comments (classifier OUTDATED) so the timeline
+// surfaces only the latest round. Fail-soft: a minimize failure never fails
+// the review.
+function minimizePreviousRoundComments(
+	repo: string,
+	prNumber: number,
+): void {
+	const raw = ghJson(["api", `repos/${repo}/issues/${prNumber}/comments`]);
+	if (!Array.isArray(raw)) return;
+	for (const item of raw) {
+		if (!isRecord(item)) continue;
+		const body = stringField(item, "body");
+		if (!body.includes("<!-- needlefish-round -->")) continue;
+		if (!isBotAuthor(item)) continue;
+		const nodeId = stringField(item, "node_id");
+		if (!nodeId) continue;
+		const query =
+			`mutation { minimizeComment(input: {subjectId: "${nodeId}", classifier: OUTDATED}) { minimizedComment { isMinimized } } }`;
+		ghJson(["api", "graphql", "-f", `query=${query}`]);
+	}
+}
+
 function isCurrentOpenHead(
 	repo: string,
 	prNumber: number,
@@ -562,6 +707,25 @@ export async function runGithub(
 				stateMarker: renderState(headSha, result.findings),
 			});
 			updateReviewBody(repo, prNumber, prev.id, body);
+			// S4: notify the timeline (body edits don't notify), then minimize
+			// prior round comments so the latest round is what surfaces.
+			postRoundComment(
+				repo,
+				prNumber,
+				buildRoundCommentBody(
+					result,
+					headSha,
+					resolvedCount,
+					open,
+					renderOpts.newCount,
+				),
+			);
+			try {
+				minimizePreviousRoundComments(repo, prNumber);
+			} catch (minErr) {
+				const mm = minErr instanceof Error ? minErr.message : String(minErr);
+				process.stderr.write(`needlefish: could not minimize previous round comments: ${mm}\n`);
+			}
 			if (freshComments.length > 0) {
 				postReview(repo, prNumber, headSha, "", freshComments);
 			}
@@ -572,7 +736,7 @@ export async function runGithub(
 				headSha,
 				result,
 				conclusion,
-				`Needlefish: ${result.verdict}`,
+				checkRunTitle(result),
 				summary,
 			);
 			process.stdout.write(summary);
@@ -597,7 +761,7 @@ export async function runGithub(
 				headSha,
 				result,
 				conclusion,
-				`Needlefish: ${result.verdict}`,
+				checkRunTitle(result),
 				summary,
 			);
 			process.stdout.write(summary);
@@ -613,6 +777,8 @@ export async function runGithub(
 				"Needlefish: review failed",
 				`Review errored and did NOT pass this PR.\n\n\`\`\`\n${msg.slice(0, 4000)}\n\`\`\``,
 			);
+			// S3: post a PR comment so a red X always has something to read.
+			postErrorComment(repo, prNumber, msg);
 		}
 		process.stderr.write(`needlefish review failed: ${msg}\n`);
 		process.exitCode = 1;

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -565,7 +565,11 @@ function minimizePreviousRoundComments(
 	repo: string,
 	prNumber: number,
 ): void {
-	const raw = ghJson(["api", `repos/${repo}/issues/${prNumber}/comments`]);
+	const raw = ghJson([
+		"api",
+		"--paginate",
+		`repos/${repo}/issues/${prNumber}/comments`,
+	]);
 	if (!Array.isArray(raw)) return;
 	for (const item of raw) {
 		if (!isRecord(item)) continue;
@@ -716,17 +720,27 @@ export async function runGithub(
 				const mm = minErr instanceof Error ? minErr.message : String(minErr);
 				process.stderr.write(`needlefish: could not minimize previous round comments: ${mm}\n`);
 			}
-			postRoundComment(
-				repo,
-				prNumber,
-				buildRoundCommentBody(
-					result,
-					headSha,
-					resolvedCount,
-					open,
-					renderOpts.newCount,
-				),
-			);
+			// Fail-soft: the round comment is cosmetic; a transient POST failure
+			// must not throw to the outer catch, which would replace a computed
+			// verdict check-run with a red "review failed" one.
+			try {
+				postRoundComment(
+					repo,
+					prNumber,
+					buildRoundCommentBody(
+						result,
+						headSha,
+						resolvedCount,
+						open,
+						renderOpts.newCount,
+					),
+				);
+			} catch (roundErr) {
+				const rm = roundErr instanceof Error ? roundErr.message : String(roundErr);
+				process.stderr.write(
+					`needlefish: could not post round comment: ${rm}\n`,
+				);
+			}
 			if (freshComments.length > 0) {
 				postReview(repo, prNumber, headSha, "", freshComments);
 			}

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -575,8 +575,8 @@ function minimizePreviousRoundComments(
 		const nodeId = stringField(item, "node_id");
 		if (!nodeId) continue;
 		const query =
-			`mutation { minimizeComment(input: {subjectId: "${nodeId}", classifier: OUTDATED}) { minimizedComment { isMinimized } } }`;
-		ghJson(["api", "graphql", "-f", `query=${query}`]);
+			"mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }";
+		ghJson(["api", "graphql", "-f", `query=${query}`, "-f", `id=${nodeId}`]);
 	}
 }
 
@@ -707,8 +707,15 @@ export async function runGithub(
 				stateMarker: renderState(headSha, result.findings),
 			});
 			updateReviewBody(repo, prNumber, prev.id, body);
-			// S4: notify the timeline (body edits don't notify), then minimize
-			// prior round comments so the latest round is what surfaces.
+			// S4: minimize prior round comments FIRST, then post this round's
+			// comment (body edits don't notify). Minimizing after posting would
+			// sweep up the fresh comment too — it carries the same marker.
+			try {
+				minimizePreviousRoundComments(repo, prNumber);
+			} catch (minErr) {
+				const mm = minErr instanceof Error ? minErr.message : String(minErr);
+				process.stderr.write(`needlefish: could not minimize previous round comments: ${mm}\n`);
+			}
 			postRoundComment(
 				repo,
 				prNumber,
@@ -720,12 +727,6 @@ export async function runGithub(
 					renderOpts.newCount,
 				),
 			);
-			try {
-				minimizePreviousRoundComments(repo, prNumber);
-			} catch (minErr) {
-				const mm = minErr instanceof Error ? minErr.message : String(minErr);
-				process.stderr.write(`needlefish: could not minimize previous round comments: ${mm}\n`);
-			}
 			if (freshComments.length > 0) {
 				postReview(repo, prNumber, headSha, "", freshComments);
 			}

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -558,6 +558,18 @@ function isBotAuthor(item: JsonRecord): boolean {
 	return login.includes("github-actions") || /\[bot\]$/.test(login);
 }
 
+// Self-hosted runners often authenticate gh with a PAT, so Needlefish's own
+// round comments carry a plain user login rather than a bot-shaped one.
+// Fail-soft: an empty string just narrows recognition back to bot authors.
+function authenticatedLogin(): string {
+	try {
+		const user = ghJson(["api", "user"]);
+		return isRecord(user) ? stringField(user, "login") : "";
+	} catch {
+		return "";
+	}
+}
+
 // S4.2: minimize prior round comments (classifier OUTDATED) so the timeline
 // surfaces only the latest round. Fail-soft: a minimize failure never fails
 // the review.
@@ -574,13 +586,17 @@ function minimizePreviousRoundComments(
 		`repos/${repo}/issues/${prNumber}/comments`,
 	]);
 	if (!Array.isArray(raw)) return;
+	const selfLogin = authenticatedLogin();
 	// Each element is a page (an array of comments); flat(1) also tolerates a
 	// plain comment list from stubs or older gh versions.
 	for (const item of raw.flat(1)) {
 		if (!isRecord(item)) continue;
 		const body = stringField(item, "body");
 		if (!body.includes("<!-- needlefish-round -->")) continue;
-		if (!isBotAuthor(item)) continue;
+		// Ours = bot-shaped author, or the identity this run posts as (PAT).
+		// The author check keeps humans quoting the marker from being swept.
+		const author = nestedString(item, "user", "login");
+		if (!isBotAuthor(item) && !(selfLogin && author === selfLogin)) continue;
 		const nodeId = stringField(item, "node_id");
 		if (!nodeId) continue;
 		const query =

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -565,13 +565,18 @@ function minimizePreviousRoundComments(
 	repo: string,
 	prNumber: number,
 ): void {
+	// --slurp: --paginate alone emits one JSON document PER PAGE (concatenated,
+	// unparseable); --slurp wraps the pages into a single outer array.
 	const raw = ghJson([
 		"api",
 		"--paginate",
+		"--slurp",
 		`repos/${repo}/issues/${prNumber}/comments`,
 	]);
 	if (!Array.isArray(raw)) return;
-	for (const item of raw) {
+	// Each element is a page (an array of comments); flat(1) also tolerates a
+	// plain comment list from stubs or older gh versions.
+	for (const item of raw.flat(1)) {
 		if (!isRecord(item)) continue;
 		const body = stringField(item, "body");
 		if (!body.includes("<!-- needlefish-round -->")) continue;

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -789,14 +789,25 @@ export async function runGithub(
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
 		if (isCurrentOpenHead(repo, prNumber, headSha)) {
-			postCheck(
-				repo,
-				headSha,
-				null,
-				"failure",
-				"Needlefish: review failed",
-				`Review errored and did NOT pass this PR.\n\n\`\`\`\n${msg.slice(0, 4000)}\n\`\`\``,
-			);
+			// Check run and error comment are independent fail-soft attempts: a
+			// failure of either GitHub endpoint must not suppress the other, nor
+			// the stderr line and exit code below.
+			try {
+				postCheck(
+					repo,
+					headSha,
+					null,
+					"failure",
+					"Needlefish: review failed",
+					`Review errored and did NOT pass this PR.\n\n\`\`\`\n${msg.slice(0, 4000)}\n\`\`\``,
+				);
+			} catch (checkErr) {
+				const cm =
+					checkErr instanceof Error ? checkErr.message : String(checkErr);
+				process.stderr.write(
+					`needlefish: could not post failure check: ${cm}\n`,
+				);
+			}
 			// S3: post a PR comment so a red X always has something to read.
 			postErrorComment(repo, prNumber, msg);
 		}

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -228,6 +228,81 @@ test("review keeps deep failure residuals after critic pruning", async (t) => {
 	);
 });
 
+test("review treats a degenerate deep response as a failed pass", async (t) => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  if (input.includes('review-MAP pass')) {",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'changed', files: ['src/app.ts'], why: 'changed file', risk: 'high', edges: [] }] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('doing a DEEP review')) {",
+			// Valid JSON shape, zero evidence: empty summary AND empty checked.
+			// normalizeReview accepts this; only the usability gate rejects it.
+			"    fs.writeFileSync(out, JSON.stringify({ summary: '', findings: [], checked: [], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('adversarial critic')) {",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'critic pruned', findings: [], checked: ['critic checked'], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  process.stderr.write('unexpected prompt');",
+			"  process.exit(1);",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: true,
+		focus: null,
+	};
+
+	const result = await review(bundle);
+
+	assert.equal(result.verdict, "needs_human");
+	assert.match(
+		result.residualRisks[0]?.text ?? "",
+		/deep review of "changed" failed/,
+	);
+	// A response with no summary and no checked list is not deep-review
+	// evidence — its hotspot must be excluded from coverage, same as a crash.
+	assert.match(
+		result.coverage ?? "",
+		/^0\/1 changed files deep-reviewed across 0 hotspots/,
+	);
+});
+
 test("review re-asks once when the model emits malformed JSON", async (t) => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
 	const repo = initRepo(tmp);

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -222,7 +222,10 @@ test("review keeps deep failure residuals after critic pruning", async (t) => {
 	// Coverage must NOT count the failed hotspot's files as deep-reviewed:
 	// the single hotspot failed, so 0/1 — an overstated coverage line would
 	// contradict the blocking residual right below it.
-	assert.match(result.coverage ?? "", /^0\/1 changed files deep-reviewed/);
+	assert.match(
+		result.coverage ?? "",
+		/^0\/1 changed files deep-reviewed across 0 hotspots/,
+	);
 });
 
 test("review re-asks once when the model emits malformed JSON", async (t) => {

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,851 +15,893 @@ import { headSha, initRepo } from "../shared/codex-runner-test-fixtures";
 import type { Bundle } from "../shared/schema";
 
 test("review preserves deep evidence through tail coverage", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  const finding = { severity: 'P2', title: 'Deep bug', category: 'bug', file: 'src/app.ts', lineStart: 1, lineEnd: 1, confidence: 0.9, whyItBreaks: 'The changed path breaks.', suggestedFix: 'Fix the path.', validation: 'pnpm test' };",
-      "  const evidence = 'EVIDENCE finding:Deep bug changed=src/app.ts:1 effect=bad path';",
-      "  if (input.includes('review-MAP pass')) {",
-      "    if (!input.includes('Review body') || !input.includes('review comment')) { process.stderr.write('missing map PR metadata'); process.exit(1); }",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'consumer', files: ['src/unchanged.ts'], why: 'consumer only', risk: 'high', edges: [] }] }));",
-      "    return;",
-      "  }",
-      "  if (input.includes('doing a DEEP review')) {",
-      "    if (!input.includes('tail-coverage') || !input.includes('src/app.ts')) { process.stderr.write('missing tail coverage'); process.exit(1); }",
-      "    if (!input.includes('Review body') || !input.includes('review comment')) { process.stderr.write('missing deep PR metadata'); process.exit(1); }",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'deep found blocker', findings: [finding], checked: [evidence], residual_risks: [] }));",
-      "    return;",
-      "  }",
-      "  if (input.includes('adversarial critic')) {",
-      "    if (!input.includes(evidence)) { process.stderr.write('missing deep evidence'); process.exit(1); }",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'critic kept blocker', findings: [finding], checked: [evidence], residual_risks: [] }));",
-      "    return;",
-      "  }",
-      "  process.stderr.write('unexpected prompt');",
-      "  process.exit(1);",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  const finding = { severity: 'P2', title: 'Deep bug', category: 'bug', file: 'src/app.ts', lineStart: 1, lineEnd: 1, confidence: 0.9, whyItBreaks: 'The changed path breaks.', suggestedFix: 'Fix the path.', validation: 'pnpm test' };",
+			"  const evidence = 'EVIDENCE finding:Deep bug changed=src/app.ts:1 effect=bad path';",
+			"  if (input.includes('review-MAP pass')) {",
+			"    if (!input.includes('Review body') || !input.includes('review comment')) { process.stderr.write('missing map PR metadata'); process.exit(1); }",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'consumer', files: ['src/unchanged.ts'], why: 'consumer only', risk: 'high', edges: [] }] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('doing a DEEP review')) {",
+			"    if (!input.includes('tail-coverage') || !input.includes('src/app.ts')) { process.stderr.write('missing tail coverage'); process.exit(1); }",
+			"    if (!input.includes('Review body') || !input.includes('review comment')) { process.stderr.write('missing deep PR metadata'); process.exit(1); }",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'deep found blocker', findings: [finding], checked: [evidence], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('adversarial critic')) {",
+			"    if (!input.includes(evidence)) { process.stderr.write('missing deep evidence'); process.exit(1); }",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'critic kept blocker', findings: [finding], checked: [evidence], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  process.stderr.write('unexpected prompt');",
+			"  process.exit(1);",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: {
-      number: 123,
-      title: "PR title",
-      body: "Review body",
-      comments: ["review comment"],
-      reviews: [],
-      checks: [],
-    },
-    deep: true,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: {
+			number: 123,
+			title: "PR title",
+			body: "Review body",
+			comments: ["review comment"],
+			reviews: [],
+			checks: [],
+		},
+		deep: true,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.equal(result.verdict, "changes_requested");
-  assert.deepEqual(result.checked, [
-    "EVIDENCE finding:Deep bug changed=src/app.ts:1 effect=bad path",
-  ]);
-  // S5: coverage string counts the tail backstop hotspot that deep-reviewed
-  // the one changed file the map pass left uncovered.
-  assert.equal(
-    result.coverage,
-    "1/1 changed files deep-reviewed across 1 hotspot, incl. tail-coverage",
-  );
+	assert.equal(result.verdict, "changes_requested");
+	assert.deepEqual(result.checked, [
+		"EVIDENCE finding:Deep bug changed=src/app.ts:1 effect=bad path",
+	]);
+	// S5: coverage string counts the tail backstop hotspot that deep-reviewed
+	// the one changed file the map pass left uncovered.
+	assert.equal(
+		result.coverage,
+		"1/1 changed files deep-reviewed across 1 hotspot, incl. tail-coverage",
+	);
 });
 
 test("review aborts deep fallback when a non-codex runner dirties the sandbox", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "claude-bin.js");
-  const previous = process.env.CLAUDE_BIN;
-  t.after(() => {
-    if (previous === undefined) delete process.env.CLAUDE_BIN;
-    else process.env.CLAUDE_BIN = previous;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  if (input.includes('review-MAP pass')) {",
-      "    process.stdout.write(JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'changed', files: ['src/app.ts'], why: 'changed file', risk: 'high', edges: [] }] }));",
-      "    return;",
-      "  }",
-      "  if (input.includes('doing a DEEP review')) {",
-      "    fs.writeFileSync('runner-wrote.txt', 'dirty');",
-      "    process.stdout.write(JSON.stringify({ summary: 'deep', findings: [], checked: ['deep checked'], residual_risks: [] }));",
-      "    return;",
-      "  }",
-      "  process.stderr.write('unexpected prompt');",
-      "  process.exit(1);",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CLAUDE_BIN = bin;
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: true,
-    focus: null,
-  };
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "claude-bin.js");
+	const previous = process.env.CLAUDE_BIN;
+	t.after(() => {
+		if (previous === undefined) delete process.env.CLAUDE_BIN;
+		else process.env.CLAUDE_BIN = previous;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  if (input.includes('review-MAP pass')) {",
+			"    process.stdout.write(JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'changed', files: ['src/app.ts'], why: 'changed file', risk: 'high', edges: [] }] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('doing a DEEP review')) {",
+			"    fs.writeFileSync('runner-wrote.txt', 'dirty');",
+			"    process.stdout.write(JSON.stringify({ summary: 'deep', findings: [], checked: ['deep checked'], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  process.stderr.write('unexpected prompt');",
+			"  process.exit(1);",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CLAUDE_BIN = bin;
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: true,
+		focus: null,
+	};
 
-  await assert.rejects(
-    () => review(bundle, { runner: "claude", timeoutMs: 1000 }),
-    /claude runner changed the review sandbox worktree/
-  );
+	await assert.rejects(
+		() => review(bundle, { runner: "claude", timeoutMs: 1000 }),
+		/claude runner changed the review sandbox worktree/,
+	);
 });
 
 test("review keeps deep failure residuals after critic pruning", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  if (input.includes('review-MAP pass')) {",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'changed', files: ['src/app.ts'], why: 'changed file', risk: 'high', edges: [] }] }));",
-      "    return;",
-      "  }",
-      "  if (input.includes('doing a DEEP review')) {",
-      "    fs.writeFileSync(out, 'not json');",
-      "    return;",
-      "  }",
-      "  if (input.includes('adversarial critic')) {",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'critic pruned', findings: [], checked: ['critic checked'], residual_risks: [] }));",
-      "    return;",
-      "  }",
-      "  process.stderr.write('unexpected prompt');",
-      "  process.exit(1);",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: true,
-    focus: null,
-  };
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  if (input.includes('review-MAP pass')) {",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'changed', files: ['src/app.ts'], why: 'changed file', risk: 'high', edges: [] }] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('doing a DEEP review')) {",
+			"    fs.writeFileSync(out, 'not json');",
+			"    return;",
+			"  }",
+			"  if (input.includes('adversarial critic')) {",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'critic pruned', findings: [], checked: ['critic checked'], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  process.stderr.write('unexpected prompt');",
+			"  process.exit(1);",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: true,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.equal(result.verdict, "needs_human");
-  assert.match(result.residualRisks[0]?.text ?? "", /deep review of "changed" failed/);
+	assert.equal(result.verdict, "needs_human");
+	assert.match(
+		result.residualRisks[0]?.text ?? "",
+		/deep review of "changed" failed/,
+	);
 });
 
 test("review re-asks once when the model emits malformed JSON", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const calls = path.join(tmp, "calls.log");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      `  const calls = ${JSON.stringify(calls)};`,
-      "  const review = { summary: 'clean', findings: [], checked: ['looked at diff'], residual_risks: [] };",
-      "  if (input.includes('adversarial critic')) {",
-      "    fs.appendFileSync(calls, 'critic\\n');",
-      "    fs.writeFileSync(out, JSON.stringify(review));",
-      "    return;",
-      "  }",
-      "  fs.appendFileSync(calls, 'review\\n');",
-      "  const reviews = fs.readFileSync(calls, 'utf8').split('\\n').filter((line) => line === 'review').length;",
-      "  fs.writeFileSync(out, reviews === 1 ? 'not json at all' : JSON.stringify(review));",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			`  const calls = ${JSON.stringify(calls)};`,
+			"  const review = { summary: 'clean', findings: [], checked: ['looked at diff'], residual_risks: [] };",
+			"  if (input.includes('adversarial critic')) {",
+			"    fs.appendFileSync(calls, 'critic\\n');",
+			"    fs.writeFileSync(out, JSON.stringify(review));",
+			"    return;",
+			"  }",
+			"  fs.appendFileSync(calls, 'review\\n');",
+			"  const reviews = fs.readFileSync(calls, 'utf8').split('\\n').filter((line) => line === 'review').length;",
+			"  fs.writeFileSync(out, reviews === 1 ? 'not json at all' : JSON.stringify(review));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.equal(result.verdict, "pass");
-  assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), ["review", "review", "critic"]);
-  assert.deepEqual(result.stats?.map((s) => s.label), ["review", "review", "critic"]);
-  assert.ok(result.stats?.every((s) => s.ok && s.attempts === 1 && s.durationMs > 0));
-  assert.ok((result.totalDurationMs ?? 0) > 0);
+	assert.equal(result.verdict, "pass");
+	assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), [
+		"review",
+		"review",
+		"critic",
+	]);
+	assert.deepEqual(
+		result.stats?.map((s) => s.label),
+		["review", "review", "critic"],
+	);
+	assert.ok(
+		result.stats?.every((s) => s.ok && s.attempts === 1 && s.durationMs > 0),
+	);
+	assert.ok((result.totalDurationMs ?? 0) > 0);
 });
 
 test("review fails after a second malformed response", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const calls = path.join(tmp, "calls.log");
-  const previous = process.env.CODEX_BIN;
-  t.after(() => {
-    if (previous === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "process.stdin.resume();",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      `  fs.appendFileSync(${JSON.stringify(calls)}, 'review\\n');`,
-      "  fs.writeFileSync(out, 'still not json');",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = process.env.CODEX_BIN;
+	t.after(() => {
+		if (previous === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"process.stdin.resume();",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			`  fs.appendFileSync(${JSON.stringify(calls)}, 'review\\n');`,
+			"  fs.writeFileSync(out, 'still not json');",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  await assert.rejects(() => review(bundle), /no JSON object found/);
-  assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), ["review", "review"]);
+	await assert.rejects(() => review(bundle), /no JSON object found/);
+	assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), [
+		"review",
+		"review",
+	]);
 });
 
 test("review does not re-ask after a runner safety error", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "claude-bin.js");
-  const calls = path.join(tmp, "calls.log");
-  const previous = process.env.CLAUDE_BIN;
-  t.after(() => {
-    if (previous === undefined) delete process.env.CLAUDE_BIN;
-    else process.env.CLAUDE_BIN = previous;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "process.stdin.resume();",
-      "process.stdin.on('end', () => {",
-      `  fs.appendFileSync(${JSON.stringify(calls)}, 'review\\n');`,
-      "  fs.writeFileSync('runner-wrote.txt', 'dirty');",
-      "  process.stdout.write(JSON.stringify({ summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] }));",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CLAUDE_BIN = bin;
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "claude-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = process.env.CLAUDE_BIN;
+	t.after(() => {
+		if (previous === undefined) delete process.env.CLAUDE_BIN;
+		else process.env.CLAUDE_BIN = previous;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"process.stdin.resume();",
+			"process.stdin.on('end', () => {",
+			`  fs.appendFileSync(${JSON.stringify(calls)}, 'review\\n');`,
+			"  fs.writeFileSync('runner-wrote.txt', 'dirty');",
+			"  process.stdout.write(JSON.stringify({ summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] }));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CLAUDE_BIN = bin;
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  await assert.rejects(
-    () => review(bundle, { runner: "claude", timeoutMs: 5000 }),
-    /claude runner changed the review sandbox worktree/
-  );
-  assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), ["review"]);
+	await assert.rejects(
+		() => review(bundle, { runner: "claude", timeoutMs: 5000 }),
+		/claude runner changed the review sandbox worktree/,
+	);
+	assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), ["review"]);
 });
 
 test("review runs deep passes concurrently and keeps hotspot order", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-    concurrency: process.env.NEEDLEFISH_DEEP_CONCURRENCY,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    if (previous.concurrency === undefined) delete process.env.NEEDLEFISH_DEEP_CONCURRENCY;
-    else process.env.NEEDLEFISH_DEEP_CONCURRENCY = previous.concurrency;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "const path = require('node:path');",
-      `const tmp = ${JSON.stringify(tmp)};`,
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  if (input.includes('review-MAP pass')) {",
-      "    const hotspot = (name, file) => ({ name, files: [file], why: 'changed', risk: 'high', edges: [] });",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [hotspot('h1', 'src/a.ts'), hotspot('h2', 'src/b.ts'), hotspot('h3', 'src/c.ts')] }));",
-      "    return;",
-      "  }",
-      "  if (input.includes('doing a DEEP review')) {",
-      "    const name = /\"name\": \"(h\\d)\"/.exec(input)[1];",
-      "    const delays = { h1: 800, h2: 500, h3: 200 };",
-      "    const start = Date.now();",
-      "    setTimeout(() => {",
-      "      fs.writeFileSync(path.join(tmp, `deep-${name}.json`), JSON.stringify({ start, end: Date.now() }));",
-      "      fs.writeFileSync(out, JSON.stringify({ summary: `deep ${name}`, findings: [], checked: [`checked ${name}`], residual_risks: [] }));",
-      "    }, delays[name]);",
-      "    return;",
-      "  }",
-      "  if (input.includes('adversarial critic')) {",
-      "    const candidate = input.slice(input.indexOf('# Candidate findings') + '# Candidate findings'.length, input.indexOf('# Diff stat'));",
-      "    fs.writeFileSync(out, JSON.stringify(JSON.parse(candidate)));",
-      "    return;",
-      "  }",
-      "  process.stderr.write('unexpected prompt');",
-      "  process.exit(1);",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
-  process.env.NEEDLEFISH_DEEP_CONCURRENCY = "3";
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+		concurrency: process.env.NEEDLEFISH_DEEP_CONCURRENCY,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		if (previous.concurrency === undefined)
+			delete process.env.NEEDLEFISH_DEEP_CONCURRENCY;
+		else process.env.NEEDLEFISH_DEEP_CONCURRENCY = previous.concurrency;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"const path = require('node:path');",
+			`const tmp = ${JSON.stringify(tmp)};`,
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  if (input.includes('review-MAP pass')) {",
+			"    const hotspot = (name, file) => ({ name, files: [file], why: 'changed', risk: 'high', edges: [] });",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [hotspot('h1', 'src/a.ts'), hotspot('h2', 'src/b.ts'), hotspot('h3', 'src/c.ts')] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('doing a DEEP review')) {",
+			'    const name = /"name": "(h\\d)"/.exec(input)[1];',
+			"    const delays = { h1: 800, h2: 500, h3: 200 };",
+			"    const start = Date.now();",
+			"    setTimeout(() => {",
+			"      fs.writeFileSync(path.join(tmp, `deep-${name}.json`), JSON.stringify({ start, end: Date.now() }));",
+			"      fs.writeFileSync(out, JSON.stringify({ summary: `deep ${name}`, findings: [], checked: [`checked ${name}`], residual_risks: [] }));",
+			"    }, delays[name]);",
+			"    return;",
+			"  }",
+			"  if (input.includes('adversarial critic')) {",
+			"    const candidate = input.slice(input.indexOf('# Candidate findings') + '# Candidate findings'.length, input.indexOf('# Diff stat'));",
+			"    fs.writeFileSync(out, JSON.stringify(JSON.parse(candidate)));",
+			"    return;",
+			"  }",
+			"  process.stderr.write('unexpected prompt');",
+			"  process.exit(1);",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
+	process.env.NEEDLEFISH_DEEP_CONCURRENCY = "3";
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/a.ts | 1 +",
-    changedFiles: [
-      { path: "src/a.ts", surface: "source" },
-      { path: "src/b.ts", surface: "source" },
-      { path: "src/c.ts", surface: "source" },
-    ],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: true,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/a.ts | 1 +",
+		changedFiles: [
+			{ path: "src/a.ts", surface: "source" },
+			{ path: "src/b.ts", surface: "source" },
+			{ path: "src/c.ts", surface: "source" },
+		],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: true,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.deepEqual(result.checked, [
-    "[h1] deep h1",
-    "checked h1",
-    "[h2] deep h2",
-    "checked h2",
-    "[h3] deep h3",
-    "checked h3",
-  ]);
-  const windows = ["h1", "h2", "h3"].map(
-    (name) =>
-      JSON.parse(readFileSync(path.join(tmp, `deep-${name}.json`), "utf8")) as {
-        start: number;
-        end: number;
-      }
-  );
-  const overlaps = windows.some((a, i) =>
-    windows.some((b, j) => i < j && a.start < b.end && b.start < a.end)
-  );
-  assert.ok(overlaps, "expected at least two deep passes to overlap in time");
-  const labels = new Set(result.stats?.map((s) => s.label));
-  for (const expected of ["map", "deep:h1", "deep:h2", "deep:h3", "critic"]) {
-    assert.ok(labels.has(expected), `missing stat label ${expected}`);
-  }
+	assert.deepEqual(result.checked, [
+		"[h1] deep h1",
+		"checked h1",
+		"[h2] deep h2",
+		"checked h2",
+		"[h3] deep h3",
+		"checked h3",
+	]);
+	const windows = ["h1", "h2", "h3"].map(
+		(name) =>
+			JSON.parse(readFileSync(path.join(tmp, `deep-${name}.json`), "utf8")) as {
+				start: number;
+				end: number;
+			},
+	);
+	const overlaps = windows.some((a, i) =>
+		windows.some((b, j) => i < j && a.start < b.end && b.start < a.end),
+	);
+	assert.ok(overlaps, "expected at least two deep passes to overlap in time");
+	const labels = new Set(result.stats?.map((s) => s.label));
+	for (const expected of ["map", "deep:h1", "deep:h2", "deep:h3", "critic"]) {
+		assert.ok(labels.has(expected), `missing stat label ${expected}`);
+	}
 });
 
 test("review feeds the diff as raw text, not escaped bundle JSON", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const previous = process.env.CODEX_BIN;
-  t.after(() => {
-    if (previous === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  const review = { summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] };",
-      "  if (input.includes('adversarial critic')) {",
-      "    fs.writeFileSync(out, JSON.stringify(review));",
-      "    return;",
-      "  }",
-      "  if (!input.includes('===== BEGIN DIFF (base..head) =====')) { process.stderr.write('missing diff sentinel'); process.exit(1); }",
-      "  if (!input.includes('diff --git a/src/app.ts b/src/app.ts\\n+const answer = 42;')) { process.stderr.write('diff not raw text'); process.exit(1); }",
-      "  if (input.includes('\"patch\"')) { process.stderr.write('patch leaked into bundle json'); process.exit(1); }",
-      "  fs.writeFileSync(out, JSON.stringify(review));",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = process.env.CODEX_BIN;
+	t.after(() => {
+		if (previous === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  const review = { summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] };",
+			"  if (input.includes('adversarial critic')) {",
+			"    fs.writeFileSync(out, JSON.stringify(review));",
+			"    return;",
+			"  }",
+			"  if (!input.includes('===== BEGIN DIFF (base..head) =====')) { process.stderr.write('missing diff sentinel'); process.exit(1); }",
+			"  if (!input.includes('diff --git a/src/app.ts b/src/app.ts\\n+const answer = 42;')) { process.stderr.write('diff not raw text'); process.exit(1); }",
+			"  if (input.includes('\"patch\"')) { process.stderr.write('patch leaked into bundle json'); process.exit(1); }",
+			"  fs.writeFileSync(out, JSON.stringify(review));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "diff --git a/src/app.ts b/src/app.ts\n+const answer = 42;\n",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "diff --git a/src/app.ts b/src/app.ts\n+const answer = 42;\n",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.equal(result.verdict, "pass");
+	assert.equal(result.verdict, "pass");
 });
 
 test("review large thresholds are env-overridable", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    chars: process.env.NEEDLEFISH_LARGE_PATCH_CHARS,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.chars === undefined) delete process.env.NEEDLEFISH_LARGE_PATCH_CHARS;
-    else process.env.NEEDLEFISH_LARGE_PATCH_CHARS = previous.chars;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  if (input.includes('review-MAP pass')) {",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'h1', files: ['src/app.ts'], why: 'changed', risk: 'high', edges: [] }] }));",
-      "    return;",
-      "  }",
-      "  if (input.includes('doing a DEEP review')) {",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'deep h1', findings: [], checked: ['checked h1'], residual_risks: [] }));",
-      "    return;",
-      "  }",
-      "  if (input.includes('adversarial critic')) {",
-      "    fs.writeFileSync(out, JSON.stringify({ summary: 'critic done', findings: [], checked: ['critic checked'], residual_risks: [] }));",
-      "    return;",
-      "  }",
-      "  process.stderr.write('unexpected prompt');",
-      "  process.exit(1);",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
-  process.env.NEEDLEFISH_LARGE_PATCH_CHARS = "5";
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		chars: process.env.NEEDLEFISH_LARGE_PATCH_CHARS,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.chars === undefined)
+			delete process.env.NEEDLEFISH_LARGE_PATCH_CHARS;
+		else process.env.NEEDLEFISH_LARGE_PATCH_CHARS = previous.chars;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  if (input.includes('review-MAP pass')) {",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'mapped', hotspots: [{ name: 'h1', files: ['src/app.ts'], why: 'changed', risk: 'high', edges: [] }] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('doing a DEEP review')) {",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'deep h1', findings: [], checked: ['checked h1'], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  if (input.includes('adversarial critic')) {",
+			"    fs.writeFileSync(out, JSON.stringify({ summary: 'critic done', findings: [], checked: ['critic checked'], residual_risks: [] }));",
+			"    return;",
+			"  }",
+			"  process.stderr.write('unexpected prompt');",
+			"  process.exit(1);",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.NEEDLEFISH_LARGE_PATCH_CHARS = "5";
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "longer than five characters",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "longer than five characters",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  const labels = result.stats?.map((s) => s.label) ?? [];
-  assert.ok(labels.includes("map"), "expected the large path (map pass) to run");
+	const labels = result.stats?.map((s) => s.label) ?? [];
+	assert.ok(
+		labels.includes("map"),
+		"expected the large path (map pass) to run",
+	);
 });
 
 test("review docs-only fast path skips all model calls", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const calls = path.join(tmp, "calls.log");
-  const previous = process.env.CODEX_BIN;
-  t.after(() => {
-    if (previous === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      `fs.appendFileSync(${JSON.stringify(calls)}, 'called\\n');`,
-      "process.exit(1);",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = process.env.CODEX_BIN;
+	t.after(() => {
+		if (previous === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			`fs.appendFileSync(${JSON.stringify(calls)}, 'called\\n');`,
+			"process.exit(1);",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "diff --git a/README.md b/README.md\n+docs\n",
-    patchStat: " README.md | 1 +",
-    changedFiles: [
-      { path: "README.md", surface: "docs" },
-      { path: "docs/guide.md", surface: "docs" },
-    ],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "diff --git a/README.md b/README.md\n+docs\n",
+		patchStat: " README.md | 1 +",
+		changedFiles: [
+			{ path: "README.md", surface: "docs" },
+			{ path: "docs/guide.md", surface: "docs" },
+		],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.equal(result.verdict, "pass");
-  assert.deepEqual(result.findings, []);
-  assert.deepEqual(result.residualRisks, []);
-  assert.match(result.summary, /Docs-only change \(2 file\(s\)\); model review skipped\./);
-  assert.deepEqual(result.checked, ["FAST_PATH docs-only files=[README.md, docs/guide.md]"]);
-  assert.equal(result.stats, undefined, "no stats when model is not called");
-  assert.ok((result.totalDurationMs ?? -1) >= 0, "totalDurationMs must be set");
-  assert.equal(result.baseSha, "base");
-  assert.ok(!existsSync(calls), "runner must not be invoked for docs-only bundle");
+	assert.equal(result.verdict, "pass");
+	assert.deepEqual(result.findings, []);
+	assert.deepEqual(result.residualRisks, []);
+	assert.match(
+		result.summary,
+		/Docs-only change \(2 file\(s\)\); model review skipped\./,
+	);
+	assert.deepEqual(result.checked, [
+		"FAST_PATH docs-only files=[README.md, docs/guide.md]",
+	]);
+	assert.equal(result.stats, undefined, "no stats when model is not called");
+	assert.ok((result.totalDurationMs ?? -1) >= 0, "totalDurationMs must be set");
+	assert.equal(result.baseSha, "base");
+	assert.ok(
+		!existsSync(calls),
+		"runner must not be invoked for docs-only bundle",
+	);
 });
 
 test("review mixed docs+source bundle still invokes the model", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const calls = path.join(tmp, "calls.log");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  const review = { summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] };",
-      "  fs.appendFileSync(" + JSON.stringify(calls) + ", 'x\\n');",
-      "  fs.writeFileSync(out, JSON.stringify(review));",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  const review = { summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] };",
+			"  fs.appendFileSync(" + JSON.stringify(calls) + ", 'x\\n');",
+			"  fs.writeFileSync(out, JSON.stringify(review));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "diff --git a/README.md b/README.md\n+docs\n",
-    patchStat: " README.md | 1 +",
-    changedFiles: [
-      { path: "README.md", surface: "docs" },
-      { path: "src/app.ts", surface: "source" },
-    ],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "diff --git a/README.md b/README.md\n+docs\n",
+		patchStat: " README.md | 1 +",
+		changedFiles: [
+			{ path: "README.md", surface: "docs" },
+			{ path: "src/app.ts", surface: "source" },
+		],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.equal(result.verdict, "pass");
-  assert.ok(existsSync(calls), "runner must be invoked for mixed docs+source bundle");
+	assert.equal(result.verdict, "pass");
+	assert.ok(
+		existsSync(calls),
+		"runner must be invoked for mixed docs+source bundle",
+	);
 });
 
 test("review NEEDLEFISH_NO_FAST_PATH disables docs-only fast path", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const calls = path.join(tmp, "calls.log");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-    noFastPath: process.env.NEEDLEFISH_NO_FAST_PATH,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    if (previous.noFastPath === undefined) delete process.env.NEEDLEFISH_NO_FAST_PATH;
-    else process.env.NEEDLEFISH_NO_FAST_PATH = previous.noFastPath;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  const review = { summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] };",
-      "  fs.appendFileSync(" + JSON.stringify(calls) + ", 'x\\n');",
-      "  fs.writeFileSync(out, JSON.stringify(review));",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
-  process.env.NEEDLEFISH_NO_FAST_PATH = "1";
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+		noFastPath: process.env.NEEDLEFISH_NO_FAST_PATH,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		if (previous.noFastPath === undefined)
+			delete process.env.NEEDLEFISH_NO_FAST_PATH;
+		else process.env.NEEDLEFISH_NO_FAST_PATH = previous.noFastPath;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  const review = { summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] };",
+			"  fs.appendFileSync(" + JSON.stringify(calls) + ", 'x\\n');",
+			"  fs.writeFileSync(out, JSON.stringify(review));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
+	process.env.NEEDLEFISH_NO_FAST_PATH = "1";
 
-  const bundle: Bundle = {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "diff --git a/README.md b/README.md\n+docs\n",
-    patchStat: " README.md | 1 +",
-    changedFiles: [{ path: "README.md", surface: "docs" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "diff --git a/README.md b/README.md\n+docs\n",
+		patchStat: " README.md | 1 +",
+		changedFiles: [{ path: "README.md", surface: "docs" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 
-  const result = await review(bundle);
+	const result = await review(bundle);
 
-  assert.equal(result.verdict, "pass");
-  assert.ok(existsSync(calls), "runner must be invoked when NEEDLEFISH_NO_FAST_PATH is set");
-  assert.doesNotMatch(result.summary, /Docs-only change/);
+	assert.equal(result.verdict, "pass");
+	assert.ok(
+		existsSync(calls),
+		"runner must be invoked when NEEDLEFISH_NO_FAST_PATH is set",
+	);
+	assert.doesNotMatch(result.summary, /Docs-only change/);
 });
 
 // Small-path echo critic: the runner answers both review and critic prompts
 // with the same finding. Under NEEDLEFISH_EVAL_TRACE the result must expose
 // the pre-critic candidate findings; without it, the field stays absent.
 function evalTraceEchoBundle(repo: string): Bundle {
-  return {
-    repoPath: repo,
-    baseSha: "base",
-    headSha: headSha(repo),
-    patch: "short",
-    patchStat: " src/app.ts | 1 +",
-    changedFiles: [{ path: "src/app.ts", surface: "source" }],
-    agentsMd: "(none)",
-    prMeta: null,
-    deep: false,
-    focus: null,
-  };
+	return {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "short",
+		patchStat: " src/app.ts | 1 +",
+		changedFiles: [{ path: "src/app.ts", surface: "source" }],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
 }
 
 function writeEchoCriticBin(bin: string): void {
-  writeFileSync(
-    bin,
-    [
-      "#!/usr/bin/env node",
-      "const fs = require('node:fs');",
-      "let input = '';",
-      "process.stdin.setEncoding('utf8');",
-      "process.stdin.on('data', (chunk) => { input += chunk; });",
-      "process.stdin.on('end', () => {",
-      "  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
-      "  const finding = { severity: 'P2', title: 'Echo bug', category: 'bug', file: 'src/app.ts', lineStart: 1, lineEnd: 1, confidence: 0.9, whyItBreaks: 'breaks', suggestedFix: 'fix', validation: 'pnpm test' };",
-      "  fs.writeFileSync(out, JSON.stringify({ summary: 'clean', findings: [finding], checked: ['looked'], residual_risks: [] }));",
-      "});",
-    ].join("\n")
-  );
-  chmodSync(bin, 0o755);
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  const finding = { severity: 'P2', title: 'Echo bug', category: 'bug', file: 'src/app.ts', lineStart: 1, lineEnd: 1, confidence: 0.9, whyItBreaks: 'breaks', suggestedFix: 'fix', validation: 'pnpm test' };",
+			"  fs.writeFileSync(out, JSON.stringify({ summary: 'clean', findings: [finding], checked: ['looked'], residual_risks: [] }));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
 }
 
 test("review records candidateFindings when NEEDLEFISH_EVAL_TRACE is set (small path)", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-    trace: process.env.NEEDLEFISH_EVAL_TRACE,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    if (previous.trace === undefined) delete process.env.NEEDLEFISH_EVAL_TRACE;
-    else process.env.NEEDLEFISH_EVAL_TRACE = previous.trace;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeEchoCriticBin(bin);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
-  process.env.NEEDLEFISH_EVAL_TRACE = "1";
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+		trace: process.env.NEEDLEFISH_EVAL_TRACE,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		if (previous.trace === undefined) delete process.env.NEEDLEFISH_EVAL_TRACE;
+		else process.env.NEEDLEFISH_EVAL_TRACE = previous.trace;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeEchoCriticBin(bin);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
+	process.env.NEEDLEFISH_EVAL_TRACE = "1";
 
-  const result = await review(evalTraceEchoBundle(repo));
+	const result = await review(evalTraceEchoBundle(repo));
 
-  assert.ok(result.candidateFindings, "candidateFindings must be present under NEEDLEFISH_EVAL_TRACE");
-  assert.equal(result.candidateFindings!.length, 1);
-  assert.equal(result.candidateFindings![0].title, "Echo bug");
-  assert.equal(result.findings.length, 1);
-  assert.equal(result.findings[0].title, "Echo bug");
+	assert.ok(
+		result.candidateFindings,
+		"candidateFindings must be present under NEEDLEFISH_EVAL_TRACE",
+	);
+	assert.equal(result.candidateFindings!.length, 1);
+	assert.equal(result.candidateFindings![0].title, "Echo bug");
+	assert.equal(result.findings.length, 1);
+	assert.equal(result.findings[0].title, "Echo bug");
 });
 
 test("review omits candidateFindings when NEEDLEFISH_EVAL_TRACE is unset (small path)", async (t) => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
-  const repo = initRepo(tmp);
-  const bin = path.join(tmp, "codex-bin.js");
-  const previous = {
-    bin: process.env.CODEX_BIN,
-    retry: process.env.CODEX_RETRY_MS,
-    trace: process.env.NEEDLEFISH_EVAL_TRACE,
-  };
-  t.after(() => {
-    if (previous.bin === undefined) delete process.env.CODEX_BIN;
-    else process.env.CODEX_BIN = previous.bin;
-    if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
-    else process.env.CODEX_RETRY_MS = previous.retry;
-    if (previous.trace === undefined) delete process.env.NEEDLEFISH_EVAL_TRACE;
-    else process.env.NEEDLEFISH_EVAL_TRACE = previous.trace;
-    rmSync(tmp, { recursive: true, force: true });
-  });
-  writeEchoCriticBin(bin);
-  process.env.CODEX_BIN = bin;
-  process.env.CODEX_RETRY_MS = "1";
-  delete process.env.NEEDLEFISH_EVAL_TRACE;
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+		trace: process.env.NEEDLEFISH_EVAL_TRACE,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		if (previous.trace === undefined) delete process.env.NEEDLEFISH_EVAL_TRACE;
+		else process.env.NEEDLEFISH_EVAL_TRACE = previous.trace;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeEchoCriticBin(bin);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
+	delete process.env.NEEDLEFISH_EVAL_TRACE;
 
-  const result = await review(evalTraceEchoBundle(repo));
+	const result = await review(evalTraceEchoBundle(repo));
 
-  assert.equal(result.candidateFindings, undefined, "candidateFindings must be absent without NEEDLEFISH_EVAL_TRACE");
-  assert.equal(result.findings.length, 1);
+	assert.equal(
+		result.candidateFindings,
+		undefined,
+		"candidateFindings must be absent without NEEDLEFISH_EVAL_TRACE",
+	);
+	assert.equal(result.findings.length, 1);
 });

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -871,6 +871,11 @@ test("review records candidateFindings when NEEDLEFISH_EVAL_TRACE is set (small 
 	assert.equal(result.candidateFindings![0].title, "Echo bug");
 	assert.equal(result.findings.length, 1);
 	assert.equal(result.findings[0].title, "Echo bug");
+	// S2: the small path states its coverage guarantee.
+	assert.match(
+		result.coverage ?? "",
+		/^full diff reviewed in one pass \(\d+ files?\)$/,
+	);
 });
 
 test("review omits candidateFindings when NEEDLEFISH_EVAL_TRACE is unset (small path)", async (t) => {

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -85,6 +85,12 @@ test("review preserves deep evidence through tail coverage", async (t) => {
   assert.deepEqual(result.checked, [
     "EVIDENCE finding:Deep bug changed=src/app.ts:1 effect=bad path",
   ]);
+  // S5: coverage string counts the tail backstop hotspot that deep-reviewed
+  // the one changed file the map pass left uncovered.
+  assert.equal(
+    result.coverage,
+    "1/1 changed files deep-reviewed across 1 hotspot, incl. tail-coverage",
+  );
 });
 
 test("review aborts deep fallback when a non-codex runner dirties the sandbox", async (t) => {

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -219,6 +219,10 @@ test("review keeps deep failure residuals after critic pruning", async (t) => {
 		result.residualRisks[0]?.text ?? "",
 		/deep review of "changed" failed/,
 	);
+	// Coverage must NOT count the failed hotspot's files as deep-reviewed:
+	// the single hotspot failed, so 0/1 — an overstated coverage line would
+	// contradict the blocking residual right below it.
+	assert.match(result.coverage ?? "", /^0\/1 changed files deep-reviewed/);
 });
 
 test("review re-asks once when the model emits malformed JSON", async (t) => {

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -1,14 +1,23 @@
-import { runCodex, extractJson, isRunnerSafetyError, type CodexOptions } from "../shared/codex.js";
-import { parsePositiveInteger, type RunnerOptions, type RunStat } from "../shared/runner.js";
 import {
-  REVIEW_RESULT_SCHEMA_VERSION,
-  type Bundle,
-  type Finding,
-  type Hotspot,
-  type RawReview,
-  type ResidualRisk,
-  type ReviewResult,
-  type Severity,
+	runCodex,
+	extractJson,
+	isRunnerSafetyError,
+	type CodexOptions,
+} from "../shared/codex.js";
+import {
+	parsePositiveInteger,
+	type RunnerOptions,
+	type RunStat,
+} from "../shared/runner.js";
+import {
+	REVIEW_RESULT_SCHEMA_VERSION,
+	type Bundle,
+	type Finding,
+	type Hotspot,
+	type RawReview,
+	type ResidualRisk,
+	type ReviewResult,
+	type Severity,
 } from "../shared/schema.js";
 import { normalizeMap, normalizeReview } from "../shared/normalize.js";
 import { deriveVerdict } from "./verdict.js";
@@ -21,20 +30,23 @@ const DEFAULT_DEEP_CONCURRENCY = 3;
 const SEV_RANK: Record<Severity, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
 
 interface ReviewRun {
-  readonly bundle: Bundle;
-  readonly runnerOptions: RunnerOptions;
-  readonly stats: RunStat[];
-  readonly startedAt: number;
+	readonly bundle: Bundle;
+	readonly runnerOptions: RunnerOptions;
+	readonly stats: RunStat[];
+	readonly startedAt: number;
 }
 
 function envPositiveInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw === "") return fallback;
-  return parsePositiveInteger(raw, name);
+	const raw = process.env[name];
+	if (raw === undefined || raw === "") return fallback;
+	return parsePositiveInteger(raw, name);
 }
 
 function deepConcurrency(): number {
-  return envPositiveInt("NEEDLEFISH_DEEP_CONCURRENCY", DEFAULT_DEEP_CONCURRENCY);
+	return envPositiveInt(
+		"NEEDLEFISH_DEEP_CONCURRENCY",
+		DEFAULT_DEEP_CONCURRENCY,
+	);
 }
 
 // Eval-only: when set, ReviewResult carries candidateFindings (the pre-critic
@@ -42,251 +54,305 @@ function deepConcurrency(): number {
 // when unset — callers still pass the candidate list (a reference), but it is
 // only attached to the result here when the flag is on.
 function evalTraceOn(): boolean {
-  const raw = process.env.NEEDLEFISH_EVAL_TRACE;
-  return raw !== undefined && raw !== "";
+	const raw = process.env.NEEDLEFISH_EVAL_TRACE;
+	return raw !== undefined && raw !== "";
 }
 
 // Worker pool over a shared index; results land at their item's index so
 // output order never depends on completion order.
 async function mapLimit<T, R>(
-  items: readonly T[],
-  limit: number,
-  fn: (item: T, index: number) => Promise<R>
+	items: readonly T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let next = 0;
-  const workers = Array.from(
-    { length: Math.max(1, Math.min(limit, items.length)) },
-    async () => {
-      while (next < items.length) {
-        const i = next++;
-        results[i] = await fn(items[i], i);
-      }
-    }
-  );
-  await Promise.all(workers);
-  return results;
+	const results = new Array<R>(items.length);
+	let next = 0;
+	const workers = Array.from(
+		{ length: Math.max(1, Math.min(limit, items.length)) },
+		async () => {
+			while (next < items.length) {
+				const i = next++;
+				results[i] = await fn(items[i], i);
+			}
+		},
+	);
+	await Promise.all(workers);
+	return results;
 }
 
 function isLarge(bundle: Bundle): boolean {
-  return (
-    bundle.patch.length > envPositiveInt("NEEDLEFISH_LARGE_PATCH_CHARS", LARGE_PATCH_CHARS) ||
-    bundle.changedFiles.length > envPositiveInt("NEEDLEFISH_LARGE_FILE_COUNT", LARGE_FILE_COUNT)
-  );
+	return (
+		bundle.patch.length >
+			envPositiveInt("NEEDLEFISH_LARGE_PATCH_CHARS", LARGE_PATCH_CHARS) ||
+		bundle.changedFiles.length >
+			envPositiveInt("NEEDLEFISH_LARGE_FILE_COUNT", LARGE_FILE_COUNT)
+	);
 }
 
-function changedHotspots(hotspots: readonly Hotspot[], bundle: Bundle): Hotspot[] {
-  const changed = new Set(bundle.changedFiles.map((file) => file.path));
-  return hotspots
-    .map((hotspot) => ({
-      ...hotspot,
-      files: hotspot.files.filter((file) => changed.has(file)),
-    }))
-    .filter((hotspot) => hotspot.files.length > 0);
+function changedHotspots(
+	hotspots: readonly Hotspot[],
+	bundle: Bundle,
+): Hotspot[] {
+	const changed = new Set(bundle.changedFiles.map((file) => file.path));
+	return hotspots
+		.map((hotspot) => ({
+			...hotspot,
+			files: hotspot.files.filter((file) => changed.has(file)),
+		}))
+		.filter((hotspot) => hotspot.files.length > 0);
 }
 
 function dedup(findings: readonly Finding[]): Finding[] {
-  const norm = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
-  const out = new Map<string, Finding>();
-  for (const f of findings) {
-    const key = `${f.file}|${f.lineStart}|${f.category}|${norm(f.title).slice(0, 60)}|${norm(f.whyItBreaks).slice(0, 80)}`;
-    const prev = out.get(key);
-    if (!prev || SEV_RANK[f.severity] < SEV_RANK[prev.severity]) out.set(key, f);
-  }
-  return [...out.values()];
+	const norm = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
+	const out = new Map<string, Finding>();
+	for (const f of findings) {
+		const key = `${f.file}|${f.lineStart}|${f.category}|${norm(f.title).slice(0, 60)}|${norm(f.whyItBreaks).slice(0, 80)}`;
+		const prev = out.get(key);
+		if (!prev || SEV_RANK[f.severity] < SEV_RANK[prev.severity])
+			out.set(key, f);
+	}
+	return [...out.values()];
 }
 
 function sortByRisk(hotspots: readonly Hotspot[]): Hotspot[] {
-  const rank = { high: 0, med: 1, low: 2 } as const;
-  return [...hotspots].sort((a, b) => rank[a.risk] - rank[b.risk]);
+	const rank = { high: 0, med: 1, low: 2 } as const;
+	return [...hotspots].sort((a, b) => rank[a.risk] - rank[b.risk]);
 }
 
 function codexOptions(run: ReviewRun, label: string): CodexOptions {
-  return {
-    repoPath: run.bundle.repoPath,
-    targetHeadSha: run.bundle.headSha,
-    ...(run.bundle.headSha === "WORKING" ? { targetPatch: run.bundle.patch } : {}),
-    label,
-    onStat: (stat) => run.stats.push(stat),
-    ...run.runnerOptions,
-  };
+	return {
+		repoPath: run.bundle.repoPath,
+		targetHeadSha: run.bundle.headSha,
+		...(run.bundle.headSha === "WORKING"
+			? { targetPatch: run.bundle.patch }
+			: {}),
+		label,
+		onStat: (stat) => run.stats.push(stat),
+		...run.runnerOptions,
+	};
 }
 
 // One retry on malformed output: re-ask the model, never re-parse the same
 // text. Safety errors throw from runCodex itself, outside the try, so they
 // propagate immediately without a retry.
 async function runJsonPrompt<T>(
-  label: string,
-  prompt: string,
-  run: ReviewRun,
-  parse: (raw: unknown) => T
+	label: string,
+	prompt: string,
+	run: ReviewRun,
+	parse: (raw: unknown) => T,
 ): Promise<T> {
-  let lastErr: unknown;
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    const out = await runCodex(prompt, codexOptions(run, label));
-    try {
-      return parse(extractJson(out));
-    } catch (err) {
-      lastErr = err;
-    }
-  }
-  throw lastErr;
+	let lastErr: unknown;
+	for (let attempt = 1; attempt <= 2; attempt++) {
+		const out = await runCodex(prompt, codexOptions(run, label));
+		try {
+			return parse(extractJson(out));
+		} catch (err) {
+			lastErr = err;
+		}
+	}
+	throw lastErr;
 }
 
 function assertUsableReview(review: RawReview, label: string): void {
-  if (!review.summary || review.checked.length === 0) {
-    throw new Error(`${label} produced no summary or checked list (likely malformed output)`);
-  }
+	if (!review.summary || review.checked.length === 0) {
+		throw new Error(
+			`${label} produced no summary or checked list (likely malformed output)`,
+		);
+	}
 }
 
 function parseUsableReview(label: string): (raw: unknown) => RawReview {
-  return (raw) => {
-    const review = normalizeReview(raw);
-    assertUsableReview(review, label);
-    return review;
-  };
+	return (raw) => {
+		const review = normalizeReview(raw);
+		assertUsableReview(review, label);
+		return review;
+	};
 }
 
-async function runCritic(candidate: RawReview, patchText: string, run: ReviewRun): Promise<RawReview> {
-  const { bundle } = run;
-  const criticPrompt = loadPrompt("critic.md")
-    .replace("{{FINDINGS}}", () => JSON.stringify(candidate, null, 2))
-    .replace("{{PATCH}}", () => patchText)
-    .replace("{{BASE}}", bundle.baseSha)
-    .replace("{{HEAD}}", bundle.headSha);
-  return runJsonPrompt("critic", criticPrompt, run, parseUsableReview("critic"));
+async function runCritic(
+	candidate: RawReview,
+	patchText: string,
+	run: ReviewRun,
+): Promise<RawReview> {
+	const { bundle } = run;
+	const criticPrompt = loadPrompt("critic.md")
+		.replace("{{FINDINGS}}", () => JSON.stringify(candidate, null, 2))
+		.replace("{{PATCH}}", () => patchText)
+		.replace("{{BASE}}", bundle.baseSha)
+		.replace("{{HEAD}}", bundle.headSha);
+	return runJsonPrompt(
+		"critic",
+		criticPrompt,
+		run,
+		parseUsableReview("critic"),
+	);
 }
 
 function toReviewResult(
-  raw: RawReview,
-  run: ReviewRun,
-  summary = raw.summary,
-  candidateFindings?: readonly Finding[],
-  coverage?: string
+	raw: RawReview,
+	run: ReviewRun,
+	summary = raw.summary,
+	candidateFindings?: readonly Finding[],
+	coverage?: string,
 ): ReviewResult {
-  const { bundle } = run;
-  const verdict = deriveVerdict(raw.findings, raw.residual_risks);
-  return {
-    schemaVersion: REVIEW_RESULT_SCHEMA_VERSION,
-    verdict,
-    summary,
-    findings: raw.findings,
-    checked: raw.checked,
-    residualRisks: raw.residual_risks,
-    baseSha: bundle.baseSha,
-    headSha: bundle.headSha,
-    ...(bundle.reviewTarget ? { reviewTarget: bundle.reviewTarget } : {}),
-    ...(run.stats.length > 0 ? { stats: [...run.stats] } : {}),
-    totalDurationMs: Date.now() - run.startedAt,
-    ...(coverage ? { coverage } : {}),
-    ...(evalTraceOn() && candidateFindings ? { candidateFindings } : {}),
-  };
+	const { bundle } = run;
+	const verdict = deriveVerdict(raw.findings, raw.residual_risks);
+	return {
+		schemaVersion: REVIEW_RESULT_SCHEMA_VERSION,
+		verdict,
+		summary,
+		findings: raw.findings,
+		checked: raw.checked,
+		residualRisks: raw.residual_risks,
+		baseSha: bundle.baseSha,
+		headSha: bundle.headSha,
+		...(bundle.reviewTarget ? { reviewTarget: bundle.reviewTarget } : {}),
+		...(run.stats.length > 0 ? { stats: [...run.stats] } : {}),
+		totalDurationMs: Date.now() - run.startedAt,
+		...(coverage ? { coverage } : {}),
+		...(evalTraceOn() && candidateFindings ? { candidateFindings } : {}),
+	};
 }
 
 // Small PR: one review call over the full diff. The diff goes in as raw text
 // between sentinel lines — never inside the JSON bundle, where escaping
 // inflates tokens and hurts the model's read of the hunks.
 async function reviewSmall(run: ReviewRun): Promise<ReviewResult> {
-  const { bundle } = run;
-  const { patch, ...meta } = bundle;
-  const reviewPrompt = loadPrompt("review.md")
-    .replace("{{BUNDLE}}", () => JSON.stringify(meta, null, 2))
-    .replace("{{PATCH}}", () => patch);
-  const candidate = await runJsonPrompt("review", reviewPrompt, run, parseUsableReview("review"));
-  const coverage = `full diff reviewed in one pass (${bundle.changedFiles.length} file${bundle.changedFiles.length === 1 ? "" : "s"})`;
-  return toReviewResult(await runCritic(candidate, bundle.patch, run), run, undefined, candidate.findings, coverage);
+	const { bundle } = run;
+	const { patch, ...meta } = bundle;
+	const reviewPrompt = loadPrompt("review.md")
+		.replace("{{BUNDLE}}", () => JSON.stringify(meta, null, 2))
+		.replace("{{PATCH}}", () => patch);
+	const candidate = await runJsonPrompt(
+		"review",
+		reviewPrompt,
+		run,
+		parseUsableReview("review"),
+	);
+	const coverage = `full diff reviewed in one pass (${bundle.changedFiles.length} file${bundle.changedFiles.length === 1 ? "" : "s"})`;
+	return toReviewResult(
+		await runCritic(candidate, bundle.patch, run),
+		run,
+		undefined,
+		candidate.findings,
+		coverage,
+	);
 }
 
 // Large PR: map (blast-radius survey, no diff text) -> deep per hotspot -> merge -> critic.
 async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
-  const { bundle } = run;
-  const mapBundle = {
-    baseSha: bundle.baseSha,
-    headSha: bundle.headSha,
-    patchStat: bundle.patchStat,
-    changedFiles: bundle.changedFiles,
-    agentsMd: bundle.agentsMd,
-    prMeta: bundle.prMeta,
-    focus: bundle.focus,
-    deep: bundle.deep,
-  };
-  const mapPrompt = loadPrompt("map.md").replace("{{BUNDLE}}", () => JSON.stringify(mapBundle, null, 2));
-  const mapResult = await runJsonPrompt("map", mapPrompt, run, normalizeMap);
-  const mappedHotspots = changedHotspots(mapResult.hotspots, bundle);
-  const hotspots = sortByRisk(mappedHotspots).slice(0, MAX_HOTSPOTS);
+	const { bundle } = run;
+	const mapBundle = {
+		baseSha: bundle.baseSha,
+		headSha: bundle.headSha,
+		patchStat: bundle.patchStat,
+		changedFiles: bundle.changedFiles,
+		agentsMd: bundle.agentsMd,
+		prMeta: bundle.prMeta,
+		focus: bundle.focus,
+		deep: bundle.deep,
+	};
+	const mapPrompt = loadPrompt("map.md").replace("{{BUNDLE}}", () =>
+		JSON.stringify(mapBundle, null, 2),
+	);
+	const mapResult = await runJsonPrompt("map", mapPrompt, run, normalizeMap);
+	const mappedHotspots = changedHotspots(mapResult.hotspots, bundle);
+	const hotspots = sortByRisk(mappedHotspots).slice(0, MAX_HOTSPOTS);
 
-  // Coverage backstop: any changed file not in a selected hotspot goes into a tail
-  // hotspot so it still gets deep-reviewed (never silently skip a changed file).
-  const covered = new Set(hotspots.flatMap((h) => h.files));
-  const uncovered = bundle.changedFiles.map((f) => f.path).filter((p) => !covered.has(p));
-  let tailAdded = false;
-  if (uncovered.length > 0) {
-    tailAdded = true;
-    hotspots.push({
-      name: "tail-coverage (files not mapped to a surface)",
-      files: uncovered,
-      why: "coverage backstop: these changed files were not assigned to any surface",
-      risk: "low",
-      edges: [],
-    });
-  }
-  if (hotspots.length === 0) {
-    throw new Error("map pass produced no changed-file hotspots");
-  }
+	// Coverage backstop: any changed file not in a selected hotspot goes into a tail
+	// hotspot so it still gets deep-reviewed (never silently skip a changed file).
+	const covered = new Set(hotspots.flatMap((h) => h.files));
+	const uncovered = bundle.changedFiles
+		.map((f) => f.path)
+		.filter((p) => !covered.has(p));
+	let tailAdded = false;
+	if (uncovered.length > 0) {
+		tailAdded = true;
+		hotspots.push({
+			name: "tail-coverage (files not mapped to a surface)",
+			files: uncovered,
+			why: "coverage backstop: these changed files were not assigned to any surface",
+			risk: "low",
+			edges: [],
+		});
+	}
+	if (hotspots.length === 0) {
+		throw new Error("map pass produced no changed-file hotspots");
+	}
 
-  const agents = bundle.agentsMd;
-  const passes = await mapLimit(hotspots, deepConcurrency(), async (h) => {
-    const deepPrompt = loadPrompt("deep.md")
-      .replace("{{AGENTS}}", () => agents)
-      .replace("{{PR_META}}", () => JSON.stringify(bundle.prMeta, null, 2))
-      .replace("{{HOTSPOT}}", () => JSON.stringify(h, null, 2))
-      .replace("{{FOCUS}}", bundle.focus ?? "(none)")
-      .replace("{{BASE}}", bundle.baseSha)
-      .replace("{{HEAD}}", bundle.headSha);
-    try {
-      const res = await runJsonPrompt(`deep:${h.name}`, deepPrompt, run, (raw) => normalizeReview(raw));
-      return {
-        checked: [`[${h.name}] ${res.summary || "(no summary)"}`, ...res.checked],
-        findings: res.findings,
-        residuals: res.residual_risks,
-      };
-    } catch (e) {
-      if (isRunnerSafetyError(e)) throw e;
-      const msg = e instanceof Error ? e.message : String(e);
-      return {
-        checked: [`[${h.name}] DEEP PASS FAILED: ${msg.slice(0, 200)}`],
-        findings: [] as readonly Finding[],
-        residuals: [
-          { text: `deep review of "${h.name}" failed (${msg.slice(0, 150)}); ${h.files.length} file(s) not deep-reviewed`, blocks: true },
-        ] as readonly ResidualRisk[],
-      };
-    }
-  });
-  const all = passes.flatMap((p) => p.findings);
-  const checked = passes.flatMap((p) => p.checked);
-  const residuals = passes.flatMap((p) => p.residuals);
+	const agents = bundle.agentsMd;
+	const passes = await mapLimit(hotspots, deepConcurrency(), async (h) => {
+		const deepPrompt = loadPrompt("deep.md")
+			.replace("{{AGENTS}}", () => agents)
+			.replace("{{PR_META}}", () => JSON.stringify(bundle.prMeta, null, 2))
+			.replace("{{HOTSPOT}}", () => JSON.stringify(h, null, 2))
+			.replace("{{FOCUS}}", bundle.focus ?? "(none)")
+			.replace("{{BASE}}", bundle.baseSha)
+			.replace("{{HEAD}}", bundle.headSha);
+		try {
+			const res = await runJsonPrompt(
+				`deep:${h.name}`,
+				deepPrompt,
+				run,
+				(raw) => normalizeReview(raw),
+			);
+			return {
+				checked: [
+					`[${h.name}] ${res.summary || "(no summary)"}`,
+					...res.checked,
+				],
+				findings: res.findings,
+				residuals: res.residual_risks,
+			};
+		} catch (e) {
+			if (isRunnerSafetyError(e)) throw e;
+			const msg = e instanceof Error ? e.message : String(e);
+			return {
+				checked: [`[${h.name}] DEEP PASS FAILED: ${msg.slice(0, 200)}`],
+				findings: [] as readonly Finding[],
+				residuals: [
+					{
+						text: `deep review of "${h.name}" failed (${msg.slice(0, 150)}); ${h.files.length} file(s) not deep-reviewed`,
+						blocks: true,
+					},
+				] as readonly ResidualRisk[],
+			};
+		}
+	});
+	const all = passes.flatMap((p) => p.findings);
+	const checked = passes.flatMap((p) => p.checked);
+	const residuals = passes.flatMap((p) => p.residuals);
 
-  const merged = dedup(all);
-  const candidateMerged: RawReview = {
-    summary: mapResult.summary,
-    findings: merged,
-    checked,
-    residual_risks: residuals,
-  };
-  const pruned = await runCritic(
-    candidateMerged,
-    bundle.patchStat || "(see git diff --stat; repo at HEAD)",
-    run
-  );
-  const blockingResiduals = residuals.filter((risk) => risk.blocks);
-  const final = { ...pruned, residual_risks: [...pruned.residual_risks, ...blockingResiduals] };
-  // Compute coverage from the hotspots actually deep-reviewed (includes the tail
-  // backstop): unique changed-file paths that landed in any hotspot. By
-  // construction of the tail backstop this equals changedFiles.length, but we
-  // compute it rather than assume it.
-  const coveredFileCount = new Set(hotspots.flatMap((h) => h.files)).size;
-  const coverage = `${coveredFileCount}/${bundle.changedFiles.length} changed files deep-reviewed across ${hotspots.length} hotspot${hotspots.length === 1 ? "" : "s"}${tailAdded ? ", incl. tail-coverage" : ""}`;
-  return toReviewResult(final, run, `${mapResult.summary} — ${pruned.summary}`, merged, coverage);
+	const merged = dedup(all);
+	const candidateMerged: RawReview = {
+		summary: mapResult.summary,
+		findings: merged,
+		checked,
+		residual_risks: residuals,
+	};
+	const pruned = await runCritic(
+		candidateMerged,
+		bundle.patchStat || "(see git diff --stat; repo at HEAD)",
+		run,
+	);
+	const blockingResiduals = residuals.filter((risk) => risk.blocks);
+	const final = {
+		...pruned,
+		residual_risks: [...pruned.residual_risks, ...blockingResiduals],
+	};
+	// Compute coverage from the hotspots actually deep-reviewed (includes the tail
+	// backstop): unique changed-file paths that landed in any hotspot. By
+	// construction of the tail backstop this equals changedFiles.length, but we
+	// compute it rather than assume it.
+	const coveredFileCount = new Set(hotspots.flatMap((h) => h.files)).size;
+	const coverage = `${coveredFileCount}/${bundle.changedFiles.length} changed files deep-reviewed across ${hotspots.length} hotspot${hotspots.length === 1 ? "" : "s"}${tailAdded ? ", incl. tail-coverage" : ""}`;
+	return toReviewResult(
+		final,
+		run,
+		`${mapResult.summary} — ${pruned.summary}`,
+		merged,
+		coverage,
+	);
 }
 
 // Docs-only fast path: when every changed file is classified "docs" and the
@@ -294,35 +360,35 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
 // classify.ts rule order already routes workflow yml to "workflow", so CI files
 // can never ride this path.
 function isDocsOnlyFastPath(bundle: Bundle): boolean {
-  return (
-    bundle.changedFiles.length > 0 &&
-    bundle.changedFiles.every((f) => f.surface === "docs") &&
-    !process.env.NEEDLEFISH_NO_FAST_PATH
-  );
+	return (
+		bundle.changedFiles.length > 0 &&
+		bundle.changedFiles.every((f) => f.surface === "docs") &&
+		!process.env.NEEDLEFISH_NO_FAST_PATH
+	);
 }
 
 export async function review(
-  bundle: Bundle,
-  runnerOptions: RunnerOptions = {}
+	bundle: Bundle,
+	runnerOptions: RunnerOptions = {},
 ): Promise<ReviewResult> {
-  const startedAt = Date.now();
+	const startedAt = Date.now();
 
-  if (isDocsOnlyFastPath(bundle)) {
-    const paths = bundle.changedFiles.map((f) => f.path).join(", ");
-    return {
-      schemaVersion: REVIEW_RESULT_SCHEMA_VERSION,
-      verdict: "pass",
-      summary: `Docs-only change (${bundle.changedFiles.length} file(s)); model review skipped.`,
-      findings: [],
-      checked: [`FAST_PATH docs-only files=[${paths}]`],
-      residualRisks: [],
-      baseSha: bundle.baseSha,
-      headSha: bundle.headSha,
-      ...(bundle.reviewTarget ? { reviewTarget: bundle.reviewTarget } : {}),
-      totalDurationMs: Date.now() - startedAt,
-    };
-  }
+	if (isDocsOnlyFastPath(bundle)) {
+		const paths = bundle.changedFiles.map((f) => f.path).join(", ");
+		return {
+			schemaVersion: REVIEW_RESULT_SCHEMA_VERSION,
+			verdict: "pass",
+			summary: `Docs-only change (${bundle.changedFiles.length} file(s)); model review skipped.`,
+			findings: [],
+			checked: [`FAST_PATH docs-only files=[${paths}]`],
+			residualRisks: [],
+			baseSha: bundle.baseSha,
+			headSha: bundle.headSha,
+			...(bundle.reviewTarget ? { reviewTarget: bundle.reviewTarget } : {}),
+			totalDurationMs: Date.now() - startedAt,
+		};
+	}
 
-  const run: ReviewRun = { bundle, runnerOptions, stats: [], startedAt };
-  return bundle.deep || isLarge(bundle) ? reviewLarge(run) : reviewSmall(run);
+	const run: ReviewRun = { bundle, runnerOptions, stats: [], startedAt };
+	return bundle.deep || isLarge(bundle) ? reviewLarge(run) : reviewSmall(run);
 }

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -344,12 +344,12 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
 	};
 	// Compute coverage from the hotspots whose deep pass actually SUCCEEDED
 	// (includes the tail backstop). A failed pass's files were not reviewed —
-	// counting them would make the coverage line overstate exactly when it
-	// matters most; the failure itself is already a blocking residual.
-	const coveredFileCount = new Set(
-		hotspots.filter((_, i) => passes[i].ok).flatMap((h) => h.files),
-	).size;
-	const coverage = `${coveredFileCount}/${bundle.changedFiles.length} changed files deep-reviewed across ${hotspots.length} hotspot${hotspots.length === 1 ? "" : "s"}${tailAdded ? ", incl. tail-coverage" : ""}`;
+	// counting them (or their hotspot) would make the coverage line overstate
+	// exactly when it matters most; the failure itself is a blocking residual.
+	const okHotspots = hotspots.filter((_, i) => passes[i].ok);
+	const coveredFileCount = new Set(okHotspots.flatMap((h) => h.files)).size;
+	const tailOk = tailAdded && passes[passes.length - 1].ok;
+	const coverage = `${coveredFileCount}/${bundle.changedFiles.length} changed files deep-reviewed across ${okHotspots.length} hotspot${okHotspots.length === 1 ? "" : "s"}${tailOk ? ", incl. tail-coverage" : ""}`;
 	return toReviewResult(
 		final,
 		run,

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -294,7 +294,7 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
 				`deep:${h.name}`,
 				deepPrompt,
 				run,
-				(raw) => normalizeReview(raw),
+				parseUsableReview(`deep:${h.name}`),
 			);
 			return {
 				ok: true,

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -297,6 +297,7 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
 				(raw) => normalizeReview(raw),
 			);
 			return {
+				ok: true,
 				checked: [
 					`[${h.name}] ${res.summary || "(no summary)"}`,
 					...res.checked,
@@ -308,6 +309,7 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
 			if (isRunnerSafetyError(e)) throw e;
 			const msg = e instanceof Error ? e.message : String(e);
 			return {
+				ok: false,
 				checked: [`[${h.name}] DEEP PASS FAILED: ${msg.slice(0, 200)}`],
 				findings: [] as readonly Finding[],
 				residuals: [
@@ -340,11 +342,13 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
 		...pruned,
 		residual_risks: [...pruned.residual_risks, ...blockingResiduals],
 	};
-	// Compute coverage from the hotspots actually deep-reviewed (includes the tail
-	// backstop): unique changed-file paths that landed in any hotspot. By
-	// construction of the tail backstop this equals changedFiles.length, but we
-	// compute it rather than assume it.
-	const coveredFileCount = new Set(hotspots.flatMap((h) => h.files)).size;
+	// Compute coverage from the hotspots whose deep pass actually SUCCEEDED
+	// (includes the tail backstop). A failed pass's files were not reviewed —
+	// counting them would make the coverage line overstate exactly when it
+	// matters most; the failure itself is already a blocking residual.
+	const coveredFileCount = new Set(
+		hotspots.filter((_, i) => passes[i].ok).flatMap((h) => h.files),
+	).size;
 	const coverage = `${coveredFileCount}/${bundle.changedFiles.length} changed files deep-reviewed across ${hotspots.length} hotspot${hotspots.length === 1 ? "" : "s"}${tailAdded ? ", incl. tail-coverage" : ""}`;
 	return toReviewResult(
 		final,

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -161,7 +161,8 @@ function toReviewResult(
   raw: RawReview,
   run: ReviewRun,
   summary = raw.summary,
-  candidateFindings?: readonly Finding[]
+  candidateFindings?: readonly Finding[],
+  coverage?: string
 ): ReviewResult {
   const { bundle } = run;
   const verdict = deriveVerdict(raw.findings, raw.residual_risks);
@@ -177,6 +178,7 @@ function toReviewResult(
     ...(bundle.reviewTarget ? { reviewTarget: bundle.reviewTarget } : {}),
     ...(run.stats.length > 0 ? { stats: [...run.stats] } : {}),
     totalDurationMs: Date.now() - run.startedAt,
+    ...(coverage ? { coverage } : {}),
     ...(evalTraceOn() && candidateFindings ? { candidateFindings } : {}),
   };
 }
@@ -191,7 +193,8 @@ async function reviewSmall(run: ReviewRun): Promise<ReviewResult> {
     .replace("{{BUNDLE}}", () => JSON.stringify(meta, null, 2))
     .replace("{{PATCH}}", () => patch);
   const candidate = await runJsonPrompt("review", reviewPrompt, run, parseUsableReview("review"));
-  return toReviewResult(await runCritic(candidate, bundle.patch, run), run, undefined, candidate.findings);
+  const coverage = `full diff reviewed in one pass (${bundle.changedFiles.length} file${bundle.changedFiles.length === 1 ? "" : "s"})`;
+  return toReviewResult(await runCritic(candidate, bundle.patch, run), run, undefined, candidate.findings, coverage);
 }
 
 // Large PR: map (blast-radius survey, no diff text) -> deep per hotspot -> merge -> critic.
@@ -216,7 +219,9 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
   // hotspot so it still gets deep-reviewed (never silently skip a changed file).
   const covered = new Set(hotspots.flatMap((h) => h.files));
   const uncovered = bundle.changedFiles.map((f) => f.path).filter((p) => !covered.has(p));
+  let tailAdded = false;
   if (uncovered.length > 0) {
+    tailAdded = true;
     hotspots.push({
       name: "tail-coverage (files not mapped to a surface)",
       files: uncovered,
@@ -275,7 +280,13 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
   );
   const blockingResiduals = residuals.filter((risk) => risk.blocks);
   const final = { ...pruned, residual_risks: [...pruned.residual_risks, ...blockingResiduals] };
-  return toReviewResult(final, run, `${mapResult.summary} — ${pruned.summary}`, merged);
+  // Compute coverage from the hotspots actually deep-reviewed (includes the tail
+  // backstop): unique changed-file paths that landed in any hotspot. By
+  // construction of the tail backstop this equals changedFiles.length, but we
+  // compute it rather than assume it.
+  const coveredFileCount = new Set(hotspots.flatMap((h) => h.files)).size;
+  const coverage = `${coveredFileCount}/${bundle.changedFiles.length} changed files deep-reviewed across ${hotspots.length} hotspot${hotspots.length === 1 ? "" : "s"}${tailAdded ? ", incl. tail-coverage" : ""}`;
+  return toReviewResult(final, run, `${mapResult.summary} — ${pruned.summary}`, merged, coverage);
 }
 
 // Docs-only fast path: when every changed file is classified "docs" and the

--- a/src/shared/render.test.ts
+++ b/src/shared/render.test.ts
@@ -135,10 +135,12 @@ test("renderMarkdown adds blocking and nit counts directly below the headline", 
 			finding("P3", "three", "d.ts"),
 		]),
 	);
-	assert.match(four, /^[^\n]+\n\*\*3 blocking\*\* · 1 nit\n/);
+	// Red-reason headline replaces the summary on line 1; the summary
+	// first-sentence then carries to line 2, counts follow on line 3.
+	assert.match(four, /^[^\n]+\nFirst sentence\.\n\*\*3 blocking\*\* · 1 nit\n/);
 
 	const blocking = renderMarkdown(baseResult([finding("P2", "one", "a.ts")]));
-	assert.match(blocking, /^[^\n]+\n\*\*1 blocking\*\*\n/);
+	assert.match(blocking, /^[^\n]+\nFirst sentence\.\n\*\*1 blocking\*\*\n/);
 
 	const nits = renderMarkdown(
 		baseResult([finding("P3", "one", "a.ts"), finding("P3", "two", "b.ts")]),
@@ -151,17 +153,18 @@ test("renderMarkdown adds blocking and nit counts directly below the headline", 
 
 test("renderMarkdown shows compact re-review deltas only for positive counts", () => {
 	const result = baseResult([finding("P2", "one", "a.ts")]);
+	// Summary occupies line 2 (reason replaced the headline); counts then delta.
 	assert.match(
 		renderMarkdown(result, { resolvedCount: 2 }),
-		/^([^\n]+\n)\*\*1 blocking\*\*\n✅ 2 resolved\n/,
+		/^([^\n]+\n)First sentence\.\n\*\*1 blocking\*\*\n✅ 2 resolved\n/,
 	);
 	assert.match(
 		renderMarkdown(result, { newCount: 1 }),
-		/^([^\n]+\n)\*\*1 blocking\*\*\n🆕 1 new\n/,
+		/^([^\n]+\n)First sentence\.\n\*\*1 blocking\*\*\n🆕 1 new\n/,
 	);
 	assert.match(
 		renderMarkdown(result, { resolvedCount: 2, newCount: 1 }),
-		/^([^\n]+\n)\*\*1 blocking\*\*\n✅ 2 resolved · 🆕 1 new\n/,
+		/^([^\n]+\n)First sentence\.\n\*\*1 blocking\*\*\n✅ 2 resolved · 🆕 1 new\n/,
 	);
 	assert.doesNotMatch(
 		renderMarkdown(result, { resolvedCount: 0, newCount: 0 }),

--- a/src/shared/render.test.ts
+++ b/src/shared/render.test.ts
@@ -256,3 +256,49 @@ test("renderMarkdown preserves review target, round state options, marker, and s
 	);
 	assert.match(markdown, /<!-- state -->\n$/);
 });
+
+test("renderMarkdown red-reason headline names the top blocking finding and its location", () => {
+	const markdown = renderMarkdown(
+		baseResult([
+			finding("P3", "nit only", "nit.ts"),
+			finding("P1", "Top blocking bug", "src/auth.ts", {
+				lineStart: 88,
+				lineEnd: 90,
+			}),
+			finding("P2", "other blocker", "src/util.ts", { lineStart: 4 }),
+		]),
+	);
+	const firstLine = markdown.split("\n")[0];
+	// The most severe (P1) finding is the top after the severity sort.
+	assert.match(firstLine, /Top blocking bug/);
+	assert.match(firstLine, /src\/auth\.ts:88/);
+	// Multiple blocking findings get the (+N more) suffix.
+	assert.match(firstLine, /\(\+1 more\)/);
+});
+
+test("renderMarkdown needs_human headline carries the blocking residual and a visible why-not-green line", () => {
+	const markdown = renderMarkdown({
+		...baseResult([], "needs_human"),
+		residualRisks: [
+			{ text: "deep review of the auth hotspot failed; not fully covered", blocks: true },
+		],
+	});
+	const firstLine = markdown.split("\n")[0];
+	assert.match(firstLine, /NEEDS HUMAN 👀 — deep review of the auth hotspot failed/);
+	// A non-collapsed ⛔ line must appear before the first <details>.
+	const detailsIdx = markdown.indexOf("<details>");
+	assert.ok(detailsIdx > 0, "expected a collapsed details section");
+	const beforeDetails = markdown.slice(0, detailsIdx);
+	assert.match(beforeDetails, /^- ⛔ .*not fully covered/m);
+	assert.match(beforeDetails, /\*\*⛔ Why not green:\*\*/);
+});
+
+test("renderMarkdown renders the coverage line visibly outside any collapsed section", () => {
+	const markdown = renderMarkdown({
+		...baseResult([], "pass"),
+		coverage: "3/3 changed files deep-reviewed across 2 hotspots, incl. tail-coverage",
+	});
+	const detailsIdx = markdown.indexOf("<details>");
+	const beforeDetails = detailsIdx > 0 ? markdown.slice(0, detailsIdx) : markdown;
+	assert.match(beforeDetails, /^Coverage: 3\/3 changed files/m);
+});

--- a/src/shared/render.test.ts
+++ b/src/shared/render.test.ts
@@ -280,11 +280,17 @@ test("renderMarkdown needs_human headline carries the blocking residual and a vi
 	const markdown = renderMarkdown({
 		...baseResult([], "needs_human"),
 		residualRisks: [
-			{ text: "deep review of the auth hotspot failed; not fully covered", blocks: true },
+			{
+				text: "deep review of the auth hotspot failed; not fully covered",
+				blocks: true,
+			},
 		],
 	});
 	const firstLine = markdown.split("\n")[0];
-	assert.match(firstLine, /NEEDS HUMAN 👀 — deep review of the auth hotspot failed/);
+	assert.match(
+		firstLine,
+		/NEEDS HUMAN 👀 — deep review of the auth hotspot failed/,
+	);
 	// A non-collapsed ⛔ line must appear before the first <details>.
 	const detailsIdx = markdown.indexOf("<details>");
 	assert.ok(detailsIdx > 0, "expected a collapsed details section");
@@ -296,9 +302,14 @@ test("renderMarkdown needs_human headline carries the blocking residual and a vi
 test("renderMarkdown renders the coverage line visibly outside any collapsed section", () => {
 	const markdown = renderMarkdown({
 		...baseResult([], "pass"),
-		coverage: "3/3 changed files deep-reviewed across 2 hotspots, incl. tail-coverage",
+		coverage:
+			"3/3 changed files deep-reviewed across 2 hotspots, incl. tail-coverage",
 	});
 	const detailsIdx = markdown.indexOf("<details>");
-	const beforeDetails = detailsIdx > 0 ? markdown.slice(0, detailsIdx) : markdown;
+	const beforeDetails =
+		detailsIdx > 0 ? markdown.slice(0, detailsIdx) : markdown;
 	assert.match(beforeDetails, /^Coverage: 3\/3 changed files/m);
+	// Preceded by a blank line: otherwise GFM lazy-continues the previous
+	// bullet list / paragraph and the coverage line is absorbed into it.
+	assert.match(markdown, /\n\nCoverage: /);
 });

--- a/src/shared/render.test.ts
+++ b/src/shared/render.test.ts
@@ -245,7 +245,12 @@ test("renderMarkdown preserves review target, round state options, marker, and s
 		stateMarker: "<!-- state -->",
 	});
 
-	assert.match(markdown, /^CHANGES REQUESTED ⚠️[^\n]*\n✅ 1 resolved\n/);
+	// The still-open blocker now feeds the red-reason headline (fresh set is
+	// empty); summary drops to line 2, delta follows.
+	assert.match(
+		markdown,
+		/^CHANGES REQUESTED ⚠️ — 1 blocking: still broken \(open\.ts:1\)\nFirst sentence\.\n✅ 1 resolved\n/,
+	);
 	assert.match(markdown, /Review target: local base\.\.head/);
 	assert.match(markdown, /PR context: #24 metadata only/);
 	assert.match(markdown, /<summary>Still open \(1\)<\/summary>/);
@@ -312,4 +317,22 @@ test("renderMarkdown renders the coverage line visibly outside any collapsed sec
 	// Preceded by a blank line: otherwise GFM lazy-continues the previous
 	// bullet list / paragraph and the coverage line is absorbed into it.
 	assert.match(markdown, /\n\nCoverage: /);
+});
+
+test("renderMarkdown re-review headline keeps the reason when all blockers are still open (none fresh)", () => {
+	// Re-review rounds render with findings = FRESH only; when every blocker
+	// is still-open the verdict stays red and the first line must still name
+	// the reason from the open set instead of falling back to the summary.
+	const open = finding("P1", "auth bypass persists", "src/auth.ts", {
+		lineStart: 42,
+		lineEnd: 42,
+	});
+	const markdown = renderMarkdown(baseResult([], "changes_requested"), {
+		openFindings: [open],
+	});
+	const first = markdown.split("\n")[0];
+	assert.match(
+		first,
+		/^CHANGES REQUESTED ⚠️ — 1 blocking: auth bypass persists \(src\/auth\.ts:42\)/,
+	);
 });

--- a/src/shared/render.ts
+++ b/src/shared/render.ts
@@ -95,6 +95,9 @@ export function renderMarkdown(
 	}
 
 	if (result.coverage) {
+		// Blank line first: without it this line lazy-continues the preceding
+		// ⛔ bullet list (or counts paragraph) in GFM.
+		lines.push("");
 		lines.push(`Coverage: ${result.coverage}`);
 	}
 

--- a/src/shared/render.ts
+++ b/src/shared/render.ts
@@ -57,6 +57,10 @@ export function renderMarkdown(
 	}
 	if (delta.length > 0) lines.push(delta.join(" · "));
 
+	if (result.coverage) {
+		lines.push(`Coverage: ${result.coverage}`);
+	}
+
 	if (result.reviewTarget) {
 		lines.push("");
 		lines.push(...result.reviewTarget.split("\n"));

--- a/src/shared/render.ts
+++ b/src/shared/render.ts
@@ -33,14 +33,42 @@ export function renderMarkdown(
 ): string {
 	const lines: string[] = [];
 	const summary = firstSentence(result.summary);
-	lines.push(
-		`${VERDICT_HEADLINE[result.verdict]}${summary ? ` — ${summary}` : ""}`,
-	);
 
-	const blockingCount = result.findings.filter(
+	const findings = [...result.findings].sort(
+		(a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity],
+	);
+	const blockingCount = findings.filter(
 		(finding) => finding.severity !== "P3",
 	).length;
-	const nitCount = result.findings.length - blockingCount;
+	const blockingResiduals = result.residualRisks.filter((risk) => risk.blocks);
+
+	// Red-reason headline: when the verdict is red, the first line states WHY
+	// (top blocking finding / first blocking residual) instead of the summary.
+	// Defensive: if the reason data is absent, fall back to the summary headline.
+	let headlineReplaced = false;
+	if (result.verdict === "changes_requested" && blockingCount > 0) {
+		const top = findings[0];
+		const title = truncate(oneLine(top.title), 120);
+		let headline = `CHANGES REQUESTED ⚠️ — ${blockingCount} blocking: ${title}`;
+		if (top.file) headline += ` (${top.file}:${top.lineStart})`;
+		if (blockingCount > 1) headline += ` (+${blockingCount - 1} more)`;
+		lines.push(headline);
+		headlineReplaced = true;
+	} else if (result.verdict === "needs_human" && blockingResiduals.length > 0) {
+		const text = truncate(oneLine(blockingResiduals[0].text), 160);
+		lines.push(`NEEDS HUMAN 👀 — ${text}`);
+		headlineReplaced = true;
+	} else {
+		lines.push(
+			`${VERDICT_HEADLINE[result.verdict]}${summary ? ` — ${summary}` : ""}`,
+		);
+	}
+
+	// When the headline carried the reason, the summary first-sentence goes on
+	// its own line so the information is not lost.
+	if (headlineReplaced && summary) lines.push(summary);
+
+	const nitCount = findings.length - blockingCount;
 	const findingCounts: string[] = [];
 	if (blockingCount > 0) findingCounts.push(`**${blockingCount} blocking**`);
 	if (nitCount > 0) {
@@ -57,6 +85,15 @@ export function renderMarkdown(
 	}
 	if (delta.length > 0) lines.push(delta.join(" · "));
 
+	// Visible (non-collapsed) explanation of why the verdict is not green.
+	if (blockingResiduals.length > 0) {
+		lines.push("");
+		lines.push("**⛔ Why not green:**");
+		for (const risk of blockingResiduals) {
+			lines.push(`- ⛔ ${oneLine(risk.text)}`);
+		}
+	}
+
 	if (result.coverage) {
 		lines.push(`Coverage: ${result.coverage}`);
 	}
@@ -66,9 +103,6 @@ export function renderMarkdown(
 		lines.push(...result.reviewTarget.split("\n"));
 	}
 
-	const findings = [...result.findings].sort(
-		(a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity],
-	);
 	const inlinedSet = opts?.inlinedFindings;
 
 	lines.push("");
@@ -194,6 +228,10 @@ function firstSentence(summary: string): string {
 
 function oneLine(text: string): string {
 	return text.replace(/\s*\r?\n\s*/g, " ");
+}
+
+function truncate(text: string, max: number): string {
+	return text.length > max ? text.slice(0, max) : text;
 }
 
 function tableText(text: string): string {

--- a/src/shared/render.ts
+++ b/src/shared/render.ts
@@ -42,16 +42,28 @@ export function renderMarkdown(
 	).length;
 	const blockingResiduals = result.residualRisks.filter((risk) => risk.blocks);
 
+	// Reason pool for the red headline: on re-review rounds `result.findings`
+	// holds only the FRESH findings, but the verdict is computed from the full
+	// set — a round where every blocker is still-open (none fresh) must still
+	// name its reason, so still-open findings join the pool.
+	const headlineFindings = [...findings, ...(opts?.openFindings ?? [])].sort(
+		(a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity],
+	);
+	const headlineBlockingCount = headlineFindings.filter(
+		(finding) => finding.severity !== "P3",
+	).length;
+
 	// Red-reason headline: when the verdict is red, the first line states WHY
 	// (top blocking finding / first blocking residual) instead of the summary.
 	// Defensive: if the reason data is absent, fall back to the summary headline.
 	let headlineReplaced = false;
-	if (result.verdict === "changes_requested" && blockingCount > 0) {
-		const top = findings[0];
+	if (result.verdict === "changes_requested" && headlineBlockingCount > 0) {
+		const top = headlineFindings[0];
 		const title = truncate(oneLine(top.title), 120);
-		let headline = `CHANGES REQUESTED ⚠️ — ${blockingCount} blocking: ${title}`;
+		let headline = `CHANGES REQUESTED ⚠️ — ${headlineBlockingCount} blocking: ${title}`;
 		if (top.file) headline += ` (${top.file}:${top.lineStart})`;
-		if (blockingCount > 1) headline += ` (+${blockingCount - 1} more)`;
+		if (headlineBlockingCount > 1)
+			headline += ` (+${headlineBlockingCount - 1} more)`;
 		lines.push(headline);
 		headlineReplaced = true;
 	} else if (result.verdict === "needs_human" && blockingResiduals.length > 0) {

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -93,6 +93,9 @@ export interface ReviewResult {
   readonly reviewTarget?: string;
   readonly stats?: readonly RunStat[];
   readonly totalDurationMs?: number;
+  // Preformatted one-line coverage summary rendered visibly below the counts
+  // (e.g. "3/3 changed files deep-reviewed across 2 hotspots, incl. tail-coverage").
+  readonly coverage?: string;
   // Eval-only tracing: the candidate findings as they stood BEFORE runCritic.
   // Populated only when NEEDLEFISH_EVAL_TRACE is set; never shipped to users.
   readonly candidateFindings?: readonly Finding[];

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -5,124 +5,128 @@ export const REVIEW_RESULT_SCHEMA_VERSION = 1;
 export type Severity = "P0" | "P1" | "P2" | "P3";
 
 export type Category =
-  | "bug"
-  | "contract"
-  | "duplicate"
-  | "runtime"
-  | "security"
-  | "validation";
+	| "bug"
+	| "contract"
+	| "duplicate"
+	| "runtime"
+	| "security"
+	| "validation";
 
 export type Surface =
-  | "public-api"
-  | "cli"
-  | "config"
-  | "schema"
-  | "workflow"
-  | "dependency"
-  | "test"
-  | "docs"
-  | "source";
+	| "public-api"
+	| "cli"
+	| "config"
+	| "schema"
+	| "workflow"
+	| "dependency"
+	| "test"
+	| "docs"
+	| "source";
 
 export type Verdict = "pass" | "changes_requested" | "needs_human";
 
 export interface ChangedFile {
-  readonly path: string;
-  readonly surface: Surface;
+	readonly path: string;
+	readonly surface: Surface;
 }
 
 export interface PrMeta {
-  readonly number: number;
-  readonly title: string;
-  readonly body: string | null;
-  readonly comments: readonly string[];
-  readonly reviews: readonly string[];
-  readonly checks: readonly { readonly name: string; readonly status: string; readonly conclusion: string | null }[];
+	readonly number: number;
+	readonly title: string;
+	readonly body: string | null;
+	readonly comments: readonly string[];
+	readonly reviews: readonly string[];
+	readonly checks: readonly {
+		readonly name: string;
+		readonly status: string;
+		readonly conclusion: string | null;
+	}[];
 }
 
 export interface Bundle {
-  readonly repoPath: string;
-  readonly baseSha: string;
-  readonly headSha: string;
-  readonly patch: string;
-  readonly patchStat: string;
-  readonly changedFiles: readonly ChangedFile[];
-  readonly reviewTarget?: string;
-  readonly agentsMd: string;
-  readonly prMeta: PrMeta | null;
-  readonly deep: boolean;
-  readonly focus: string | null;
+	readonly repoPath: string;
+	readonly baseSha: string;
+	readonly headSha: string;
+	readonly patch: string;
+	readonly patchStat: string;
+	readonly changedFiles: readonly ChangedFile[];
+	readonly reviewTarget?: string;
+	readonly agentsMd: string;
+	readonly prMeta: PrMeta | null;
+	readonly deep: boolean;
+	readonly focus: string | null;
 }
 
 export interface Finding {
-  readonly severity: Severity;
-  readonly title: string;
-  readonly category: Category;
-  readonly file: string;
-  readonly lineStart: number;
-  readonly lineEnd: number;
-  readonly confidence: number;
-  readonly whyItBreaks: string;
-  readonly suggestedFix: string;
-  readonly validation: string;
-  readonly consumerFile?: string;
-  readonly consumerLine?: number;
-  readonly replacement?: { readonly lines: readonly string[] };
+	readonly severity: Severity;
+	readonly title: string;
+	readonly category: Category;
+	readonly file: string;
+	readonly lineStart: number;
+	readonly lineEnd: number;
+	readonly confidence: number;
+	readonly whyItBreaks: string;
+	readonly suggestedFix: string;
+	readonly validation: string;
+	readonly consumerFile?: string;
+	readonly consumerLine?: number;
+	readonly replacement?: { readonly lines: readonly string[] };
 }
 
 export interface ResidualRisk {
-  readonly text: string;
-  readonly blocks: boolean;
+	readonly text: string;
+	readonly blocks: boolean;
 }
 
 export interface RawReview {
-  readonly summary: string;
-  readonly findings: readonly Finding[];
-  readonly checked: readonly string[];
-  readonly residual_risks: readonly ResidualRisk[];
+	readonly summary: string;
+	readonly findings: readonly Finding[];
+	readonly checked: readonly string[];
+	readonly residual_risks: readonly ResidualRisk[];
 }
 
 export interface ReviewResult {
-  readonly schemaVersion: typeof REVIEW_RESULT_SCHEMA_VERSION;
-  readonly verdict: Verdict;
-  readonly summary: string;
-  readonly findings: readonly Finding[];
-  readonly checked: readonly string[];
-  readonly residualRisks: readonly ResidualRisk[];
-  readonly baseSha: string;
-  readonly headSha: string;
-  readonly reviewTarget?: string;
-  readonly stats?: readonly RunStat[];
-  readonly totalDurationMs?: number;
-  // Preformatted one-line coverage summary rendered visibly below the counts
-  // (e.g. "3/3 changed files deep-reviewed across 2 hotspots, incl. tail-coverage").
-  readonly coverage?: string;
-  // Eval-only tracing: the candidate findings as they stood BEFORE runCritic.
-  // Populated only when NEEDLEFISH_EVAL_TRACE is set; never shipped to users.
-  readonly candidateFindings?: readonly Finding[];
+	readonly schemaVersion: typeof REVIEW_RESULT_SCHEMA_VERSION;
+	readonly verdict: Verdict;
+	readonly summary: string;
+	readonly findings: readonly Finding[];
+	readonly checked: readonly string[];
+	readonly residualRisks: readonly ResidualRisk[];
+	readonly baseSha: string;
+	readonly headSha: string;
+	readonly reviewTarget?: string;
+	readonly stats?: readonly RunStat[];
+	readonly totalDurationMs?: number;
+	// Preformatted one-line coverage summary rendered visibly below the counts
+	// (e.g. "3/3 changed files deep-reviewed across 2 hotspots, incl. tail-coverage").
+	readonly coverage?: string;
+	// Eval-only tracing: the candidate findings as they stood BEFORE runCritic.
+	// Populated only when NEEDLEFISH_EVAL_TRACE is set; never shipped to users.
+	readonly candidateFindings?: readonly Finding[];
 }
 
 export function serializeReviewResult(result: ReviewResult): string {
-  const json = JSON.stringify(result, null, 2);
-  if (!json) throw new Error("ReviewResult serialization failed");
-  return `${json}\n`;
+	const json = JSON.stringify(result, null, 2);
+	if (!json) throw new Error("ReviewResult serialization failed");
+	return `${json}\n`;
 }
 
 export interface RiskEdge {
-  readonly producer: string;
-  readonly consumerFile: string;
-  readonly consumerLine: number;
-  readonly why: string;
+	readonly producer: string;
+	readonly consumerFile: string;
+	readonly consumerLine: number;
+	readonly why: string;
 }
 
 export interface Hotspot {
-  readonly name: string;
-  readonly files: readonly string[];
-  readonly why: string;
-  readonly risk: "high" | "med" | "low";
-  readonly edges: readonly RiskEdge[];
+	readonly name: string;
+	readonly files: readonly string[];
+	readonly why: string;
+	readonly risk: "high" | "med" | "low";
+	readonly edges: readonly RiskEdge[];
 }
 
 export interface MapResult {
-  readonly summary: string;
-  readonly hotspots: readonly Hotspot[];
+	readonly summary: string;
+	readonly hotspots: readonly Hotspot[];
 }


### PR DESCRIPTION
Phase 1 of plans/007-bot-review-methodology-v2.md (M1 + M5 + M6). Adapter/render layer only — no prompt or verdict-semantics changes.

## What changes

- **Red explains itself in the first line**: `CHANGES REQUESTED ⚠️ — N blocking: <top finding> (file:line)`; needs_human leads with the blocking residual; the check-run title carries the same reason. A visible `⛔ Why not green:` section joins the collapsed residual view.
- **Review errors post a PR comment**: a red X from an infra failure now says so in the timeline ("FAILED TO RUN — not a code verdict"), fail-soft.
- **Re-reviews post a round comment** (body edits don't notify): resolved/open/new counts + top open finding; previous round comments are minimized (GraphQL, paginated scan, fail-soft) BEFORE posting, so a round never sweeps up its own comment.
- **Coverage line always visible**: small path "full diff reviewed in one pass (N files)"; large path "X/Y changed files deep-reviewed across H hotspots, incl. tail-coverage".

## Verification

- 367/367 tests, typecheck clean; lint carries only the 4 pre-existing baseline errors.
- 8 invariant tests, each revert-checked (behavior removed → test fails), incl. minimize-before-post ordering across 3 rounds and verdict-survives-failing-cosmetic-POST.
- Independent read-only review: 1 P2 (round-comment fail-soft) found and fixed; P3s fixed (--paginate) or consciously deferred (bot-author filter under PAT; fence escaping matches the existing postCheck pattern).
- Eval regression x3 on BOTH lanes (grok-4.5 xhigh, gpt-5.6-sol medium), full 84-fixture set: drifts within noise, opposite directions per lane, stable-miss sets identical to baseline — behavior-neutral (RESULTS.md 2026-07-13 entry).