### PR TITLE
fix(workflow): keep review sandboxes in runner temp

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -132,6 +132,44 @@ jobs:
         if: steps.refs.outputs.skip == 'true'
         run: echo "${{ steps.refs.outputs.skip_reason }}"
 
+      - name: Configure Needlefish temp storage
+        if: steps.refs.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+          temp_root="$RUNNER_TEMP/needlefish"
+          mkdir -p "$temp_root"
+
+          report_capacity_failure() {
+            echo "Needlefish temp preflight failed: $1" >&2
+            df -hT -- "$temp_root" >&2 || true
+            df -i -- "$temp_root" >&2 || true
+            exit 1
+          }
+
+          space_df="$(df -Pk -- "$temp_root")" || report_capacity_failure "cannot inspect capacity"
+          available_kib="$(awk 'NR == 2 { print $4 }' <<< "$space_df")"
+          if [[ ! "$available_kib" =~ ^[0-9]+$ ]]; then
+            report_capacity_failure "invalid capacity data"
+          fi
+          if (( available_kib < 2097152 )); then
+            report_capacity_failure "less than 2 GiB available"
+          fi
+
+          inode_df="$(df -Pi -- "$temp_root")" || report_capacity_failure "cannot inspect inodes"
+          read -r inode_total inode_free <<< "$(awk 'NR == 2 { print $2, $4 }' <<< "$inode_df")"
+          if [[ ! "$inode_total" =~ ^[0-9]+$ || ! "$inode_free" =~ ^[0-9]+$ ]]; then
+            report_capacity_failure "invalid inode data"
+          fi
+          if (( inode_total == 0 )); then
+            report_capacity_failure "invalid inode data"
+          fi
+          if (( inode_free * 100 < inode_total * 10 )); then
+            report_capacity_failure "less than 10% inodes free"
+          fi
+
+          echo "TMPDIR=$temp_root" >> "$GITHUB_ENV"
+
       - name: Verify Needlefish release
         if: steps.refs.outputs.skip != 'true'
         env:

--- a/scripts/review-workflow-temp.test.mjs
+++ b/scripts/review-workflow-temp.test.mjs
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const workflow = readFileSync(".github/workflows/review.yml", "utf8");
+const configureStep = workflow.match(
+	/      - name: Configure Needlefish temp storage\n([\s\S]*?)(?=\n      - name:)/,
+);
+assert.ok(configureStep, "Configure Needlefish temp storage step must exist");
+const runBlock = configureStep[1].match(/        run: \|\n([\s\S]*)/);
+assert.ok(runBlock, "Configure Needlefish temp storage must have a run block");
+const script = runBlock[1]
+	.split("\n")
+	.map((line) => line.replace(/^          /, ""))
+	.join("\n");
+
+function runPreflight({
+	spaceAvailableKib = "2097152",
+	inodeTotal = "100",
+	inodeFree = "10",
+	dfFailure = "",
+} = {}) {
+	const root = mkdtempSync(join(tmpdir(), "needlefish-workflow-temp-"));
+	const runnerTemp = join(root, "runner temp with spaces");
+	const fakeBin = join(root, "fake bin");
+	const githubEnv = join(root, "github-env");
+	const dfLog = join(root, "df.log");
+	mkdirSync(runnerTemp);
+	mkdirSync(fakeBin);
+	writeFileSync(
+		join(fakeBin, "df"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+for arg in "$@"; do printf '<%s>\\n' "$arg" >> "$DF_LOG"; done
+if [[ "$DF_FAILURE" == "$1" ]]; then exit 1; fi
+case "$1" in
+  -Pk)
+    printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'
+    printf '/dev/test 4194304 0 %s 0%% %s\\n' "$DF_SPACE_AVAILABLE" "$3"
+    ;;
+  -Pi)
+    printf 'Filesystem Inodes IUsed IFree IUse%% Mounted on\\n'
+    printf '/dev/test %s 0 %s 0%% %s\\n' "$DF_INODE_TOTAL" "$DF_INODE_FREE" "$3"
+    ;;
+  -hT|-i)
+    printf 'diagnostic %s %s\\n' "$1" "$3"
+    ;;
+  *) exit 64 ;;
+esac
+`,
+	);
+	chmodSync(join(fakeBin, "df"), 0o755);
+
+	const result = spawnSync("bash", ["-c", script], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			DF_FAILURE: dfFailure,
+			DF_INODE_FREE: inodeFree,
+			DF_INODE_TOTAL: inodeTotal,
+			DF_LOG: dfLog,
+			DF_SPACE_AVAILABLE: spaceAvailableKib,
+			GITHUB_ENV: githubEnv,
+			PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+			RUNNER_TEMP: runnerTemp,
+		},
+	});
+	const output = {
+		...result,
+		dfLog: existsSync(dfLog) ? readFileSync(dfLog, "utf8") : "",
+		githubEnv: existsSync(githubEnv) ? readFileSync(githubEnv, "utf8") : "",
+		tempRoot: join(runnerTemp, "needlefish"),
+	};
+	rmSync(root, { recursive: true, force: true });
+	return output;
+}
+
+test("temp setup runs before checkout with the existing skip guard", () => {
+	const reportIndex = workflow.indexOf("      - name: Report skipped PR");
+	const configureIndex = workflow.indexOf(
+		"      - name: Configure Needlefish temp storage",
+	);
+	const checkoutIndex = workflow.indexOf(
+		"      - name: Checkout review target (PR head)",
+	);
+
+	assert.ok(reportIndex < configureIndex);
+	assert.ok(configureIndex < checkoutIndex);
+	assert.match(
+		configureStep[0],
+		/^      - name: Configure Needlefish temp storage\n        if: steps\.refs\.outputs\.skip != 'true'$/m,
+	);
+});
+
+test("temp setup is fail-closed and exports only after preflight", () => {
+	assert.match(script, /temp_root="\$RUNNER_TEMP\/needlefish"/);
+	const mkdirIndex = script.indexOf('mkdir -p "$temp_root"');
+	const exportIndex = script.indexOf('>> "$GITHUB_ENV"');
+	assert.notEqual(mkdirIndex, -1);
+	assert.notEqual(exportIndex, -1);
+	assert.ok(mkdirIndex < exportIndex);
+	assert.doesNotMatch(script, /\/(?:home|mnt|tmp)(?:\/|\b)/);
+	assert.doesNotMatch(script, /os\.tmpdir|TMPDIR:-|\/tmp/);
+});
+
+test("temp preflight accepts the exact capacity boundaries and preserves spaces", () => {
+	const result = runPreflight();
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.githubEnv, `TMPDIR=${result.tempRoot}\n`);
+	assert.match(result.dfLog, new RegExp(`<${result.tempRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}>`));
+});
+
+test("temp preflight rejects insufficient capacity with disk diagnostics", () => {
+	const result = runPreflight({ spaceAvailableKib: "2097151" });
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /2 GiB/);
+	assert.match(result.dfLog, /<-hT>/);
+	assert.match(result.dfLog, /<-i>/);
+	assert.equal(result.githubEnv, "");
+});
+
+test("temp preflight rejects fewer than ten percent free inodes", () => {
+	const result = runPreflight({ inodeFree: "9" });
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /10%/);
+	assert.match(result.dfLog, /<-hT>/);
+	assert.match(result.dfLog, /<-i>/);
+	assert.equal(result.githubEnv, "");
+});
+
+test("temp preflight fails closed when df cannot inspect the target", () => {
+	const result = runPreflight({ dfFailure: "-Pk" });
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.dfLog, /<-hT>/);
+	assert.match(result.dfLog, /<-i>/);
+	assert.equal(result.githubEnv, "");
+});
+
+test("temp preflight fails closed on invalid capacity data", () => {
+	const result = runPreflight({ spaceAvailableKib: "unknown" });
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /invalid capacity data/);
+	assert.equal(result.githubEnv, "");
+});
+
+test("temp preflight fails closed on a zero inode total", () => {
+	const result = runPreflight({ inodeTotal: "0" });
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /invalid inode data/);
+	assert.equal(result.githubEnv, "");
+});


### PR DESCRIPTION
## Problem

Self-hosted review sandboxes used Node `/tmp`; canceled runs could strand large repositories and fill air-1 storage before checkout.

## Change

Configure `$RUNNER_TEMP/needlefish` before checkout, fail closed below 2 GiB or 10% free inodes, emit `df` diagnostics, and add a direct regression harness.

## Verification

- Focused workflow harness: 8/8
- `pnpm check`: passed
- `pnpm test`: 379/379 passed
- actionlint and YAML validation: passed
- Independent review: passed
- `pnpm lint`: four pre-existing untouched errors in `src/adapters/local.ts`, `src/shared/acp.test.ts`, and `src/shared/runner-process.test.ts`

## Scope

Reusable Linux self-hosted review workflow only; no application runner logic or deployment changes.