### PR TITLE
chore(release): 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.3 — 2026-07-15
+
+- Eval: add fail-closed anti-cheat guards with per-draw ephemeral HOME,
+  answer-key canaries, and full-transcript scanning.
+- Review: harden coverage, error-path, round-comment, and report-integrity
+  handling across local and GitHub review paths.
+- GitHub: support an explicit Grok 4.5 review lane and keep review sandboxes
+  on the runner's temporary storage.
+- Docs: document the self-hosted Grok 4.5 GitHub workflow.
+
 ## 0.3.2 — 2026-07-07
 
 - CLI: `--version` now reads the version from package.json at runtime instead of a hardcoded string (0.3.1 still reported "0.3.0").

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needlefish",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "description": "Strict local PR review agent.",


### PR DESCRIPTION
Release 0.3.3.

Includes the merged anti-cheat guards, review hardening, Grok 4.5 GitHub workflow support, and GitHub documentation updates.

Release gates passed locally: `pnpm check` and `pnpm test` (478 tests).