### PR TITLE
chore(release): 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.4 — 2026-07-15
+
+- Tests: isolate OpenCode's XDG config/data roots so ephemeral-home coverage is
+  deterministic on GitHub-hosted runners.
+
 ## 0.3.3 — 2026-07-15
 
 - Eval: add fail-closed anti-cheat guards with per-draw ephemeral HOME,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needlefish",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "description": "Strict local PR review agent.",

--- a/src/shared/codex-ephemeral-home.test.ts
+++ b/src/shared/codex-ephemeral-home.test.ts
@@ -368,6 +368,8 @@ test("prepareEphemeralHome: opencode with OPENAI_API_KEY treats HOME files as op
 	const previous = {
 		ephemeral: process.env.NEEDLEFISH_EPHEMERAL_HOME,
 		home: process.env.HOME,
+		xdgConfig: process.env.XDG_CONFIG_HOME,
+		xdgData: process.env.XDG_DATA_HOME,
 		key: process.env.OPENAI_API_KEY,
 	};
 	t.after(() => {
@@ -375,6 +377,10 @@ test("prepareEphemeralHome: opencode with OPENAI_API_KEY treats HOME files as op
 			delete process.env.NEEDLEFISH_EPHEMERAL_HOME;
 		else process.env.NEEDLEFISH_EPHEMERAL_HOME = previous.ephemeral;
 		process.env.HOME = previous.home;
+		if (previous.xdgConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+		else process.env.XDG_CONFIG_HOME = previous.xdgConfig;
+		if (previous.xdgData === undefined) delete process.env.XDG_DATA_HOME;
+		else process.env.XDG_DATA_HOME = previous.xdgData;
 		if (previous.key === undefined) delete process.env.OPENAI_API_KEY;
 		else process.env.OPENAI_API_KEY = previous.key;
 		rmSync(tmp, { recursive: true, force: true });
@@ -382,6 +388,8 @@ test("prepareEphemeralHome: opencode with OPENAI_API_KEY treats HOME files as op
 	});
 	process.env.HOME = fakeHome;
 	process.env.NEEDLEFISH_EPHEMERAL_HOME = "1";
+	delete process.env.XDG_CONFIG_HOME;
+	delete process.env.XDG_DATA_HOME;
 
 	// Without the provider key, the HOME credential store is required.
 	delete process.env.OPENAI_API_KEY;


### PR DESCRIPTION
Release 0.3.4.

- Fixes ephemeral OpenCode HOME tests when XDG_CONFIG_HOME/XDG_DATA_HOME are set on hosted runners.
- Bumps package metadata and changelog.

Local gates under isolated XDG roots: `pnpm check` and `pnpm test` (478 tests).