### PR TITLE
fix: strict boolean env gates + cross-round review-state fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ needlefish/
 - ESM only: `type: "module"`.
 - TypeScript is strict/no-emit with `moduleResolution: "bundler"`.
 - Use `unknown` at JSON/model/GitHub boundaries, then validate or narrow.
+- All NEEDLEFISH_* boolean flags go through `envFlagOn` in `src/shared/env.ts`; only `"1"` is on.
 - Keep tests beside the code path as `src/**/*.test.ts`.
 - Use Node built-ins (`node:test`, `assert/strict`, `spawnSync`, temp dirs) before adding dependencies.
 - Stub external CLIs in tests with temp scripts and env vars.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Runner: boolean environment flags now require exactly `1`; previously any
+  non-empty value enabled them.
+
 ## 0.3.4 — 2026-07-15
 
 - Tests: isolate OpenCode's XDG config/data roots so ephemeral-home coverage is

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -42,6 +42,7 @@ type FixtureOptions = {
 	readonly prNumber: number;
 	readonly rawReview: string;
 	readonly staleHeadAfterReview?: boolean;
+	readonly paginatePreviousReviewOnSecondPage?: boolean;
 	// Make POSTs to the issue-comments endpoint exit 1 (after logging the
 	// attempt) to exercise the fail-soft paths around cosmetic comments.
 	readonly failIssueCommentPosts?: boolean;
@@ -239,10 +240,11 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  }));",
 			"  process.exit(0);",
 			"}",
-			`if (args[1] === ${JSON.stringify(`repos/frankekn/needlefish/pulls/${opts.prNumber}/reviews`)}) {`,
+			`if (args[1] === '--paginate' && args[2] === '--slurp' && args[3] === ${JSON.stringify(`repos/frankekn/needlefish/pulls/${opts.prNumber}/reviews`)}) {`,
 			`  const reviewsPath = ${JSON.stringify(reviewsState)};`,
 			"  const reviews = fs.existsSync(reviewsPath) ? JSON.parse(fs.readFileSync(reviewsPath, 'utf8')) : [];",
-			"  process.stdout.write(JSON.stringify(reviews));",
+			`  const pages = ${JSON.stringify(opts.paginatePreviousReviewOnSecondPage === true)} ? [[], reviews] : [reviews];`,
+			"  process.stdout.write(JSON.stringify(pages));",
 			"  process.exit(0);",
 			"}",
 			"if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
@@ -928,6 +930,30 @@ test("runGithub re-reviews same head when recheck is true", async (t) => {
 	assert.ok(
 		putPost,
 		"round 2 with --recheck should still review and PUT-update",
+	);
+});
+
+test("runGithub finds a state-bearing review on the second paginated page", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 32,
+		paginatePreviousReviewOnSecondPage: true,
+		rawReview: JSON.stringify({
+			summary: "first round",
+			findings: [mkFinding({ title: "bug", lineStart: 1 })],
+			checked: ["checked"],
+			residual_risks: [],
+		}),
+	});
+
+	await runGithub(fixture.repo, 32, { timeoutMs: 1000 });
+	const round1Count = readPosts(fixture.postLog).length;
+
+	await runGithub(fixture.repo, 32, { timeoutMs: 1000 }, true);
+	const round2Posts = readPosts(fixture.postLog).slice(round1Count);
+
+	assert.ok(
+		round2Posts.some((post) => post.args.includes("PUT")),
+		"a state-bearing review on page 2 must be found for the update",
 	);
 });
 

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -69,7 +69,7 @@ test("runGithub normalizes relative repo paths before building prompts", async (
         })
       )}); process.exit(0); }`,
       "if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
-      "if (args[1] === 'repos/frankekn/needlefish/pulls/7/reviews') { process.stdout.write('[]'); process.exit(0); }",
+      "if (args[1] === '--paginate' && args[2] === '--slurp' && args[3] === 'repos/frankekn/needlefish/pulls/7/reviews') { process.stdout.write('[[]]'); process.exit(0); }",
       "process.stderr.write(`unexpected gh args ${args.join(' ')}`);",
       "process.exit(2);",
     ].join("\n")

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -239,20 +239,6 @@ export interface MatchResult {
 	readonly resolvedCount: number;
 }
 
-function countNewFindings(
-	prevKeys: readonly FindingKey[],
-	curr: readonly Finding[],
-): number {
-	return curr.filter(
-		(finding) =>
-			!prevKeys.some(
-				(previous) =>
-					finding.file === previous.file &&
-					finding.lineStart === previous.lineStart &&
-					normalizeTitle(finding.title) === previous.title,
-			),
-	).length;
-}
 
 export function matchFindings(
 	prevKeys: readonly FindingKey[],
@@ -733,7 +719,8 @@ export async function runGithub(
 				inlinedFindings: freshInlined,
 				openFindings: open,
 				resolvedCount,
-				newCount: countNewFindings(prev.state.findings, result.findings),
+				// New = not matched to a previous-round key.
+				newCount: fresh.length,
 				repoSlug: repo,
 			};
 			const body = renderMarkdown(freshResult, {

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -401,10 +401,19 @@ function findPreviousReview(
 	repo: string,
 	prNumber: number,
 ): { id: number; state: RoundState } | null {
-	const raw = ghJson(["api", `repos/${repo}/pulls/${prNumber}/reviews`]);
+	// --slurp: --paginate alone emits one JSON document PER PAGE (concatenated,
+	// unparseable); --slurp wraps the pages into a single outer array.
+	const raw = ghJson([
+		"api",
+		"--paginate",
+		"--slurp",
+		`repos/${repo}/pulls/${prNumber}/reviews`,
+	]);
 	if (!Array.isArray(raw)) return null;
-	for (let i = raw.length - 1; i >= 0; i--) {
-		const item = raw[i];
+	// flat(1) also tolerates a plain review list from stubs or older gh versions.
+	const reviews = raw.flat(1);
+	for (let i = reviews.length - 1; i >= 0; i--) {
+		const item = reviews[i];
 		if (!isRecord(item)) continue;
 		const state = parseState(stringField(item, "body"));
 		if (!state) continue;

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -1430,10 +1430,16 @@ test("review docs-only fast path skips all model calls", async (t) => {
 	const repo = initRepo(tmp);
 	const bin = path.join(tmp, "codex-bin.js");
 	const calls = path.join(tmp, "calls.log");
-	const previous = process.env.CODEX_BIN;
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		noFastPath: process.env.NEEDLEFISH_NO_FAST_PATH,
+	};
 	t.after(() => {
-		if (previous === undefined) delete process.env.CODEX_BIN;
-		else process.env.CODEX_BIN = previous;
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.noFastPath === undefined)
+			delete process.env.NEEDLEFISH_NO_FAST_PATH;
+		else process.env.NEEDLEFISH_NO_FAST_PATH = previous.noFastPath;
 		rmSync(tmp, { recursive: true, force: true });
 	});
 	writeFileSync(
@@ -1464,25 +1470,31 @@ test("review docs-only fast path skips all model calls", async (t) => {
 		focus: null,
 	};
 
-	const result = await review(bundle);
+	for (const noFastPath of [undefined, "0"] as const) {
+		if (noFastPath === undefined)
+			delete process.env.NEEDLEFISH_NO_FAST_PATH;
+		else process.env.NEEDLEFISH_NO_FAST_PATH = noFastPath;
 
-	assert.equal(result.verdict, "pass");
-	assert.deepEqual(result.findings, []);
-	assert.deepEqual(result.residualRisks, []);
-	assert.match(
-		result.summary,
-		/Docs-only change \(2 file\(s\)\); model review skipped\./,
-	);
-	assert.deepEqual(result.checked, [
-		"FAST_PATH docs-only files=[README.md, docs/guide.md]",
-	]);
-	assert.equal(result.stats, undefined, "no stats when model is not called");
-	assert.ok((result.totalDurationMs ?? -1) >= 0, "totalDurationMs must be set");
-	assert.equal(result.baseSha, "base");
-	assert.ok(
-		!existsSync(calls),
-		"runner must not be invoked for docs-only bundle",
-	);
+		const result = await review(bundle);
+
+		assert.equal(result.verdict, "pass");
+		assert.deepEqual(result.findings, []);
+		assert.deepEqual(result.residualRisks, []);
+		assert.match(
+			result.summary,
+			/Docs-only change \(2 file\(s\)\); model review skipped\./,
+		);
+		assert.deepEqual(result.checked, [
+			"FAST_PATH docs-only files=[README.md, docs/guide.md]",
+		]);
+		assert.equal(result.stats, undefined, "no stats when model is not called");
+		assert.ok((result.totalDurationMs ?? -1) >= 0, "totalDurationMs must be set");
+		assert.equal(result.baseSha, "base");
+		assert.ok(
+			!existsSync(calls),
+			"runner must not be invoked for docs-only bundle",
+		);
+	}
 });
 
 test("review mixed docs+source bundle still invokes the model", async (t) => {

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -9,6 +9,7 @@ import {
 	type RunnerOptions,
 	type RunStat,
 } from "../shared/runner.js";
+import { envFlagOn } from "../shared/env.js";
 import {
 	REVIEW_RESULT_SCHEMA_VERSION,
 	type Bundle,
@@ -656,7 +657,7 @@ function isDocsOnlyFastPath(bundle: Bundle): boolean {
 	return (
 		bundle.changedFiles.length > 0 &&
 		bundle.changedFiles.every((f) => f.surface === "docs") &&
-		!process.env.NEEDLEFISH_NO_FAST_PATH
+		!envFlagOn("NEEDLEFISH_NO_FAST_PATH")
 	);
 }
 

--- a/src/shared/codex-runners.test.ts
+++ b/src/shared/codex-runners.test.ts
@@ -351,7 +351,7 @@ test("runCodex reports opencode exit errors before parsing stdout", async (t) =>
 	);
 });
 
-test("runCodex passes grok plan permission mode by default", async () => {
+test("runCodex passes grok plan permission mode when unset or set to 0", async () => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
 	const repo = initRepo(tmp);
 	const bin = path.join(tmp, "grok-bin.js");
@@ -374,19 +374,23 @@ test("runCodex passes grok plan permission mode by default", async () => {
 		chmodSync(bin, 0o755);
 		process.env.GROK_BIN = bin;
 		process.env.NEEDLEFISH_RUNNER = "grok";
-		delete process.env.NEEDLEFISH_ALLOW_GROK_UNSANDBOXED;
+		for (const allowUnsandboxed of [undefined, "0"] as const) {
+			if (allowUnsandboxed === undefined)
+				delete process.env.NEEDLEFISH_ALLOW_GROK_UNSANDBOXED;
+			else process.env.NEEDLEFISH_ALLOW_GROK_UNSANDBOXED = allowUnsandboxed;
 
-		const output = await runCodex("prompt", {
-			repoPath: repo,
-			targetHeadSha: headSha(repo),
-			timeoutMs: 1000,
-		});
-		const args = readStringArray(argsPath);
+			const output = await runCodex("prompt", {
+				repoPath: repo,
+				targetHeadSha: headSha(repo),
+				timeoutMs: 1000,
+			});
+			const args = readStringArray(argsPath);
 
-		assert.equal(output, '{"ok":true}');
-		const flagIndex = args.indexOf("--permission-mode");
-		assert.notEqual(flagIndex, -1);
-		assert.equal(args[flagIndex + 1], "plan");
+			assert.equal(output, '{"ok":true}');
+			const flagIndex = args.indexOf("--permission-mode");
+			assert.notEqual(flagIndex, -1);
+			assert.equal(args[flagIndex + 1], "plan");
+		}
 	} finally {
 		if (previous.bin === undefined) delete process.env.GROK_BIN;
 		else process.env.GROK_BIN = previous.bin;
@@ -478,17 +482,21 @@ test("runCodex refuses the opencode runner without explicit opt-in", async (t) =
 	chmodSync(bin, 0o755);
 	process.env.OPENCODE_BIN = bin;
 	process.env.NEEDLEFISH_RUNNER = "opencode";
-	delete process.env.NEEDLEFISH_ALLOW_OPENCODE_RUNNER;
+	for (const allowOpenCode of [undefined, "0"] as const) {
+		if (allowOpenCode === undefined)
+			delete process.env.NEEDLEFISH_ALLOW_OPENCODE_RUNNER;
+		else process.env.NEEDLEFISH_ALLOW_OPENCODE_RUNNER = allowOpenCode;
 
-	await assert.rejects(
-		() =>
-			runCodex("prompt", {
-				repoPath: repo,
-				targetHeadSha: headSha(repo),
-				timeoutMs: 1000,
-			}),
-		/NEEDLEFISH_ALLOW_OPENCODE_RUNNER/,
-	);
+		await assert.rejects(
+			() =>
+				runCodex("prompt", {
+					repoPath: repo,
+					targetHeadSha: headSha(repo),
+					timeoutMs: 1000,
+				}),
+			/NEEDLEFISH_ALLOW_OPENCODE_RUNNER/,
+		);
+	}
 });
 
 test("runCodex allows opencode when explicitly opted in", async (t) => {
@@ -632,17 +640,21 @@ test("runCodex refuses the pi runner without explicit opt-in", async () => {
 		chmodSync(bin, 0o755);
 		process.env.PI_BIN = bin;
 		process.env.NEEDLEFISH_RUNNER = "pi";
-		delete process.env.NEEDLEFISH_ALLOW_PI_RUNNER;
+		for (const allowPi of [undefined, "0"] as const) {
+			if (allowPi === undefined)
+				delete process.env.NEEDLEFISH_ALLOW_PI_RUNNER;
+			else process.env.NEEDLEFISH_ALLOW_PI_RUNNER = allowPi;
 
-		await assert.rejects(
-			() =>
-				runCodex("prompt", {
-					repoPath: repo,
-					targetHeadSha: headSha(repo),
-					timeoutMs: 1000,
+			await assert.rejects(
+				() =>
+					runCodex("prompt", {
+						repoPath: repo,
+						targetHeadSha: headSha(repo),
+						timeoutMs: 1000,
 				}),
 			/NEEDLEFISH_ALLOW_PI_RUNNER/,
-		);
+			);
+		}
 	} finally {
 		if (previous.bin === undefined) delete process.env.PI_BIN;
 		else process.env.PI_BIN = previous.bin;

--- a/src/shared/codex.test.ts
+++ b/src/shared/codex.test.ts
@@ -28,12 +28,15 @@ test("runCodex retry backoff yields the event loop", async (t) => {
   const previous = {
     bin: process.env.CODEX_BIN,
     retry: process.env.CODEX_RETRY_MS,
+    noRetry: process.env.NEEDLEFISH_NO_RETRY,
   };
   t.after(() => {
     if (previous.bin === undefined) delete process.env.CODEX_BIN;
     else process.env.CODEX_BIN = previous.bin;
     if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
     else process.env.CODEX_RETRY_MS = previous.retry;
+    if (previous.noRetry === undefined) delete process.env.NEEDLEFISH_NO_RETRY;
+    else process.env.NEEDLEFISH_NO_RETRY = previous.noRetry;
     rmSync(tmp, { recursive: true, force: true });
   });
   writeFileSync(
@@ -55,20 +58,26 @@ test("runCodex retry backoff yields the event loop", async (t) => {
   process.env.CODEX_BIN = bin;
   process.env.CODEX_RETRY_MS = "50";
 
-  let timerFired = false;
-  setTimeout(() => {
-    timerFired = true;
-  }, 0);
+  for (const noRetry of [undefined, "0"] as const) {
+    if (noRetry === undefined) delete process.env.NEEDLEFISH_NO_RETRY;
+    else process.env.NEEDLEFISH_NO_RETRY = noRetry;
+    rmSync(state, { force: true });
 
-  const output = await runCodex("prompt", {
-    repoPath: repo,
-    runner: "codex",
-    targetHeadSha: headSha(repo),
-    timeoutMs: 1000,
-  });
+    let timerFired = false;
+    setTimeout(() => {
+      timerFired = true;
+    }, 0);
 
-  assert.equal(output, "{\"ok\":true}");
-  assert.equal(timerFired, true);
+    const output = await runCodex("prompt", {
+      repoPath: repo,
+      runner: "codex",
+      targetHeadSha: headSha(repo),
+      timeoutMs: 1000,
+    });
+
+    assert.equal(output, "{\"ok\":true}");
+    assert.equal(timerFired, true);
+  }
 });
 
 test("runCodex raw callbacks identify failed and successful runner attempts", async (t) => {

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -10,6 +10,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { runAcp } from "./acp.js";
+import { envFlagOn } from "./env.js";
 import {
 	parsePositiveInteger,
 	type RunnerName,
@@ -440,7 +441,7 @@ export async function runCodex(
 	opts: CodexOptions,
 ): Promise<string> {
 	const runner = resolveRunner(opts);
-	if (runner === "opencode" && !process.env.NEEDLEFISH_ALLOW_OPENCODE_RUNNER) {
+	if (runner === "opencode" && !envFlagOn("NEEDLEFISH_ALLOW_OPENCODE_RUNNER")) {
 		throw new Error(
 			"The opencode runner has no verified process-level sandbox restraint in headless mode " +
 				"(it executes tool calls with no permission gate) and must be explicitly enabled via " +
@@ -450,14 +451,14 @@ export async function runCodex(
 	// Fail closed (single live probe is not a guarantee): on 2026-07-10 pi with
 	// `--tools read,grep,find,ls` reported "no write, shell, bash, or edit tool is
 	// available" and created no file when instructed to; keep the env gate anyway.
-	if (runner === "pi" && !process.env.NEEDLEFISH_ALLOW_PI_RUNNER) {
+	if (runner === "pi" && !envFlagOn("NEEDLEFISH_ALLOW_PI_RUNNER")) {
 		throw new Error(
 			"The pi runner has no verified process-level sandbox restraint in headless mode " +
 				"(it executes tool calls with no permission gate) and must be explicitly enabled via " +
 				"NEEDLEFISH_ALLOW_PI_RUNNER=1.",
 		);
 	}
-	const maxAttempts = process.env.NEEDLEFISH_NO_RETRY ? 1 : 2;
+	const maxAttempts = envFlagOn("NEEDLEFISH_NO_RETRY") ? 1 : 2;
 	const startedAt = Date.now();
 	let attempts = 0;
 	const emitStat = (ok: boolean): void => {
@@ -821,7 +822,7 @@ async function runGrok(invocation: RunnerInvocation): Promise<RunnerResult> {
 	// JSON in plan mode, but it was write-restrained. The env opt-in unlocks the
 	// working unsandboxed mode; grok CLI --sandbox read-only and --disallowed-tools
 	// were verified ineffective at preventing writes that day.
-	if (!process.env.NEEDLEFISH_ALLOW_GROK_UNSANDBOXED)
+	if (!envFlagOn("NEEDLEFISH_ALLOW_GROK_UNSANDBOXED"))
 		args.push("--permission-mode", "plan");
 	if (invocation.reasoningEffort)
 		args.push("--reasoning-effort", invocation.reasoningEffort);

--- a/src/shared/env.test.ts
+++ b/src/shared/env.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { envFlagOn } from "./env.js";
+
+test("envFlagOn accepts only the string 1", (t) => {
+	const name = "NEEDLEFISH_TEST_BOOLEAN_FLAG";
+	const previous = process.env[name];
+	t.after(() => {
+		if (previous === undefined) delete process.env[name];
+		else process.env[name] = previous;
+	});
+
+	for (const value of ["1", "0", "", "true", "yes"] as const) {
+		process.env[name] = value;
+		assert.equal(envFlagOn(name), value === "1", `value ${JSON.stringify(value)}`);
+	}
+	delete process.env[name];
+	assert.equal(envFlagOn(name), false, "unset flag");
+});

--- a/src/shared/env.ts
+++ b/src/shared/env.ts
@@ -1,0 +1,4 @@
+// Boolean env flags are strictly "1" = on; every other value is off.
+export function envFlagOn(name: string): boolean {
+	return process.env[name] === "1";
+}


### PR DESCRIPTION
Three surgical fail-closed fixes from a design review of origin/main.

## 1. Strict `"1"` boolean env gates (`57741e9`)
Five safety gates used JS truthiness, so `NEEDLEFISH_ALLOW_GROK_UNSANDBOXED=0` **unsandboxed** grok — the exact inversion the AGENTS.md `"1"`-only rule exists to prevent. Same bug: `NEEDLEFISH_ALLOW_OPENCODE_RUNNER`, `NEEDLEFISH_ALLOW_PI_RUNNER`, `NEEDLEFISH_NO_RETRY`, `NEEDLEFISH_NO_FAST_PATH`. All five now go through `envFlagOn` (`src/shared/env.ts`, strict `=== "1"`), with tests asserting `"0"` behaves exactly like unset for each gate.

Prod lane is a no-op: the workflow either leaves these unset or sets literal `"1"`.

## 2. Paginate `findPreviousReview` (`82ec47c`)
It read only page 1 of the reviews API (30 items) while every re-review round posts additional reviews — past 30, the state-bearing review fell off page 1 and same-head dedupe, resolved/open deltas, and body updates silently degraded to first-round behavior. Now `--paginate --slurp` + `flat(1)`, mirroring `minimizePreviousRoundComments`. Test covers a state review on page 2.

## 3. `newCount` from the real matcher (`6bc9dbd`)
`countNewFindings` used exact-line/no-category matching while `matchFindings` uses ±10 lines + category, so the round comment's "🆕 N new" could disagree with the fresh-findings list. `newCount` now derives from `matchFindings`' `fresh.length`; the duplicate matcher is deleted.

## Verification
- `pnpm check && pnpm test` exit 0 after the final commit (480/480).
- Independent read-only review (non-author): all acceptance criteria MET, no existing assertion weakened, no new deps.
- Not eval-gated: no prompts/ or review-semantics change; all three are behavior-identical on the prod lane's configuration.