### PR TITLE
eval: ground-truth gate, scorerHash comparability, weekly deploy dispatch

### DIFF
--- a/.github/workflows/weekly-eval.yml
+++ b/.github/workflows/weekly-eval.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: write
   issues: write
+  # Needed for `gh workflow run deploy.yml`: GitHub suppresses workflow triggers
+  # from a GITHUB_TOKEN push, so the deploy is dispatched explicitly below.
+  actions: write
 concurrency:
   group: needlefish-weekly-eval
   cancel-in-progress: false
@@ -68,6 +71,16 @@ jobs:
           git add eval/results/weekly
           git commit -m "chore(eval): weekly regression report $(date -u +%Y-%m-%d)" || exit 0
           git pull --rebase origin main && git push origin HEAD:main
+      - name: Dispatch deploy
+        # A GITHUB_TOKEN push does not trigger deploy.yml (issue #19), so the
+        # release lags main until someone deploys by hand. Trigger it explicitly.
+        # No `|| true`: a failed dispatch must fail the job, never strand deploy.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha="$(git rev-parse HEAD)"
+          echo "dispatching deploy.yml for main @ $sha"
+          gh workflow run deploy.yml -R "${{ github.repository }}" --ref main
       - name: Open issue on failure
         if: failure()
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Runner: boolean environment flags now require exactly `1`; previously any
   non-empty value enabled them.
+- Eval: the gate re-executes recorded finding patterns against persisted
+  per-draw evidence instead of re-adding the scorer's own booleans; a
+  `scorerHash` makes reports scored by different code fail closed on resume,
+  compare, the weekly regression, the doc generators, and the gate; and the
+  weekly lane dispatches deploy after pushing its report so the release no
+  longer lags main (#19).
 
 ## 0.3.4 — 2026-07-15
 

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -10,6 +10,7 @@ import { aggregateMustFindHitRates, cheatAlert, compare, fixtureSetHash, loadFix
 import { renderResults } from "./gen-results";
 import { loadFixture } from "./shared/fixture";
 import { promptHash } from "./shared/prompt-hash";
+import { scorerHash } from "./shared/scorer-hash";
 import { drawFindings, matchEvidence, matchesSpec, score } from "./shared/score";
 import type { Expected, FixtureSpec, Report } from "./shared/types";
 import posOverBlock from "./fixtures/pos-over-block/spec";
@@ -803,6 +804,7 @@ function resumeReport(spec: FixtureSpec, overrides: Partial<Report>): Report {
     baseline: false,
     holdout: "include",
     fixtureSetHash: fixtureSetHash([spec]),
+    scorerHash: scorerHash(),
     fixtures: [spec.id],
     results: [{
       fixtureId: spec.id,
@@ -1308,6 +1310,16 @@ test("gen-baseline-doc refuses unsafe or incomplete reports", async (t) => {
       "wrong-fixture-set-hash",
       { ...complete, fixtureSetHash: "deadbeefdeadbeef" },
     ],
+    ["missing-scorer-hash", { ...complete, scorerHash: "" }],
+    [
+      "absent-scorer-hash",
+      (() => {
+        const r = { ...complete };
+        Reflect.deleteProperty(r, "scorerHash");
+        return r as Report;
+      })(),
+    ],
+    ["wrong-scorer-hash", { ...complete, scorerHash: "deadbeefdeadbeef" }],
   ];
   const repoRoot = path.resolve(__dirname, "..");
   const baselineDocPath = path.join(repoRoot, "eval", "BASELINE.md");
@@ -1706,6 +1718,7 @@ test("compare: rejects reports from another anti-cheat generation", () => {
       cheatDetectedCount: 0,
     },
     fixtureSetHash: "fixture-hash",
+    scorerHash: scorerHash(),
     anticheatVersion: 1,
   };
   try {
@@ -1760,6 +1773,135 @@ test("compare: rejects reports from another anti-cheat generation", () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("compare: refuses a report with a missing or mismatched scorerHash", () => {
+  // Draws scored by different code (or with no stamp) are not comparable, even
+  // at a matching prompt/fixture/guard generation.
+  const dir = mkdtempSync(path.join(tmpdir(), "needlefish-scorer-compare-"));
+  const spec = holdoutSpec("scorer-compare", false);
+  const good = resumeReport(spec, { anticheatVersion: 1 });
+  const goodPath = path.join(dir, "good.json");
+  writeFileSync(goodPath, JSON.stringify(good));
+  try {
+    const missing = (() => {
+      const r = { ...good };
+      Reflect.deleteProperty(r, "scorerHash");
+      return r as Report;
+    })();
+    const mismatched: Report = { ...good, scorerHash: "deadbeefdeadbeef" };
+    for (const [name, bad] of [
+      ["missing", missing],
+      ["mismatched", mismatched],
+    ] as const) {
+      const badPath = path.join(dir, `${name}.json`);
+      writeFileSync(badPath, JSON.stringify(bad));
+      assert.throws(() => compare(badPath, good), /scorer hash is/, `${name} baseline must not anchor`);
+      assert.throws(() => compare(goodPath, bad), /scorer hash is/, `${name} candidate must not pass`);
+    }
+    // A matching scorerHash still compares cleanly.
+    compare(goodPath, good);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resumeSlots: refuses a report with a missing or mismatched scorerHash", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "needlefish-scorer-resume-"));
+  const spec = holdoutSpec("scorer-resume", false);
+  try {
+    for (const [name, override] of [
+      ["mismatched", { anticheatVersion: 1, scorerHash: "deadbeefdeadbeef" }],
+      ["missing", { anticheatVersion: 1, scorerHash: undefined }],
+    ] as const) {
+      const report = resumeReport(spec, override as Partial<Report>);
+      const resumePath = path.join(dir, `${name}.json`);
+      writeFileSync(resumePath, JSON.stringify(report));
+      const args = parseArgs(["--draws", "1", "--resume", resumePath]);
+      const resumed = resumeSlots(args, [spec], [{ spec, draw: 0 }]);
+      assert.equal(resumed.skipped, 0, `${name} scorerHash must not be reused`);
+      assert.deepEqual(resumed.slots, [null]);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("gate-verdict's scorer hash replica matches the TS scorerHash (no drift)", () => {
+  // A report stamped by the TS scorerHash() must clear gate-verdict.mjs's plain
+  // JS replica, and a wrong hash must be refused — the only guard against the
+  // two implementations drifting and silently rejecting every real report.
+  const dir = mkdtempSync(path.join(tmpdir(), "needlefish-scorer-gate-"));
+  try {
+    const criteriaPath = path.join(dir, "criteria.json");
+    writeFileSync(
+      criteriaPath,
+      JSON.stringify({ fixtures: ["fx"], riskTier: 2, maxMeanNoisePerPositive: 0.5, tier1Misses: 0 }),
+    );
+    const base = {
+      promptHash: "p",
+      fixtureSetHash: "f",
+      scorerHash: scorerHash(),
+      fixtures: ["fx"],
+      draws: 1,
+      results: [
+        {
+          fixtureId: "fx",
+          draw: 0,
+          score: { recall: true, noiseFindingCount: 0, cheatDetected: false },
+          findings: [],
+          matchEvidence: [],
+        },
+      ],
+      aggregates: { cheatDetectedCount: 0, meanNoisePerPositive: 0, recallByFixture: { fx: 1 } },
+      fixtureKinds: { fx: "positive" },
+      fixtureTiers: { fx: 2 },
+    };
+    const gate = (report: unknown): { status: number | null; reasons: string[] } => {
+      const reportPath = path.join(dir, "report.json");
+      writeFileSync(reportPath, JSON.stringify(report));
+      const res = spawnSync(
+        process.execPath,
+        [
+          path.resolve(__dirname, "..", "scripts", "gate-verdict.mjs"),
+          reportPath,
+          "--criteria",
+          criteriaPath,
+        ],
+        { encoding: "utf8" },
+      );
+      return { status: res.status, reasons: JSON.parse(res.stdout).reasons };
+    };
+    const ok = gate(base);
+    assert.equal(ok.status, 0, `TS scorerHash must clear the gate: ${JSON.stringify(ok.reasons)}`);
+    const bad = gate({ ...base, scorerHash: "deadbeefdeadbeef" });
+    assert.deepEqual(bad.reasons, ["scorer-hash-mismatch"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("renderResults: a scorerHash mismatch excludes a report from baseline and deltas", () => {
+  const spec = holdoutSpec("gen-results-scorer", false);
+  const clean = resumeReport(spec, { anticheatVersion: 1, effort: "xhigh" });
+  const staleScorer = resumeReport(spec, {
+    anticheatVersion: 1,
+    runner: "grok",
+    effort: "low",
+    scorerHash: "deadbeefdeadbeef",
+  });
+  const md = renderResults(
+    [spec],
+    [
+      { stem: "clean-codex-xhigh", report: clean },
+      { stem: "stale-scorer-grok", report: staleScorer },
+    ],
+  );
+  const row = (stem: string): string =>
+    md.split("\n").find((l) => l.includes(`${stem} |`)) ?? "";
+  assert.match(row("clean-codex-xhigh"), /\(baseline\)/, "guarded report anchors");
+  assert.match(row("stale-scorer-grok"), /🚫/, "a stale-scorer report is excluded");
+  assert.match(row("stale-scorer-grok"), /n\/a/, "a stale-scorer report gets no delta");
 });
 
 test("loadFixtures: discovers a fixture placed in eval/fixtures-real/", async () => {

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -666,9 +666,10 @@ test("matchEvidence: records the satisfying finding index per spec, null for a m
     finding({ title: "viewer branch unreachable", whyItBreaks: "blocked", file: "src/handler.ts", lineStart: 18 }),
   ];
   // First spec is satisfied by findings[1]; second spec has no match → null.
+  // Each entry records its own file anchor so the gate re-checks it.
   assert.deepEqual(matchEvidence(findings, expected), [
-    { pattern: "viewer", findingIndex: 1 },
-    { pattern: "ttl", findingIndex: null },
+    { pattern: "viewer", file: "handler.ts", findingIndex: 1 },
+    { pattern: "ttl", file: "cache.ts", findingIndex: null },
   ]);
 });
 
@@ -684,7 +685,9 @@ test("matchEvidence: a keyword hit on the wrong file records a miss, matching re
     finding({ title: "viewer logic", whyItBreaks: "viewer path", file: "src/other.ts", lineStart: 3 }),
   ];
   const evidence = matchEvidence(findings, expected);
-  assert.deepEqual(evidence, [{ pattern: "viewer", findingIndex: null }]);
+  // The inherited fixture anchorFile is recorded on the entry, so the gate can
+  // reject a wrong-file finding the same way score() does.
+  assert.deepEqual(evidence, [{ pattern: "viewer", file: "src/handler.ts", findingIndex: null }]);
   assert.equal(
     score({ verdict: "changes_requested", findings }, expected, "evidence-recall").recall,
     false,

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -10,7 +10,7 @@ import { aggregateMustFindHitRates, cheatAlert, compare, fixtureSetHash, loadFix
 import { renderResults } from "./gen-results";
 import { loadFixture } from "./shared/fixture";
 import { promptHash } from "./shared/prompt-hash";
-import { matchesSpec, score } from "./shared/score";
+import { drawFindings, matchEvidence, matchesSpec, score } from "./shared/score";
 import type { Expected, FixtureSpec, Report } from "./shared/types";
 import posOverBlock from "./fixtures/pos-over-block/spec";
 import negStyleOnly from "./fixtures/neg-style-only/spec";
@@ -625,6 +625,74 @@ test("score: criticPruneError false when candidateFindings absent (trace off)", 
   const hit = finding({ title: "viewer branch unreachable", whyItBreaks: "viewers are blocked", file: "src/h.ts", lineStart: 1 });
   const s = score({ verdict: "changes_requested", findings: [hit] }, expected, "prune-fixture");
   assert.equal(s.criticPruneError, false, "no trace means no prune-error signal");
+});
+
+// --- per-draw evidence (F1): persisted ground truth for the gate ---
+
+test("drawFindings: records the scored finding fields in full", () => {
+  const f = finding({
+    title: "viewer branch unreachable",
+    whyItBreaks: "eligibility rejects viewers",
+    file: "src/handler.ts",
+    lineStart: 18,
+    lineEnd: 20,
+    severity: "P1",
+    category: "bug",
+  });
+  assert.deepEqual(drawFindings([f]), [
+    {
+      severity: "P1",
+      category: "bug",
+      file: "src/handler.ts",
+      lineStart: 18,
+      lineEnd: 20,
+      title: "viewer branch unreachable",
+      whyItBreaks: "eligibility rejects viewers",
+    },
+  ]);
+});
+
+test("matchEvidence: records the satisfying finding index per spec, null for a miss", () => {
+  const expected: Expected = {
+    verdict: "changes_requested",
+    mustFind: [
+      { pattern: "viewer", file: "handler.ts" },
+      { pattern: "ttl", file: "cache.ts" },
+    ],
+  };
+  const findings = [
+    finding({ title: "unrelated nit", whyItBreaks: "style", file: "src/a.ts", lineStart: 1 }),
+    finding({ title: "viewer branch unreachable", whyItBreaks: "blocked", file: "src/handler.ts", lineStart: 18 }),
+  ];
+  // First spec is satisfied by findings[1]; second spec has no match → null.
+  assert.deepEqual(matchEvidence(findings, expected), [
+    { pattern: "viewer", findingIndex: 1 },
+    { pattern: "ttl", findingIndex: null },
+  ]);
+});
+
+test("matchEvidence: a keyword hit on the wrong file records a miss, matching recall", () => {
+  // Same anti-gaming contract as score(): pattern words on an unrelated file
+  // must not count. The evidence null-ness mirrors score().recall exactly.
+  const expected: Expected = {
+    verdict: "changes_requested",
+    mustFind: [{ pattern: "viewer" }],
+    anchorFile: "src/handler.ts",
+  };
+  const findings = [
+    finding({ title: "viewer logic", whyItBreaks: "viewer path", file: "src/other.ts", lineStart: 3 }),
+  ];
+  const evidence = matchEvidence(findings, expected);
+  assert.deepEqual(evidence, [{ pattern: "viewer", findingIndex: null }]);
+  assert.equal(
+    score({ verdict: "changes_requested", findings }, expected, "evidence-recall").recall,
+    false,
+    "evidence null-ness must agree with score().recall",
+  );
+});
+
+test("matchEvidence: no mustFind specs yields empty evidence", () => {
+  assert.deepEqual(matchEvidence([], { verdict: "pass" }), []);
 });
 
 // --- provenance (real-PR fixture mining, eval/tools/pr2fixture.ts) ---

--- a/eval/gen-baseline-doc.ts
+++ b/eval/gen-baseline-doc.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { fixtureSetHash, loadFixtures } from "./run";
 import { isCompleteReport } from "./shared/report-completeness";
 import { hasConsistentCheatDetection } from "./shared/report-integrity";
+import { scorerHash } from "./shared/scorer-hash";
 import { ANTICHEAT_VERSION, type Report } from "./shared/types";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -47,6 +48,10 @@ const fixtureHashOk =
 	report.fixtureSetHash.length > 0 &&
 	report.fixtureSetHash === expectedFixtureHash;
 const runnerOk = report.runner === "codex";
+const scorerHashOk =
+	typeof report.scorerHash === "string" &&
+	report.scorerHash.length > 0 &&
+	report.scorerHash === scorerHash();
 if (
 	report.anticheatVersion !== ANTICHEAT_VERSION ||
 	typeof cheatCount !== "number" ||
@@ -55,10 +60,11 @@ if (
 	!complete ||
 	!promptHashOk ||
 	!fixtureHashOk ||
+	!scorerHashOk ||
 	!runnerOk
 ) {
 	process.stderr.write(
-		`refusing to generate baseline doc: runner=${runnerOk ? "codex" : report.runner ?? "missing"}, anticheatVersion=${report.anticheatVersion ?? "none"} (current ${ANTICHEAT_VERSION}), cheatDetectedCount=${cheatCount ?? "missing"}, completeFullFixtureSet=${complete}, promptHash=${promptHashOk ? "ok" : "missing"}, fixtureSetHash=${fixtureHashOk ? "ok" : report.fixtureSetHash ?? "missing"} — re-run the full Codex baseline under the current guards\n`,
+		`refusing to generate baseline doc: runner=${runnerOk ? "codex" : report.runner ?? "missing"}, anticheatVersion=${report.anticheatVersion ?? "none"} (current ${ANTICHEAT_VERSION}), cheatDetectedCount=${cheatCount ?? "missing"}, completeFullFixtureSet=${complete}, promptHash=${promptHashOk ? "ok" : "missing"}, fixtureSetHash=${fixtureHashOk ? "ok" : report.fixtureSetHash ?? "missing"}, scorerHash=${scorerHashOk ? "ok" : report.scorerHash ?? "missing"} — re-run the full Codex baseline under the current guards\n`,
 	);
 	process.exit(1);
 }

--- a/eval/gen-results.ts
+++ b/eval/gen-results.ts
@@ -6,6 +6,7 @@ import {
   reportExpectedResultCount,
 } from "./shared/report-completeness";
 import { hasConsistentCheatDetection } from "./shared/report-integrity";
+import { scorerHash } from "./shared/scorer-hash";
 import { ANTICHEAT_VERSION, type FixtureSpec, type Report } from "./shared/types";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -39,6 +40,7 @@ export interface NamedReport {
 function guarded(r: Report): boolean {
   return (
     r.anticheatVersion === ANTICHEAT_VERSION &&
+    r.scorerHash === scorerHash() &&
     r.aggregates.cheatDetectedCount === 0 &&
     hasConsistentCheatDetection(r)
   );

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -16,7 +16,7 @@ import type { ReviewResult } from "../src/shared/schema";
 import { loadFixture } from "./shared/fixture";
 import { promptHash } from "./shared/prompt-hash";
 import { isCompleteReport } from "./shared/report-completeness";
-import { score } from "./shared/score";
+import { drawFindings, matchEvidence, score } from "./shared/score";
 import {
 	ANTICHEAT_VERSION,
 	type Aggregates,
@@ -226,6 +226,7 @@ async function runOne(
 	const stats = result?.stats;
 	const calls = stats?.length ?? 0;
 	const retries = stats?.reduce((sum, s) => sum + (s.attempts - 1), 0) ?? 0;
+	const findings = result?.findings ?? [];
 	return {
 		fixtureId: spec.id,
 		draw: 0,
@@ -242,6 +243,8 @@ async function runOne(
 		durationMs,
 		calls,
 		retries,
+		findings: drawFindings(findings),
+		matchEvidence: matchEvidence(findings, spec.expected),
 	};
 }
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -15,6 +15,7 @@ import { parseRunnerName, type RunnerName } from "../src/shared/runner";
 import type { ReviewResult } from "../src/shared/schema";
 import { loadFixture } from "./shared/fixture";
 import { promptHash } from "./shared/prompt-hash";
+import { scorerHash } from "./shared/scorer-hash";
 import { isCompleteReport } from "./shared/report-completeness";
 import { drawFindings, matchEvidence, score } from "./shared/score";
 import {
@@ -309,6 +310,15 @@ export function resumeSlots(
 			);
 			return { slots, skipped };
 		}
+		// Draws scored by different scorer code are not comparable — reusing them
+		// would splice two scoring generations into one report. Absent = legacy,
+		// never grandfathered.
+		if (existing.scorerHash !== scorerHash()) {
+			process.stderr.write(
+				`resume: scorer hash mismatch (${existing.scorerHash ?? "none"} vs ${scorerHash()}), ignoring resume file\n`,
+			);
+			return { slots, skipped };
+		}
 		// A fired trap voids the whole report (see cheatAlert) — none of its
 		// draws may seed a fresh one. Fail closed on a MISSING count too:
 		// unvalidated JSON, and absence of the canary result cannot establish
@@ -559,6 +569,7 @@ export function writeReport(
 		aggregates: aggregate(results, specs),
 		gitSha: repoGitSha(),
 		fixtureSetHash: fixtureSetHash(specs),
+		scorerHash: scorerHash(),
 		fixtureTiers,
 		// The version label is a promise that every generation-1 guard was on:
 		// HOME isolation AND eval tracing (without the trace, critic-pruned
@@ -625,6 +636,13 @@ export function compare(baselinePath: string, candidate: Report): void {
 		if (report.anticheatVersion !== ANTICHEAT_VERSION) {
 			throw new Error(
 				`${label} report anti-cheat version is ${report.anticheatVersion ?? "none"}, current is ${ANTICHEAT_VERSION}. Re-run the ${label} under the current guards.`,
+			);
+		}
+		// Different scorer code produces incomparable numbers even at the same
+		// prompt/fixture/guard generation. Absent = legacy, fail closed.
+		if (report.scorerHash !== scorerHash()) {
+			throw new Error(
+				`${label} report scorer hash is ${report.scorerHash ?? "none"}, current is ${scorerHash()}. Re-run the ${label} under the current scorer.`,
 			);
 		}
 		// A fired trap voids the whole report (see cheatAlert) — void numbers

--- a/eval/shared/score.ts
+++ b/eval/shared/score.ts
@@ -3,7 +3,13 @@ import {
 	scanRobustness,
 	type FindingMatchFields,
 } from "./robustness";
-import type { Expected, FixtureScore, MatchSpec } from "./types";
+import type {
+	DrawFinding,
+	Expected,
+	FixtureScore,
+	MatchEvidence,
+	MatchSpec,
+} from "./types";
 
 const BLOCKING: Severity[] = ["P0", "P1", "P2"];
 
@@ -39,6 +45,35 @@ export function recallMatch(
 			? spec
 			: { ...spec, file: expected.anchorFile };
 	return matchesSpec(finding, effective);
+}
+
+// Persisted per-draw ground truth (F1): the scored finding fields the gate
+// re-executes patterns against. Kept in full — truncation would break matching.
+export function drawFindings(
+	findings: readonly Finding[],
+): DrawFinding[] {
+	return findings.map((f) => ({
+		severity: f.severity,
+		category: f.category,
+		file: f.file,
+		lineStart: f.lineStart,
+		lineEnd: f.lineEnd,
+		title: f.title,
+		whyItBreaks: f.whyItBreaks,
+	}));
+}
+
+// Per-spec recall evidence (F1): reuses the SAME recallMatch used by score(),
+// so a non-null index exists for a spec iff score() counts it as a hit. The
+// index is the first satisfying finding; a miss records null.
+export function matchEvidence(
+	findings: readonly Finding[],
+	expected: Expected,
+): MatchEvidence[] {
+	return (expected.mustFind ?? []).map((spec) => {
+		const idx = findings.findIndex((f) => recallMatch(f, spec, expected));
+		return { pattern: spec.pattern, findingIndex: idx >= 0 ? idx : null };
+	});
 }
 
 function isBlocking(finding: Finding): boolean {

--- a/eval/shared/score.ts
+++ b/eval/shared/score.ts
@@ -71,8 +71,22 @@ export function matchEvidence(
 	expected: Expected,
 ): MatchEvidence[] {
 	return (expected.mustFind ?? []).map((spec) => {
-		const idx = findings.findIndex((f) => recallMatch(f, spec, expected));
-		return { pattern: spec.pattern, findingIndex: idx >= 0 ? idx : null };
+		// The effective spec recallMatch resolves: a spec without its own file
+		// inherits the fixture anchorFile. Record it in full so the gate enforces
+		// the SAME anchor, not just the pattern text. findIndex over matchesSpec
+		// is identical to recallMatch, so the index still mirrors score().recall.
+		const effective: MatchSpec =
+			spec.file || !expected.anchorFile
+				? spec
+				: { ...spec, file: expected.anchorFile };
+		const idx = findings.findIndex((f) => matchesSpec(f, effective));
+		return {
+			pattern: effective.pattern,
+			...(effective.category ? { category: effective.category } : {}),
+			...(effective.file ? { file: effective.file } : {}),
+			...(effective.lineRange ? { lineRange: effective.lineRange } : {}),
+			findingIndex: idx >= 0 ? idx : null,
+		};
 	});
 }
 

--- a/eval/shared/scorer-hash.ts
+++ b/eval/shared/scorer-hash.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// The scoring-relevant sources. Two reports are only comparable when both were
+// scored by the same code; any edit here changes the hash, so resume/compare/
+// weekly/doc generators refuse to mix generations. gate-verdict.mjs replicates
+// this exact digest (same files, order, and separators) in plain JS.
+const SCORER_FILES = ["score.ts", "robustness.ts", "types.ts"];
+
+export function scorerHash(): string {
+  const hash = createHash("sha256");
+  for (const name of SCORER_FILES) {
+    const content = readFileSync(path.join(__dirname, name), "utf8");
+    hash.update(name);
+    hash.update("\0");
+    hash.update(content);
+    hash.update("\0");
+  }
+  return hash.digest("hex").slice(0, 16);
+}

--- a/eval/shared/types.ts
+++ b/eval/shared/types.ts
@@ -153,10 +153,17 @@ export interface DrawFinding {
   readonly whyItBreaks: string;
 }
 
-// One entry per mustFind spec: the spec's pattern and the index (into the
-// draw's `findings`) of the finding that satisfied recall, or null for a miss.
+// One entry per mustFind spec: the EFFECTIVE spec — pattern plus the anchor
+// fields after fixture-level anchorFile inheritance, exactly as recallMatch
+// resolves them — and the index (into the draw's `findings`) of the finding
+// that satisfied recall, or null for a miss. The anchor fields are recorded so
+// the gate re-checks file/category/line the same way score() did; a finding
+// matching only the pattern text on the wrong file cannot fake a hit.
 export interface MatchEvidence {
   readonly pattern: string;
+  readonly category?: Category;
+  readonly file?: string;
+  readonly lineRange?: readonly [number, number];
   readonly findingIndex: number | null;
 }
 

--- a/eval/shared/types.ts
+++ b/eval/shared/types.ts
@@ -1,4 +1,4 @@
-import type { Category, Verdict } from "../../src/shared/schema";
+import type { Category, Severity, Verdict } from "../../src/shared/schema";
 import type { RunnerName } from "../../src/shared/runner";
 
 // `honeypot` fixtures are clean diffs whose trap keywords exist only in the
@@ -140,6 +140,26 @@ export interface AnticheatRobustnessDiagnostics {
   readonly matchProvenance: readonly AnticheatMatchProvenance[];
 }
 
+// The scored finding, recorded per draw so the gate can re-execute mustFind
+// patterns against real ground truth (F2) instead of re-adding score booleans.
+// Full text is kept — truncation would break pattern re-matching.
+export interface DrawFinding {
+  readonly severity: Severity;
+  readonly category: Category;
+  readonly file: string;
+  readonly lineStart: number;
+  readonly lineEnd: number;
+  readonly title: string;
+  readonly whyItBreaks: string;
+}
+
+// One entry per mustFind spec: the spec's pattern and the index (into the
+// draw's `findings`) of the finding that satisfied recall, or null for a miss.
+export interface MatchEvidence {
+  readonly pattern: string;
+  readonly findingIndex: number | null;
+}
+
 export interface DrawResult {
   readonly fixtureId: string;
   readonly draw: number;
@@ -147,6 +167,11 @@ export interface DrawResult {
   readonly durationMs: number;
   readonly calls: number;
   readonly retries: number;
+  // Ground-truth evidence for the gate's re-execution (F1). Optional because a
+  // slot resumed from a pre-F1 report carries none; F3's scorerHash gate
+  // refuses to reuse such reports, so fresh reports always populate both.
+  readonly findings?: readonly DrawFinding[];
+  readonly matchEvidence?: readonly MatchEvidence[];
 }
 
 export interface Aggregates {

--- a/eval/shared/types.ts
+++ b/eval/shared/types.ts
@@ -219,4 +219,9 @@ export interface Report {
   // guard via --env, or whose runner cannot honor one (claude is exempt from
   // HOME isolation, so claude lanes are never certified).
   readonly anticheatVersion?: number;
+  // sha256 (16 hex) over the scoring-relevant sources. Two reports are only
+  // comparable when both were scored by the same code. Absent on reports that
+  // predate F3 — resume/compare/weekly/doc generators refuse those as legacy,
+  // never grandfathered.
+  readonly scorerHash?: string;
 }

--- a/eval/weekly-compare.test.ts
+++ b/eval/weekly-compare.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { compareWeekly } from "./weekly-compare";
+import { scorerHash } from "./shared/scorer-hash";
 import type { Aggregates, DrawResult, FixtureScore, Report } from "./shared/types";
 
 function scoreOf(partial: Partial<FixtureScore> & Pick<FixtureScore, "fixtureId">): FixtureScore {
@@ -62,6 +63,7 @@ function report(results: DrawResult[], partial: Partial<Report> = {}): Report {
     results,
     aggregates: aggregatesOf(partial.aggregates ? { ...partial.aggregates } : {}),
     fixtureSetHash: "fff",
+    scorerHash: scorerHash(),
     fixtureTiers: {},
     anticheatVersion: 1,
     ...partial,
@@ -205,7 +207,7 @@ test("compareWeekly: prompt change skips regression comparison but keeps cheat a
   const v = compareWeekly(prev, latest);
   assert.equal(v.alert, false, "regression across prompt change is not comparable");
   assert.ok(
-    v.reasons.some((r) => r.includes("prompt/fixture set/anti-cheat generation changed")),
+    v.reasons.some((r) => r.includes("prompt/fixture set/anti-cheat generation/scorer changed")),
   );
 });
 
@@ -378,7 +380,7 @@ test("compareWeekly: a pre-guard previous week skips regression comparison", () 
   const v = compareWeekly(prev, latest);
   assert.equal(v.alert, false, "cross-generation regression must not alert");
   assert.ok(
-    v.reasons.some((r) => r.includes("anti-cheat generation changed")),
+    v.reasons.some((r) => r.includes("anti-cheat generation/scorer changed")),
   );
 });
 
@@ -395,6 +397,27 @@ test("compareWeekly: an unguarded latest report withholds all metrics", () => {
     assert.equal(v.alert, true, "an unguarded weekly lane must alert");
     assert.ok(v.reasons.some((r) => r.includes("metrics withheld")));
   }
+});
+
+test("compareWeekly: a latest report scored by different code is unguarded", () => {
+  const latest = report([...drawsFor("a", [true, true, true])], {
+    scorerHash: "deadbeefdeadbeef",
+  });
+  const v = compareWeekly(null, latest);
+  assert.equal(v.unguarded, true, "a stale-scorer latest must be unguarded");
+  assert.equal(v.alert, true);
+  assert.ok(v.reasons.some((r) => r.includes("metrics withheld")));
+});
+
+test("compareWeekly: a prev scored by different code skips regression comparison", () => {
+  const prev = report([...drawsFor("a", [true, true, true])], {
+    scorerHash: "deadbeefdeadbeef",
+  });
+  const latest = report([...drawsFor("a", [false, false, false])]);
+  const v = compareWeekly(prev, latest);
+  assert.equal(v.alert, false, "a stale-scorer prev must not anchor a regression");
+  assert.ok(v.reasons.some((r) => r.includes("skipping regression comparison")));
+  assert.ok(v.reasons.every((r) => !r.includes("fixtures regressed")));
 });
 
 test("compareWeekly: a missing cheatDetectedCount fails closed", () => {

--- a/eval/weekly-compare.ts
+++ b/eval/weekly-compare.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isCompleteReport } from "./shared/report-completeness";
 import { hasConsistentCheatDetection } from "./shared/report-integrity";
+import { scorerHash } from "./shared/scorer-hash";
 import { ANTICHEAT_VERSION, type Report } from "./shared/types";
 
 // Weekly regression verdict. Built around the noise floor of this eval: with
@@ -75,19 +76,20 @@ export function compareWeekly(prev: Report | null, latest: Report): WeeklyVerdic
     latest.aggregates.cheatDetectedCount;
   if (
     latest.anticheatVersion !== ANTICHEAT_VERSION ||
+    latest.scorerHash !== scorerHash() ||
     typeof latestCheatCount !== "number" ||
     latestCheatCount !== 0 ||
     !hasConsistentCheatDetection(latest)
   ) {
     // Not proven void (unlike CHEAT), but unguarded: the current generation's
-    // detection never covered (or never recorded) these draws, so no metric
-    // may be published and the weekly lane itself needs fixing — that is
-    // alert-worthy on its own.
+    // detection never covered (or never recorded) these draws, or the report
+    // was scored by different code, so no metric may be published and the
+    // weekly lane itself needs fixing — that is alert-worthy on its own.
     return {
       alert: true,
       unguarded: true,
       reasons: [
-        `latest report anti-cheat generation is ${latest.anticheatVersion ?? "none"} (current is ${ANTICHEAT_VERSION}) or its cheatDetectedCount is missing or invalid — metrics withheld; re-run the weekly lane under the current guards`,
+        `latest report anti-cheat generation is ${latest.anticheatVersion ?? "none"} (current is ${ANTICHEAT_VERSION}), its scorer hash is ${latest.scorerHash ?? "none"} (current is ${scorerHash()}), or its cheatDetectedCount is missing or invalid — metrics withheld; re-run the weekly lane under the current guards`,
       ],
     };
   }
@@ -130,14 +132,15 @@ export function compareWeekly(prev: Report | null, latest: Report): WeeklyVerdic
       // and so does a negative/NaN count (malformed; only >0 means a fired
       // trap, which the compromised branch below reports as CHEAT).
       prev.anticheatVersion !== ANTICHEAT_VERSION ||
+      prev.scorerHash !== scorerHash() ||
       typeof (prev.aggregates.cheatDetectedCount as number | undefined) !==
         "number" ||
       prev.aggregates.cheatDetectedCount < 0 ||
       Number.isNaN(prev.aggregates.cheatDetectedCount)
     ) {
-      // Different prompt, fixture set, or guard generation: week-over-week
-      // deltas are meaningless.
-      return { alert: reasons.length > 0, reasons: [...reasons, "note: prompt/fixture set/anti-cheat generation changed since last week (or previous cheatDetectedCount is missing/invalid); skipping regression comparison"] };
+      // Different prompt, fixture set, guard generation, or scorer code:
+      // week-over-week deltas are meaningless.
+      return { alert: reasons.length > 0, reasons: [...reasons, "note: prompt/fixture set/anti-cheat generation/scorer changed since last week (or previous cheatDetectedCount is missing/invalid); skipping regression comparison"] };
     }
     if (prev.aggregates.cheatDetectedCount > 0) {
       // A fired trap voids the whole report — void numbers must not produce

--- a/plans/012-eval-ground-truth.md
+++ b/plans/012-eval-ground-truth.md
@@ -1,0 +1,76 @@
+# 012 — eval ground truth + scorer comparability + weekly deploy dispatch
+
+Closes the remaining eval-integrity findings from the 2026-07-16 design
+review: the gate recomputes arithmetic, not ground truth; comparability
+ignores scorer code; and the weekly lane strands the deploy gate (issue #19).
+Touches eval/ + scripts/ + workflows only — no src pipeline change, so no
+model-eval gate; the gate here is unit tests plus demonstrated fail-closed
+refusals.
+
+## F1. Persist per-draw finding evidence in reports
+
+Problem: `DrawResult` stores only score booleans. A buggy or fabricated
+scorer emitting `recall: true, cheatDetected: false` per draw passes
+`gate-verdict.mjs`, which can only re-add the same booleans.
+
+Fix: each DrawResult additionally records
+- `findings`: the final normalized findings, each as
+  `{ severity, category, file, lineStart, lineEnd, title, whyItBreaks }`
+  (full text — truncation would break pattern re-matching), and
+- `matchEvidence`: for every mustFind spec, the spec's pattern string plus
+  the index of the finding that satisfied it (or null for a miss).
+
+Leak note (accepted tradeoff): finding text on holdout fixtures is
+answer-adjacent, but reports live in the needlefish repo, which evaluated
+runners can never read (sandbox clones the fixture repo only). Holdout
+discipline for briefs/subagents is unchanged.
+
+## F2. gate-verdict recomputes from evidence, not booleans
+
+`scripts/gate-verdict.mjs` re-executes each recorded pattern (case-insensitive,
+same `title + " " + whyItBreaks` haystack as score.ts) against the persisted
+findings and fails on any draw where the claimed recall/miss disagrees with
+the re-execution, or where evidence is missing on a report that claims the
+current scorer generation. Bounded goal: the gate now verifies the scorer's
+claims against stored ground truth; it still does not re-run models.
+
+## F3. scorerHash comparability
+
+Problem: compare/resume gate on promptHash + fixtureSetHash only; two reports
+scored by different scorer code compare as equivalent, and resume reuses
+draws across scorer changes.
+
+Fix: `scorerHash` = sha256 over the scoring-relevant sources
+(eval/shared/score.ts, eval/shared/robustness.ts, eval/shared/types.ts),
+computed like promptHash. Stamped on every report. Fail-closed, mirroring the
+anticheatVersion pattern: compare(), resumeSlots(), weekly-compare, and both
+doc generators refuse/withhold when either side's scorerHash is absent or
+mismatched. Existing reports lack the field → they are legacy on arrival;
+never grandfathered.
+
+## F4. weekly-eval dispatches deploy (issue #19)
+
+Problem: weekly-eval pushes its report commit to main with GITHUB_TOKEN;
+GitHub suppresses workflow triggers from such pushes, so deploy.yml never
+runs, release.json falls behind main, and the next PR review fails the
+release-mismatch gate until someone deploys manually.
+
+Fix: after the push step succeeds, weekly-eval.yml explicitly runs
+`gh workflow run deploy.yml` (workflow_dispatch) with the pushed SHA noted in
+the step output. Failure of the dispatch step fails the job loudly (no silent
+strand).
+
+## Consequences
+
+Reports produced before 012 lack scorerHash and finding evidence: compare,
+resume, weekly regression, and the doc generators treat them as unguarded
+legacy (refuse/withhold), same as the anticheat generation cut. The first
+weekly run after 012 skips the week-over-week comparison with an explicit
+note and self-heals the week after. The W7 formal baseline re-record should
+happen after 012 lands so the durable baseline carries evidence + scorerHash.
+
+## Sequencing
+
+Four commits (F1, F2, F3, F4). Local gate green → independent non-author
+review → PR → merge on clean bot review (standing authorization). Runs in
+parallel with 010/011 — no file overlap with src/ batches.

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -145,6 +145,14 @@ function isMatchableFinding(value) {
 function evidenceEntryOk(entry) {
   if (!isRecord(entry) || typeof entry.pattern !== "string") return false;
   if (entry.findingIndex !== null && !Number.isInteger(entry.findingIndex)) return false;
+  if (entry.category !== undefined && typeof entry.category !== "string") return false;
+  if (entry.file !== undefined && typeof entry.file !== "string") return false;
+  if (entry.lineRange !== undefined
+    && !(Array.isArray(entry.lineRange)
+      && entry.lineRange.length === 2
+      && entry.lineRange.every((n) => Number.isFinite(n)))) {
+    return false;
+  }
   try {
     new RegExp(entry.pattern, "i");
   } catch {
@@ -153,12 +161,29 @@ function evidenceEntryOk(entry) {
   return true;
 }
 
-// Ground-truth recompute (F2): re-execute each recorded mustFind pattern
-// (case-insensitive, over the same `title + " " + whyItBreaks` haystack as
-// score.ts) against the persisted findings, then fail on any draw whose claimed
-// recall/miss disagrees with the re-execution, or whose evidence is absent. A
-// non-null index that does not resolve to a finding whose text matches the
-// pattern counts as a miss, so a fabricated pointer cannot manufacture recall.
+// Mirror eval/shared/score.ts matchesSpec on the recorded finding fields:
+// category equality, file suffix, lineStart within lineRange, then the
+// case-insensitive pattern over `title + " " + whyItBreaks`. A finding that
+// matches only the pattern text on the wrong file (or category, or line) is
+// not a hit, so a fabricated pointer cannot manufacture recall past the gate.
+function evidenceMatches(entry, finding) {
+  if (entry.category && finding.category !== entry.category) return false;
+  if (entry.file && !(typeof finding.file === "string" && finding.file.endsWith(entry.file))) return false;
+  if (entry.lineRange
+    && (typeof finding.lineStart !== "number"
+      || finding.lineStart < entry.lineRange[0]
+      || finding.lineStart > entry.lineRange[1])) {
+    return false;
+  }
+  return new RegExp(entry.pattern, "i").test(`${finding.title} ${finding.whyItBreaks}`);
+}
+
+// Ground-truth recompute (F2): re-execute each recorded mustFind spec against
+// the persisted findings with the SAME semantics score.ts used (pattern plus
+// the effective file/category/line anchor), then fail on any draw whose claimed
+// recall disagrees with the re-execution, or whose evidence is absent. A
+// non-null index that does not resolve to a finding satisfying the full spec
+// counts as a miss, so a fabricated pointer cannot manufacture recall.
 function evidenceReasons(report) {
   const reasons = [];
   for (const result of report.results) {
@@ -172,13 +197,17 @@ function evidenceReasons(report) {
     for (const entry of evidence) {
       const idx = entry.findingIndex;
       const named = idx !== null && idx >= 0 && idx < findings.length ? findings[idx] : undefined;
-      const matched = isMatchableFinding(named)
-        && new RegExp(entry.pattern, "i").test(`${named.title} ${named.whyItBreaks}`);
-      if (!matched) recallReexec = false;
+      if (!isMatchableFinding(named) || !evidenceMatches(entry, named)) recallReexec = false;
     }
-    if (recallReexec && result.score.recall !== true) {
+    // Expected recall is only defined for a parsed draw. An errored draw
+    // (formatOk false) scores recall false with empty evidence, which would
+    // otherwise re-execute as a vacuous hit on a zero-mustFind fixture; that is
+    // consistent, never a tamper signal. A parsed draw — or a legacy one that
+    // omits formatOk — is cross-checked against the re-execution as before.
+    const expectedRecall = result.score.formatOk === false ? false : recallReexec;
+    if (expectedRecall && result.score.recall !== true) {
       reasons.push(`miss-with-evidence:${result.fixtureId}`);
-    } else if (!recallReexec && result.score.recall === true) {
+    } else if (!expectedRecall && result.score.recall === true) {
       reasons.push(`recall-without-evidence:${result.fixtureId}`);
     }
   }

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -1,10 +1,29 @@
 #!/usr/bin/env node
 
+import { createHash } from "node:crypto";
 import { readFileSync, realpathSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const FIXTURE_KINDS = new Set(["positive", "negative", "parity", "honeypot"]);
+
+// Plain-JS replica of eval/shared/scorer-hash.ts — same files, order, and
+// separators, so a report stamped by the TS scorerHash() matches here. The
+// cross-check test in eval/eval.test.ts fails loudly if the two ever drift.
+const SCORER_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..", "eval", "shared");
+const SCORER_FILES = ["score.ts", "robustness.ts", "types.ts"];
+
+export function computeScorerHash() {
+  const hash = createHash("sha256");
+  for (const name of SCORER_FILES) {
+    const content = readFileSync(join(SCORER_DIR, name), "utf8");
+    hash.update(name);
+    hash.update("\0");
+    hash.update(content);
+    hash.update("\0");
+  }
+  return hash.digest("hex").slice(0, 16);
+}
 
 function output(pass, reasons, promptHash = "", fixtureSetHash = "") {
   process.stdout.write(`${JSON.stringify({ pass, reasons, promptHash, fixtureSetHash })}\n`);
@@ -181,6 +200,14 @@ export function evaluateGate(report, criteria) {
 
   const reasons = [];
   const aggregates = recomputeAggregates(report);
+  // Comparability gate (F3): a report scored by different code — or with no
+  // scorer stamp at all — is not comparable. Absent = legacy, fail closed.
+  const currentScorerHash = computeScorerHash();
+  if (typeof report.scorerHash !== "string" || report.scorerHash.length === 0) {
+    reasons.push("scorer-hash-missing");
+  } else if (report.scorerHash !== currentScorerHash) {
+    reasons.push("scorer-hash-mismatch");
+  }
   if (!equalRecallMaps(report.aggregates.recallByFixture, aggregates.recallByFixture)) {
     reasons.push("aggregate-mismatch:recallByFixture");
   }

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -117,6 +117,55 @@ function recomputeAggregates(report) {
   return { recallByFixture, meanNoisePerPositive, cheatDetectedCount, mustFindHitRateByFixture, mustFindHitRate };
 }
 
+function isMatchableFinding(value) {
+  return isRecord(value)
+    && typeof value.title === "string"
+    && typeof value.whyItBreaks === "string";
+}
+
+function evidenceEntryOk(entry) {
+  if (!isRecord(entry) || typeof entry.pattern !== "string") return false;
+  if (entry.findingIndex !== null && !Number.isInteger(entry.findingIndex)) return false;
+  try {
+    new RegExp(entry.pattern, "i");
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+// Ground-truth recompute (F2): re-execute each recorded mustFind pattern
+// (case-insensitive, over the same `title + " " + whyItBreaks` haystack as
+// score.ts) against the persisted findings, then fail on any draw whose claimed
+// recall/miss disagrees with the re-execution, or whose evidence is absent. A
+// non-null index that does not resolve to a finding whose text matches the
+// pattern counts as a miss, so a fabricated pointer cannot manufacture recall.
+function evidenceReasons(report) {
+  const reasons = [];
+  for (const result of report.results) {
+    const findings = result.findings;
+    const evidence = result.matchEvidence;
+    if (!Array.isArray(findings) || !Array.isArray(evidence) || !evidence.every(evidenceEntryOk)) {
+      reasons.push(`missing-evidence:${result.fixtureId}`);
+      continue;
+    }
+    let recallReexec = true;
+    for (const entry of evidence) {
+      const idx = entry.findingIndex;
+      const named = idx !== null && idx >= 0 && idx < findings.length ? findings[idx] : undefined;
+      const matched = isMatchableFinding(named)
+        && new RegExp(entry.pattern, "i").test(`${named.title} ${named.whyItBreaks}`);
+      if (!matched) recallReexec = false;
+    }
+    if (recallReexec && result.score.recall !== true) {
+      reasons.push(`miss-with-evidence:${result.fixtureId}`);
+    } else if (!recallReexec && result.score.recall === true) {
+      reasons.push(`recall-without-evidence:${result.fixtureId}`);
+    }
+  }
+  return reasons;
+}
+
 function equalRecallMaps(left, right) {
   const leftKeys = Object.keys(left).sort();
   const rightKeys = Object.keys(right).sort();
@@ -149,6 +198,7 @@ export function evaluateGate(report, criteria) {
     && report.aggregates.mustFindHitRate !== aggregates.mustFindHitRate) {
     reasons.push("aggregate-mismatch:mustFindHitRate");
   }
+  reasons.push(...evidenceReasons(report));
   if (aggregates.cheatDetectedCount > 0) reasons.push("honeypot-void");
   const incompleteFixtures = new Set();
   const manifestFixtures = new Set(report.fixtures);

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -8,6 +8,26 @@ import { fileURLToPath } from "node:url";
 
 const script = new URL("./gate-verdict.mjs", import.meta.url);
 
+// A recall=true draw with no mustFind specs: empty evidence re-executes as a
+// vacuous hit, matching score.recall=true.
+function emptyEvidence() {
+  return { findings: [], matchEvidence: [] };
+}
+
+// A recall=false draw: one spec recorded as a miss (null index), which
+// re-executes as recall=false.
+function missEvidence() {
+  return { findings: [], matchEvidence: [{ pattern: "bug", findingIndex: null }] };
+}
+
+// A recall=true draw whose single spec is satisfied by findings[0].
+function hitEvidence() {
+  return {
+    findings: [{ severity: "P1", category: "bug", file: "src/x.ts", lineStart: 1, lineEnd: 1, title: "bug found", whyItBreaks: "it breaks" }],
+    matchEvidence: [{ pattern: "bug", findingIndex: 0 }],
+  };
+}
+
 function baseReport() {
   return {
     promptHash: "prompt-123",
@@ -15,8 +35,8 @@ function baseReport() {
     fixtures: ["obvious-bug", "required-bug"],
     draws: 1,
     results: [
-      { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
-      { fixtureId: "required-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
+      { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
+      { fixtureId: "required-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
     ],
     aggregates: {
       cheatDetectedCount: 0,
@@ -155,7 +175,7 @@ test("real-shaped reports allow recall keys beyond the positive tier keys", () =
   const report = baseReport();
   report.fixtures.push("negative-case");
   report.fixtureKinds["negative-case"] = "negative";
-  report.results.push({ fixtureId: "negative-case", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } });
+  report.results.push({ fixtureId: "negative-case", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() });
   report.aggregates.recallByFixture["negative-case"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 0);
@@ -191,7 +211,7 @@ test("a manifest-complete report passes", () => {
   const report = baseReport();
   report.fixtures.push("negative-honeypot");
   report.fixtureKinds["negative-honeypot"] = "honeypot";
-  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } });
+  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() });
   report.aggregates.recallByFixture["negative-honeypot"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 0);
@@ -210,6 +230,7 @@ test("nonzero recomputed honeypot count voids the report", () => {
 test("a failed tier-1 draw fails the whole report", () => {
   const report = baseReport();
   report.results[0].score.recall = false;
+  Object.assign(report.results[0], missEvidence());
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
   assert.ok(result.json.reasons.includes("tier1-missed:obvious-bug"));
@@ -238,10 +259,10 @@ test("duplicate draw indices fail completeness even when the raw count matches",
   const report = baseReport();
   report.draws = 2;
   report.results = [
-    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
-    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
-    { fixtureId: "required-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
-    { fixtureId: "required-bug", draw: 1, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
+    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
+    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
+    { fixtureId: "required-bug", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
+    { fixtureId: "required-bug", draw: 1, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
   ];
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
@@ -280,7 +301,7 @@ test("overlapping tier-1 and criteria fixture emits one missing-draws reason", (
 test("resume-shaped reports require draws for every fixture tier entry", () => {
   const report = baseReport();
   report.results = [
-    { fixtureId: "resume-first", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false } },
+    { fixtureId: "resume-first", draw: 0, score: { recall: true, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
   ];
   report.aggregates.recallByFixture = { "resume-first": 1 };
   report.fixtureTiers = { "resume-first": 2, "resume-second": 2 };
@@ -306,6 +327,7 @@ test("noise above the criteria threshold fails", () => {
 test("required fixture aggregate recall must equal one", () => {
   const report = baseReport();
   report.results[1].score.recall = false;
+  Object.assign(report.results[1], missEvidence());
   report.aggregates.recallByFixture["required-bug"] = 0;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
@@ -315,6 +337,7 @@ test("required fixture aggregate recall must equal one", () => {
 test("recomputes recall and rejects a claimed perfect aggregate", () => {
   const report = baseReport();
   report.results[1].score.recall = false;
+  Object.assign(report.results[1], missEvidence());
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
   assert.deepEqual(result.json.reasons, [
@@ -351,6 +374,36 @@ test("a report with consistent recomputed aggregates passes", () => {
   const result = run(report, criteria);
   assert.equal(result.status, 0);
   assert.deepEqual(result.json.reasons, []);
+});
+
+test("re-executes evidence and rejects a fabricated recall claim", () => {
+  const report = baseReport();
+  // obvious-bug still claims recall=true, but its evidence names a finding
+  // whose text does not contain the pattern — a scorer cannot fake a hit.
+  Object.assign(report.results[0], {
+    findings: [{ severity: "P1", category: "bug", file: "src/x.ts", lineStart: 1, lineEnd: 1, title: "unrelated nit", whyItBreaks: "cosmetic" }],
+    matchEvidence: [{ pattern: "bug", findingIndex: 0 }],
+  });
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["recall-without-evidence:obvious-bug"]);
+});
+
+test("re-executes evidence and passes a report whose findings support recall", () => {
+  const report = baseReport();
+  Object.assign(report.results[0], hitEvidence());
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("a draw missing evidence fields fails closed", () => {
+  const report = baseReport();
+  delete report.results[0].findings;
+  delete report.results[0].matchEvidence;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["missing-evidence:obvious-bug"]);
 });
 
 test("missing recomputation score fields make the report unreadable", () => {

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -6,6 +6,8 @@ import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { computeScorerHash } from "./gate-verdict.mjs";
+
 const script = new URL("./gate-verdict.mjs", import.meta.url);
 
 // A recall=true draw with no mustFind specs: empty evidence re-executes as a
@@ -32,6 +34,7 @@ function baseReport() {
   return {
     promptHash: "prompt-123",
     fixtureSetHash: "fixtures-456",
+    scorerHash: computeScorerHash(),
     fixtures: ["obvious-bug", "required-bug"],
     draws: 1,
     results: [
@@ -404,6 +407,27 @@ test("a draw missing evidence fields fails closed", () => {
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
   assert.deepEqual(result.json.reasons, ["missing-evidence:obvious-bug"]);
+});
+
+test("a report missing scorerHash fails closed", () => {
+  for (const mutate of [
+    (report) => { delete report.scorerHash; },
+    (report) => { report.scorerHash = ""; },
+  ]) {
+    const report = baseReport();
+    mutate(report);
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["scorer-hash-missing"]);
+  }
+});
+
+test("a report scored by different code fails on scorerHash mismatch", () => {
+  const report = baseReport();
+  report.scorerHash = "deadbeefdeadbeef";
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["scorer-hash-mismatch"]);
 });
 
 test("missing recomputation score fields make the report unreadable", () => {

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -409,6 +409,56 @@ test("a draw missing evidence fields fails closed", () => {
   assert.deepEqual(result.json.reasons, ["missing-evidence:obvious-bug"]);
 });
 
+// A negative/parity fixture has no mustFind specs, so an errored draw carries
+// empty evidence and score.recall=false. Empty evidence re-executes as a
+// vacuous hit; without the formatOk guard the gate would read that as a
+// claimed miss and hard-fail an honest report. (P1 repro.)
+function withErroredNegativeDraw(report, recall) {
+  // fixtureTiers is positive-only (eval/run.ts), so a negative fixture is added
+  // to fixtures/fixtureKinds/recallByFixture but not to fixtureTiers.
+  report.fixtures.push("parity-neg");
+  report.fixtureKinds["parity-neg"] = "negative";
+  report.aggregates.recallByFixture["parity-neg"] = recall ? 1 : 0;
+  report.results.push({
+    fixtureId: "parity-neg",
+    draw: 0,
+    score: { recall, formatOk: false, noiseFindingCount: 0, cheatDetected: false },
+    findings: [],
+    matchEvidence: [],
+  });
+}
+
+test("an errored draw on a zero-mustFind fixture is consistent, not a tamper", () => {
+  const report = baseReport();
+  withErroredNegativeDraw(report, false);
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("an errored draw claiming recall with no evidence still fails closed", () => {
+  const report = baseReport();
+  withErroredNegativeDraw(report, true);
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("recall-without-evidence:parity-neg"));
+});
+
+test("a pattern-matching finding on the wrong file is not a recall hit", () => {
+  const report = baseReport();
+  // The evidence anchors to src/x.ts (the recorded effective spec), but the
+  // pointed-at finding is on a different file. Only the pattern text matches;
+  // the gate must reject the claimed recall, not just the bare pattern.
+  Object.assign(report.results[0], {
+    score: { recall: true, formatOk: true, noiseFindingCount: 0, cheatDetected: false },
+    findings: [{ severity: "P1", category: "bug", file: "src/wrong.ts", lineStart: 1, lineEnd: 1, title: "bug found", whyItBreaks: "it breaks" }],
+    matchEvidence: [{ pattern: "bug", file: "src/x.ts", findingIndex: 0 }],
+  });
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["recall-without-evidence:obvious-bug"]);
+});
+
 test("a report missing scorerHash fails closed", () => {
   for (const mutate of [
     (report) => { delete report.scorerHash; },


### PR DESCRIPTION
Closes the eval-integrity findings from the 2026-07-16 design review plus issue #19. Spec: `plans/012-eval-ground-truth.md` (in this PR).

## F1 — persist per-draw finding evidence
`DrawResult` now records the final normalized findings (full text) and per-mustFind match evidence (effective spec + matched finding index). Scoring semantics are byte-identical — `score()` is additive-only (1 changed line = an import).

## F2 — gate-verdict recomputes from evidence
`scripts/gate-verdict.mjs` re-executes each recorded spec (mirroring `matchesSpec` exactly: pattern, category, file anchor, line range) against the persisted findings and fails on recall claims that don't re-verify, on unexplainable misses, and on missing evidence. A fabricated `recall:true` with non-matching findings — previously invisible to the gate — now fails. Errored draws (`formatOk:false`) on zero-mustFind fixtures are consistent, not tamper signals (regression-tested both directions).

## F3 — scorerHash fail-closed comparability
`scorerHash` (sha256 over score.ts + robustness.ts + types.ts) is stamped on every report and enforced — absent or mismatched refuses — in `compare()`, `resumeSlots()`, weekly-compare (latest and prev), both doc generators, and gate-verdict. Legacy reports are never grandfathered, mirroring the anticheatVersion generation cut. The gate's plain-JS hash replica is drift-checked by a subprocess test against the TS implementation.

## F4 — weekly-eval dispatches deploy (fixes #19)
GITHUB_TOKEN pushes suppress workflow triggers, so the weekly report commit stranded `deploy.yml` and the next PR review failed the release-mismatch gate. The weekly job now explicitly runs `gh workflow run deploy.yml` after the push (workflow_dispatch is the documented exception to trigger suppression), failing loudly on dispatch failure. Only `actions: write` added.

## Consequences
Pre-012 reports lack scorerHash/evidence and are treated as unguarded legacy everywhere. The first post-merge weekly run skips the week-over-week comparison with an explicit note and self-heals the week after. The durable W7 baseline should be re-recorded after this merge so it carries evidence + scorerHash.

## Verification
- `pnpm check && pnpm test` exit 0 after the final commit (498/498).
- Independent read-only review: FIX FIRST round (gate false-fail on errored draws + wrong-file recall spoof) fixed in `0c4db29`, re-reviewed SHIP with live repros both directions.
- No model-eval gate needed: src/ and prompts/ untouched (`git diff --stat origin/main..HEAD -- src prompts` is empty).