### PR TITLE
workflow: default review lane to gpt-5.6-terra at high effort

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -243,9 +243,12 @@ jobs:
           args=(--github --pr "${{ inputs.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}")
           if [ -z "$NEEDLEFISH_MODEL_INPUT" ]; then
             case "$NEEDLEFISH_RUNNER_INPUT" in
-              codex|pi) NEEDLEFISH_MODEL_INPUT="gpt-5.6-sol" ;;
+              codex|pi) NEEDLEFISH_MODEL_INPUT="gpt-5.6-terra" ;;
               grok) NEEDLEFISH_MODEL_INPUT="grok-4.5" ;;
             esac
+          fi
+          if [ -z "$CODEX_REASONING_EFFORT" ] && [ "$NEEDLEFISH_MODEL_INPUT" = "gpt-5.6-terra" ]; then
+            export CODEX_REASONING_EFFORT="high"
           fi
           if [ -n "$NEEDLEFISH_RUNNER_INPUT" ]; then args+=(--runner "$NEEDLEFISH_RUNNER_INPUT"); fi
           if [ -n "$NEEDLEFISH_MODEL_INPUT" ]; then args+=(--model "$NEEDLEFISH_MODEL_INPUT"); fi


### PR DESCRIPTION
Switch the default review lane from gpt-5.6-sol (medium) to gpt-5.6-terra (high). Explicit `model` / `codex_reasoning_effort` inputs still win; the high default applies only when the resolved model is gpt-5.6-terra.

Measured on identical conditions (anticheat-v2 harness, 84 fixtures, x3, guarded — eval/baselines/2026-07-18-*):

| metric | sol medium | terra high |
|---|---|---|
| recall | 0.879 | 0.885 |
| false positives | 0.111 | 0.014 |
| noise/positive | 0.126 | 0.092 |
| verdict match | 0.944 | 0.972 |
| mean duration | ~53s | ~56s |

Post-merge checklist: one manual workflow_dispatch smoke on a live PR to confirm the Ubuntu runner's codex CLI can reach gpt-5.6-terra.