### PR TITLE
fix(temp): managed temp-directory lifecycle with signal-safe reaping

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { runGithub } from "./adapters/github.js";
 import { runLocal, runLocalPr, printLocal } from "./adapters/local.js";
 import { parseArgs, USAGE } from "./cli/args.js";
 import { serializeReviewResult } from "./shared/schema.js";
+import { initializeTempLifecycle } from "./shared/temp-lifecycle.js";
 import { readFileSync } from "node:fs";
 
 // package.json sits one level above both src/ (dev) and dist/ (published).
@@ -23,6 +24,11 @@ async function main() {
     case "help":
       process.stdout.write(USAGE);
       return;
+  }
+
+  await initializeTempLifecycle();
+
+  switch (command.kind) {
     case "github": {
       if (command.fix) {
         process.stderr.write("--fix is not implemented in v0.2 (see FUTURE_TODO.md).\n");

--- a/src/shared/codex-ephemeral-home.test.ts
+++ b/src/shared/codex-ephemeral-home.test.ts
@@ -240,8 +240,19 @@ test("runCodex ephemeral HOME fail-closed: preparation failure leaves no tmp dir
 			}),
 		/required auth source is missing/,
 	);
+	const strandedInvocationDirectories = readdirSync(scratchTmp, {
+		withFileTypes: true,
+	})
+		.filter(
+			(entry) =>
+				entry.isDirectory() &&
+				/^(?:needlefish-(?:managed-)?|\.needlefish-staging-)[A-Za-z0-9]{6}$/.test(
+					entry.name,
+				),
+		)
+		.map((entry) => entry.name);
 	assert.deepEqual(
-		readdirSync(scratchTmp),
+		strandedInvocationDirectories,
 		[],
 		"a failed preparation must not leak its invocation dir",
 	);

--- a/src/shared/codex-ephemeral-home.test.ts
+++ b/src/shared/codex-ephemeral-home.test.ts
@@ -23,6 +23,8 @@ test("runCodex ephemeral HOME: child HOME is <tmp>/home and is disposed after th
 	const repo = initRepo(tmp);
 	const bin = path.join(tmp, "codex-bin.js");
 	const homeDump = path.join(tmp, "home-dump.json");
+	const lifecycleRoot = path.join(tmp, "lifecycle-root");
+	mkdirSync(lifecycleRoot);
 	// CI-safe: never depend on the real ~/.codex — plant the auth sources in a
 	// fake parent HOME (ubuntu runners have no codex auth).
 	const fakeHome = mkdtempSync(path.join(os.tmpdir(), "needlefish-fakehome-"));
@@ -34,6 +36,7 @@ test("runCodex ephemeral HOME: child HOME is <tmp>/home and is disposed after th
 		ephemeral: process.env.NEEDLEFISH_EPHEMERAL_HOME,
 		retry: process.env.NEEDLEFISH_NO_RETRY,
 		home: process.env.HOME,
+		needlefishTmpdir: process.env.NEEDLEFISH_TMPDIR,
 	};
 	t.after(() => {
 		if (previous.bin === undefined) delete process.env.CODEX_BIN;
@@ -44,6 +47,9 @@ test("runCodex ephemeral HOME: child HOME is <tmp>/home and is disposed after th
 		if (previous.retry === undefined) delete process.env.NEEDLEFISH_NO_RETRY;
 		else process.env.NEEDLEFISH_NO_RETRY = previous.retry;
 		process.env.HOME = previous.home;
+		if (previous.needlefishTmpdir === undefined)
+			delete process.env.NEEDLEFISH_TMPDIR;
+		else process.env.NEEDLEFISH_TMPDIR = previous.needlefishTmpdir;
 		rmSync(tmp, { recursive: true, force: true });
 		rmSync(fakeHome, { recursive: true, force: true });
 	});
@@ -54,7 +60,8 @@ test("runCodex ephemeral HOME: child HOME is <tmp>/home and is disposed after th
 			"const fs = require('node:fs');",
 			"const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
 			`const homeDump = ${JSON.stringify(homeDump)};`,
-			"fs.writeFileSync(homeDump, JSON.stringify({ home: process.env.HOME ?? null }));",
+			"const path = require('node:path');",
+			"fs.writeFileSync(homeDump, JSON.stringify({ home: process.env.HOME ?? null, auth: fs.readFileSync(path.join(process.env.HOME, '.codex', 'auth.json'), 'utf8') }));",
 			"fs.writeFileSync(out, '{\"ok\":true}');",
 		].join("\n"),
 	);
@@ -63,6 +70,7 @@ test("runCodex ephemeral HOME: child HOME is <tmp>/home and is disposed after th
 	process.env.NEEDLEFISH_EPHEMERAL_HOME = "1";
 	process.env.NEEDLEFISH_NO_RETRY = "1";
 	process.env.HOME = fakeHome;
+	process.env.NEEDLEFISH_TMPDIR = lifecycleRoot;
 
 	await runCodex("prompt", {
 		repoPath: repo,
@@ -73,16 +81,18 @@ test("runCodex ephemeral HOME: child HOME is <tmp>/home and is disposed after th
 
 	const dump = JSON.parse(readFileSync(homeDump, "utf8")) as {
 		home: string | null;
+		auth: string;
 	};
 	assert.ok(dump.home, "child HOME must be set");
+	assert.equal(dump.auth, '{"token":"x"}', "the disposable HOME must contain the copied credential");
 	assert.notEqual(
 		dump.home,
 		fakeHome,
 		"child HOME must NOT be the parent's HOME",
 	);
 	assert.ok(
-		dump.home.startsWith(path.join(os.tmpdir(), "needlefish-")),
-		`child HOME must live under the needlefish- tmp prefix, got: ${dump.home}`,
+		dump.home.startsWith(path.join(lifecycleRoot, "needlefish-managed-")),
+		`child HOME must live under the controlled lifecycle root, got: ${dump.home}`,
 	);
 	assert.ok(
 		dump.home.endsWith(`${path.sep}home`),
@@ -211,7 +221,7 @@ test("runCodex ephemeral HOME fail-closed: preparation failure leaves no tmp dir
 		ephemeral: process.env.NEEDLEFISH_EPHEMERAL_HOME,
 		retry: process.env.NEEDLEFISH_NO_RETRY,
 		home: process.env.HOME,
-		tmpdir: process.env.TMPDIR,
+		needlefishTmpdir: process.env.NEEDLEFISH_TMPDIR,
 	};
 	t.after(() => {
 		if (previous.ephemeral === undefined)
@@ -220,15 +230,16 @@ test("runCodex ephemeral HOME fail-closed: preparation failure leaves no tmp dir
 		if (previous.retry === undefined) delete process.env.NEEDLEFISH_NO_RETRY;
 		else process.env.NEEDLEFISH_NO_RETRY = previous.retry;
 		process.env.HOME = previous.home;
-		if (previous.tmpdir === undefined) delete process.env.TMPDIR;
-		else process.env.TMPDIR = previous.tmpdir;
+		if (previous.needlefishTmpdir === undefined)
+			delete process.env.NEEDLEFISH_TMPDIR;
+		else process.env.NEEDLEFISH_TMPDIR = previous.needlefishTmpdir;
 		rmSync(tmp, { recursive: true, force: true });
 		rmSync(fakeHome, { recursive: true, force: true });
 	});
 	process.env.HOME = fakeHome;
 	process.env.NEEDLEFISH_EPHEMERAL_HOME = "1";
 	process.env.NEEDLEFISH_NO_RETRY = "1";
-	process.env.TMPDIR = scratchTmp;
+	process.env.NEEDLEFISH_TMPDIR = scratchTmp;
 
 	await assert.rejects(
 		() =>
@@ -255,6 +266,12 @@ test("runCodex ephemeral HOME fail-closed: preparation failure leaves no tmp dir
 		strandedInvocationDirectories,
 		[],
 		"a failed preparation must not leak its invocation dir",
+	);
+	assert.ok(
+		readdirSync(scratchTmp).some((entry) =>
+			entry.startsWith(".needlefish-owner-lock-"),
+		),
+		"the assertion root must contain the lifecycle artifact created by this allocation",
 	);
 });
 

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -2,12 +2,9 @@ import {
 	existsSync,
 	copyFileSync,
 	mkdirSync,
-	mkdtempSync,
 	readFileSync,
-	rmSync,
 	writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { runAcp } from "./acp.js";
 import { envFlagOn } from "./env.js";
@@ -22,6 +19,10 @@ import {
 	spawnRunnerProcess,
 	type RunnerProcessResult,
 } from "./runner-process.js";
+import {
+	createManagedTempDirectory,
+	disposeManagedTempDirectory,
+} from "./temp-lifecycle.js";
 import {
 	assertRunnerSandboxClean,
 	isRunnerSafetyError,
@@ -520,8 +521,8 @@ async function runCodexOnce(
 			opts.onRaw?.(raw, runnerAttempt),
 		);
 	}
-	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-"));
-	// Everything after mkdtemp lives inside the try: a preparation failure
+	const tmp = await createManagedTempDirectory();
+	// Everything after temp allocation lives inside the try: a preparation failure
 	// (e.g. fail-closed missing auth in prepareEphemeralHome) must still hit
 	// the finally cleanup, or it leaks the dir — with copied credentials in it.
 	try {
@@ -606,7 +607,7 @@ async function runCodexOnce(
 			throw err;
 		}
 	} finally {
-		rmSync(tmp, { recursive: true, force: true });
+		await disposeManagedTempDirectory(tmp);
 	}
 }
 

--- a/src/shared/runner-process.ts
+++ b/src/shared/runner-process.ts
@@ -1,4 +1,8 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  assertRunnerSchedulingAllowed,
+  registerRunnerProcessGroup,
+} from "./temp-lifecycle.js";
 
 const RUNNER_MAX_BUFFER_BYTES = 1024 * 1024 * 64;
 
@@ -73,6 +77,7 @@ export async function spawnRunnerProcess(
 export async function runManagedRunnerProcess(
   invocation: ManagedRunnerProcessInvocation
 ): Promise<RunnerProcessResult> {
+  assertRunnerSchedulingAllowed();
   return await new Promise<RunnerProcessResult>((resolve) => {
     const stdout: string[] = [];
     const stderr: string[] = [];
@@ -163,6 +168,14 @@ export async function runManagedRunnerProcess(
         beginKillSequence("SIGTERM");
       },
     };
+    const unregisterProcessGroup =
+      child.pid === undefined
+        ? () => {}
+        : registerRunnerProcessGroup(
+            child.pid,
+            beginKillSequence,
+            () => killRunnerProcessTree(child.pid, "SIGKILL"),
+          );
 
     const collect = (chunks: string[], bytes: { count: number }, chunk: unknown): string | null => {
       if (bufferError !== undefined) return null;
@@ -206,7 +219,10 @@ export async function runManagedRunnerProcess(
       spawnError = error;
       finish(null, null);
     });
-    child.on("close", (status, signal) => finish(status, signal));
+    child.on("close", (status, signal) => {
+      unregisterProcessGroup();
+      finish(status, signal);
+    });
 
     timer = setTimeout(() => {
       timedOut = true;

--- a/src/shared/runner-process.ts
+++ b/src/shared/runner-process.ts
@@ -99,6 +99,7 @@ export async function runManagedRunnerProcess(
       detached: process.platform !== "win32",
       stdio: ["pipe", "pipe", "pipe"],
     });
+    const childClosed = new Promise<void>((resolve) => child.once("close", () => resolve()));
 
     const beginKillSequence = (firstSignal: NodeJS.Signals): void => {
       if (killStarted) return;
@@ -173,8 +174,10 @@ export async function runManagedRunnerProcess(
         ? () => {}
         : registerRunnerProcessGroup(
             child.pid,
+            invocation.repoPath,
             beginKillSequence,
             () => killRunnerProcessTree(child.pid, "SIGKILL"),
+            childClosed,
           );
 
     const collect = (chunks: string[], bytes: { count: number }, chunk: unknown): string | null => {
@@ -269,7 +272,9 @@ function runnerSigkillGiveUpMs(): number {
 function killRunnerProcessTree(pid: number | undefined, signal: NodeJS.Signals): void {
   if (pid === undefined) return;
   if (process.platform === "win32") {
-    spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore" });
+    const args = ["/pid", String(pid), "/T"];
+    if (signal === "SIGKILL") args.push("/F");
+    spawnSync("taskkill", args, { stdio: "ignore" });
     return;
   }
   try {

--- a/src/shared/runner-process.ts
+++ b/src/shared/runner-process.ts
@@ -101,8 +101,8 @@ export async function runManagedRunnerProcess(
     });
     const childClosed = new Promise<void>((resolve) => child.once("close", () => resolve()));
 
-    const beginKillSequence = (firstSignal: NodeJS.Signals): void => {
-      if (killStarted) return;
+    const forceKillSequence = (): void => {
+      if (settled) return;
       killStarted = true;
       if (timer !== null) {
         clearTimeout(timer);
@@ -112,13 +112,34 @@ export async function runManagedRunnerProcess(
         clearTimeout(cancelTimer);
         cancelTimer = null;
       }
-      killRunnerProcessTree(child.pid, firstSignal);
-      if (firstSignal === "SIGKILL") {
+      if (hardKillTimer !== null) {
+        clearTimeout(hardKillTimer);
+        hardKillTimer = null;
+      }
+      signalRunnerProcessTree(child, "SIGKILL");
+      if (giveUpTimer === null) {
         giveUpTimer = setTimeout(() => finish(null, "SIGKILL"), runnerSigkillGiveUpMs());
+      }
+    };
+
+    const beginKillSequence = (firstSignal: NodeJS.Signals): void => {
+      if (killStarted) return;
+      if (firstSignal === "SIGKILL") {
+        forceKillSequence();
         return;
       }
+      killStarted = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (cancelTimer !== null) {
+        clearTimeout(cancelTimer);
+        cancelTimer = null;
+      }
+      signalRunnerProcessTree(child, firstSignal);
       hardKillTimer = setTimeout(() => {
-        killRunnerProcessTree(child.pid, "SIGKILL");
+        signalRunnerProcessTree(child, "SIGKILL");
         giveUpTimer = setTimeout(() => {
           // A setsid-escaped descendant has left this kill group and may keep inherited pipes open.
           // We cannot kill that escapee here; the goal is to stop waiting for child "close".
@@ -176,7 +197,7 @@ export async function runManagedRunnerProcess(
             child.pid,
             invocation.repoPath,
             beginKillSequence,
-            () => killRunnerProcessTree(child.pid, "SIGKILL"),
+            forceKillSequence,
             childClosed,
           );
 
@@ -269,8 +290,10 @@ function runnerSigkillGiveUpMs(): number {
   return readRunnerDurationMs(process.env.NEEDLEFISH_RUNNER_SIGKILL_GIVE_UP_MS, 2000);
 }
 
-function killRunnerProcessTree(pid: number | undefined, signal: NodeJS.Signals): void {
+function signalRunnerProcessTree(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
+  const pid = child.pid;
   if (pid === undefined) return;
+  if (child.exitCode !== null || child.signalCode !== null) return;
   if (process.platform === "win32") {
     const args = ["/pid", String(pid), "/T"];
     if (signal === "SIGKILL") args.push("/F");

--- a/src/shared/runner-sandbox.ts
+++ b/src/shared/runner-sandbox.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { RunnerName } from "./runner.js";
+import { RunnerTerminatingError } from "./temp-lifecycle.js";
 
 export interface RunnerSandbox {
   readonly repoPath: string;
@@ -31,7 +32,7 @@ class RunnerWorktreeChangedError extends Error {
 }
 
 export function isRunnerSafetyError(error: unknown): boolean {
-  return error instanceof RunnerWorktreeChangedError;
+  return error instanceof RunnerWorktreeChangedError || error instanceof RunnerTerminatingError;
 }
 
 export function prepareRunnerSandbox(options: RunnerSandboxOptions): RunnerSandbox {

--- a/src/shared/temp-lifecycle.test.ts
+++ b/src/shared/temp-lifecycle.test.ts
@@ -184,20 +184,130 @@ setInterval(() => {}, 1000);
   assert.equal(children.length, 1, "one needlefish process must have one persistent lock holder");
 });
 
+for (const [signal, expectedStatus] of [
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+] as const) {
+  test(`portable ${signal} waits for runner exit before deleting its temp tree`, { timeout: 10_000 }, async (t) => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+    const readyPath = path.join(root, "ready");
+    const pidPath = path.join(root, "runner-pid");
+    const termMarker = path.join(root, "runner-saw-tree");
+    const owner = spawnModuleOnPlatform(`
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createManagedTempDirectory, disposeManagedTempDirectory, initializeTempLifecycle } from ${JSON.stringify(lifecycleUrl)};
+import { spawnRunnerProcess } from ${JSON.stringify(runnerProcessUrl)};
+await initializeTempLifecycle();
+const directory = await createManagedTempDirectory();
+const runnerRepo = path.join(directory, "runner-repo");
+mkdirSync(runnerRepo);
+const runner = path.join(runnerRepo, "runner.js");
+writeFileSync(runner, ${JSON.stringify(`
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+const onSignal = () => {
+  fs.writeFileSync(${JSON.stringify(termMarker)}, String(fs.existsSync(process.cwd()) && fs.existsSync(__filename)));
+};
+process.on("SIGINT", onSignal);
+process.on("SIGTERM", onSignal);
+setInterval(() => {}, 1000);
+`)});
+writeFileSync(${JSON.stringify(readyPath)}, directory);
+const running = spawnRunnerProcess({
+  command: process.execPath,
+  args: [runner],
+  stdin: "",
+  repoPath: runnerRepo,
+  timeoutMs: 60_000,
+  env: process.env,
+});
+try {
+  await running;
+} finally {
+  await disposeManagedTempDirectory(directory);
+}
+`, root, "darwin", {
+      NEEDLEFISH_RUNNER_TIMEOUT_GRACE_MS: "1000",
+      NEEDLEFISH_TERMINATION_GRACE_MS: "100",
+      PATH: "/needlefish-test-no-tools",
+    });
+    const cleanup: { runnerPid?: number } = {};
+    t.after(() => {
+      killIfRunning(owner.pid);
+      if (cleanup.runnerPid !== undefined) killIfRunning(-cleanup.runnerPid);
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    await waitForFile(readyPath);
+    await waitForFile(pidPath);
+    const directory = readFileSync(readyPath, "utf8");
+    const runnerPid = Number(readFileSync(pidPath, "utf8"));
+    cleanup.runnerPid = runnerPid;
+    owner.kill(signal);
+    const [status, exitSignal] = await waitForExit(owner);
+
+    assert.equal(status, expectedStatus);
+    assert.equal(exitSignal, null);
+    assert.equal(readFileSync(termMarker, "utf8"), "true");
+    assert.throws(() => process.kill(-runnerPid, 0), isMissingProcess);
+    assert.equal(existsSync(directory), false, "temp tree must be deleted after runner close");
+  });
+}
+
+test("portable termination preserves a temp tree when runner exit cannot be confirmed", { timeout: 10_000 }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const readyPath = path.join(root, "ready");
+  const termMarker = path.join(root, "term-seen");
+  const killMarker = path.join(root, "kill-seen");
+  const owner = spawnModuleOnPlatform(`
+import { writeFileSync } from "node:fs";
+import { createManagedTempDirectory, initializeTempLifecycle, registerRunnerProcessGroup } from ${JSON.stringify(lifecycleUrl)};
+await initializeTempLifecycle();
+const directory = await createManagedTempDirectory();
+registerRunnerProcessGroup(
+  123,
+  directory,
+  () => writeFileSync(${JSON.stringify(termMarker)}, "1"),
+  () => writeFileSync(${JSON.stringify(killMarker)}, "1"),
+  new Promise(() => {}),
+);
+writeFileSync(${JSON.stringify(readyPath)}, directory);
+setInterval(() => {}, 1000);
+`, root, "darwin", {
+    NEEDLEFISH_TERMINATION_GRACE_MS: "50",
+    PATH: "/needlefish-test-no-tools",
+  });
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  await waitForFile(readyPath);
+  const directory = readFileSync(readyPath, "utf8");
+  owner.kill("SIGTERM");
+  const [status, signal] = await waitForExit(owner);
+
+  assert.equal(status, 143);
+  assert.equal(signal, null);
+  assert.equal(existsSync(termMarker), true);
+  assert.equal(existsSync(killMarker), true);
+  assert.equal(existsSync(directory), true, "unconfirmed runner temp tree must be preserved");
+});
+
 test("non-Linux lifecycle uses finally-cleaned legacy temp directories without flock", async (t) => {
   const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
   const marker = path.join(root, "fallback.json");
-  const owner = spawnModule(`
+  const owner = spawnModuleOnPlatform(`
 import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
-Object.defineProperty(process, "platform", { value: "darwin" });
-const lifecycle = await import(${JSON.stringify(lifecycleUrl)});
+import * as lifecycle from ${JSON.stringify(lifecycleUrl)};
 await lifecycle.initializeTempLifecycle();
 const directory = await lifecycle.createManagedTempDirectory();
 const name = path.basename(directory);
 await lifecycle.disposeManagedTempDirectory(directory);
 writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ name, exists: existsSync(directory) }));
-`, root, { PATH: "/needlefish-test-no-tools" });
+`, root, "darwin", { PATH: "/needlefish-test-no-tools" });
   t.after(() => {
     killIfRunning(owner.pid);
     rmSync(root, { recursive: true, force: true });
@@ -241,6 +351,32 @@ function spawnModule(source: string, tmpRoot: string, extraEnv: NodeJS.ProcessEn
   return spawn(
     process.execPath,
     ["--import", importTarget, "--input-type=module", "--eval", source],
+    {
+      env: { ...process.env, ...extraEnv, NEEDLEFISH_TMPDIR: tmpRoot },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+}
+
+function spawnModuleOnPlatform(
+  source: string,
+  tmpRoot: string,
+  platform: NodeJS.Platform,
+  extraEnv: NodeJS.ProcessEnv = {},
+): ChildProcessWithoutNullStreams {
+  const preload = path.join(tmpRoot, `.platform-${platform}.cjs`);
+  writeFileSync(
+    preload,
+    `Object.defineProperty(process, "platform", { value: ${JSON.stringify(platform)} });\n`,
+  );
+  const importIndex = process.execArgv.indexOf("--import");
+  const importTarget = process.execArgv[importIndex + 1];
+  if (importIndex === -1 || importTarget === undefined) {
+    throw new Error("test process is missing its TypeScript import hook");
+  }
+  return spawn(
+    process.execPath,
+    ["--require", preload, "--import", importTarget, "--input-type=module", "--eval", source],
     {
       env: { ...process.env, ...extraEnv, NEEDLEFISH_TMPDIR: tmpRoot },
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/shared/temp-lifecycle.test.ts
+++ b/src/shared/temp-lifecycle.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -18,7 +20,9 @@ import { setTimeout as delay } from "node:timers/promises";
 import {
   reapManagedTempDirectories,
   resolveNeedlefishTempRoot,
+  RunnerTerminatingError,
 } from "./temp-lifecycle";
+import { isRunnerSafetyError } from "./runner-sandbox";
 
 const lifecycleUrl = pathToFileURL(path.resolve("src/shared/temp-lifecycle.ts")).href;
 const runnerProcessUrl = pathToFileURL(path.resolve("src/shared/runner-process.ts")).href;
@@ -64,9 +68,15 @@ setInterval(() => {}, 1000);
 test("startup reaper gives recent legacy directories an age grace", { skip: process.platform !== "linux" }, async (t) => {
   const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
   const legacy = path.join(root, "needlefish-Ab12Cd");
+  const previous = process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS;
   mkdirSync(legacy);
   writeFileSync(path.join(legacy, "payload"), "x");
-  t.after(() => rmSync(root, { recursive: true, force: true }));
+  t.after(() => {
+    if (previous === undefined) delete process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS;
+    else process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS = previous;
+    rmSync(root, { recursive: true, force: true });
+  });
+  process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS = "1";
 
   await reapManagedTempDirectories(root);
   assert.equal(existsSync(legacy), true, "a recent markerless legacy directory must be preserved");
@@ -75,6 +85,237 @@ test("startup reaper gives recent legacy directories an age grace", { skip: proc
   utimesSync(legacy, old, old);
   await reapManagedTempDirectories(root);
   assert.equal(existsSync(legacy), false, "a legacy directory past the grace must be reaped");
+});
+
+test("startup reaper preserves unowned legacy and quarantine directories by default", { skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const legacy = path.join(root, "needlefish-Ab12Cd");
+  const quarantine = path.join(root, ".needlefish-quarantine-123-456-0");
+  const previous = process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS;
+  for (const directory of [legacy, quarantine]) {
+    mkdirSync(directory);
+    writeFileSync(path.join(directory, "unrelated-data"), "keep");
+    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+    utimesSync(directory, old, old);
+  }
+  t.after(() => {
+    if (previous === undefined) delete process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS;
+    else process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS = previous;
+    rmSync(root, { recursive: true, force: true });
+  });
+  delete process.env.NEEDLEFISH_REAP_LEGACY_TMPDIRS;
+
+  await reapManagedTempDirectories(root);
+
+  assert.equal(existsSync(legacy), true, "markerless legacy data is not owned by needlefish");
+  assert.equal(existsSync(quarantine), true, "markerless quarantine data is not owned by needlefish");
+});
+
+test("startup reaper ages an owned quarantine before deleting it", { skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const owner = spawnModule(`
+import { writeFileSync } from "node:fs";
+import { createManagedTempDirectory } from ${JSON.stringify(lifecycleUrl)};
+writeFileSync(${JSON.stringify(path.join(root, "managed"))}, await createManagedTempDirectory());
+setInterval(() => {}, 1000);
+`, root);
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const managedMarker = path.join(root, "managed");
+  await waitForFile(managedMarker);
+  const managed = readFileSync(managedMarker, "utf8");
+  owner.kill("SIGKILL");
+  await waitForExit(owner);
+  const quarantine = path.join(root, ".needlefish-quarantine-123-456-0");
+  renameSync(managed, quarantine);
+
+  await reapManagedTempDirectories(root);
+  assert.equal(existsSync(quarantine), true, "a concurrent/recent quarantine must be left alone");
+
+  const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+  utimesSync(quarantine, old, old);
+  await reapManagedTempDirectories(root);
+  assert.equal(existsSync(quarantine), false, "an aged, marker-owned quarantine is collectable");
+});
+
+test("termination unregisters a runner that closes during grace and exits immediately", { timeout: 10_000 }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const ready = path.join(root, "ready");
+  const killed = path.join(root, "stale-kill");
+  const owner = spawnModule(`
+import { writeFileSync } from "node:fs";
+import { registerRunnerProcessGroup } from ${JSON.stringify(lifecycleUrl)};
+let unregister = () => {};
+let markExited = () => {};
+const exited = new Promise((resolve) => { markExited = resolve; });
+unregister = registerRunnerProcessGroup(
+  123,
+  ${JSON.stringify(root)},
+  () => setTimeout(() => { unregister(); markExited(); }, 25),
+  () => writeFileSync(${JSON.stringify(killed)}, "1"),
+  exited,
+);
+writeFileSync(${JSON.stringify(ready)}, "1");
+setInterval(() => {}, 1000);
+`, root, { NEEDLEFISH_TERMINATION_GRACE_MS: "1500" });
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  await waitForFile(ready);
+  const started = Date.now();
+  owner.kill("SIGTERM");
+  const [status, signal] = await waitForExit(owner);
+
+  assert.equal(signal, null);
+  assert.equal(status, 143);
+  assert.ok(Date.now() - started < 700, "last runner close must end the grace wait");
+  assert.equal(existsSync(killed), false, "an unregistered runner must never receive SIGKILL");
+});
+
+test("a dead process-owner lock holder is reacquired for later allocations", { timeout: 10_000, skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const marker = path.join(root, "directories.json");
+  const owner = spawnModule(`
+import { readFileSync, writeFileSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+import { createManagedTempDirectory } from ${JSON.stringify(lifecycleUrl)};
+const first = await createManagedTempDirectory();
+const childrenPath = \`/proc/\${process.pid}/task/\${process.pid}/children\`;
+const holderPid = Number(readFileSync(childrenPath, "utf8").trim());
+process.kill(holderPid, "SIGKILL");
+for (let attempt = 0; attempt < 100; attempt++) {
+  try { process.kill(holderPid, 0); } catch { break; }
+  await delay(10);
+}
+const second = await createManagedTempDirectory();
+writeFileSync(${JSON.stringify(marker)}, JSON.stringify([first, second]));
+`, root);
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const [status, signal] = await waitForExit(owner);
+  assert.equal(signal, null);
+  assert.equal(status, 0, owner.stderr.read()?.toString());
+  const directories = JSON.parse(readFileSync(marker, "utf8")) as string[];
+  assert.equal(directories.length, 2);
+  assert.ok(directories.every((directory) => existsSync(directory)));
+});
+
+test("lock readiness is rejected unless the holder actually owns the lock", { timeout: 10_000, skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const binDir = path.join(root, "bin");
+  const fakeFlock = path.join(binDir, "flock");
+  const resultPath = path.join(root, "result");
+  mkdirSync(binDir);
+  writeFileSync(fakeFlock, `#!/usr/bin/env node
+const fs = require("node:fs");
+const last = process.argv.at(-1);
+if (last === "true") process.exit(0);
+fs.writeFileSync(last, "ready-without-lock");
+process.stdin.resume();
+process.stdin.on("end", () => process.exit(0));
+`);
+  chmodSync(fakeFlock, 0o755);
+  const owner = spawnModule(`
+import { writeFileSync } from "node:fs";
+import { reapManagedTempDirectories } from ${JSON.stringify(lifecycleUrl)};
+try {
+  await reapManagedTempDirectories(${JSON.stringify(root)});
+  writeFileSync(${JSON.stringify(resultPath)}, "unexpected success");
+} catch (error) {
+  writeFileSync(${JSON.stringify(resultPath)}, error instanceof Error ? error.message : String(error));
+}
+`, root, { PATH: `${binDir}:${process.env.PATH ?? ""}` });
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const [status, signal] = await waitForExit(owner);
+  assert.equal(signal, null);
+  assert.equal(status, 0, owner.stderr.read()?.toString());
+  assert.match(readFileSync(resultPath, "utf8"), /reported ready without holding the lock/);
+});
+
+test("startup reaper treats malformed owner JSON as an invalid marker", { skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const managed = path.join(root, "needlefish-managed-Ab12Cd");
+  mkdirSync(managed);
+  writeFileSync(path.join(managed, ".needlefish-owner.json"), '{"pid":');
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  await reapManagedTempDirectories(root);
+
+  assert.equal(existsSync(managed), true, "invalid ownership metadata must never authorize deletion");
+});
+
+test("termination errors use the runner safety escape hatch", () => {
+  const error = new RunnerTerminatingError("SIGINT");
+  assert.equal(error.name, "RunnerTerminatingError");
+  assert.equal(isRunnerSafetyError(error), true);
+});
+
+test("startup reaper removes an unlocked owner file only after its owner directory is gone", { timeout: 10_000, skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const owner = spawnModule(`
+import { writeFileSync } from "node:fs";
+import { createManagedTempDirectory } from ${JSON.stringify(lifecycleUrl)};
+writeFileSync(${JSON.stringify(path.join(root, "managed"))}, await createManagedTempDirectory());
+setInterval(() => {}, 1000);
+`, root);
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const marker = path.join(root, "managed");
+  await waitForFile(marker);
+  const managed = readFileSync(marker, "utf8");
+  const metadata = JSON.parse(readFileSync(path.join(managed, ".needlefish-owner.json"), "utf8")) as { ownerLock: string };
+  assert.equal(existsSync(metadata.ownerLock), true);
+
+  owner.kill("SIGKILL");
+  await waitForExit(owner);
+  await reapManagedTempDirectories(root);
+
+  assert.equal(existsSync(managed), false);
+  assert.equal(existsSync(metadata.ownerLock), false, "dead, unreferenced owner locks must not accumulate");
+});
+
+test("startup reaper collects an orphaned owner lock alongside a metadata-less quarantine", { timeout: 10_000, skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const owner = spawnModule(`
+import { writeFileSync } from "node:fs";
+import { createManagedTempDirectory } from ${JSON.stringify(lifecycleUrl)};
+writeFileSync(${JSON.stringify(path.join(root, "managed"))}, await createManagedTempDirectory());
+setInterval(() => {}, 1000);
+`, root);
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const marker = path.join(root, "managed");
+  await waitForFile(marker);
+  const managed = readFileSync(marker, "utf8");
+  const metadata = JSON.parse(readFileSync(path.join(managed, ".needlefish-owner.json"), "utf8")) as { ownerLock: string };
+  const quarantine = path.join(root, ".needlefish-quarantine-1234-1700000000000-0");
+  mkdirSync(quarantine);
+
+  owner.kill("SIGKILL");
+  await waitForExit(owner);
+  await reapManagedTempDirectories(root);
+
+  assert.equal(existsSync(managed), false);
+  assert.equal(existsSync(quarantine), true, "unattributable quarantine data must be preserved");
+  assert.equal(existsSync(metadata.ownerLock), false, "an unrelated unattributable quarantine must not block orphan lock collection");
 });
 
 for (const [signal, expectedStatus] of [

--- a/src/shared/temp-lifecycle.test.ts
+++ b/src/shared/temp-lifecycle.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  reapManagedTempDirectories,
+  resolveNeedlefishTempRoot,
+} from "./temp-lifecycle";
+
+const lifecycleUrl = pathToFileURL(path.resolve("src/shared/temp-lifecycle.ts")).href;
+const runnerProcessUrl = pathToFileURL(path.resolve("src/shared/runner-process.ts")).href;
+
+test("NEEDLEFISH_TMPDIR overrides the ambient temp root", (t) => {
+  const previous = process.env.NEEDLEFISH_TMPDIR;
+  t.after(() => {
+    if (previous === undefined) delete process.env.NEEDLEFISH_TMPDIR;
+    else process.env.NEEDLEFISH_TMPDIR = previous;
+  });
+  process.env.NEEDLEFISH_TMPDIR = path.join("relative", "scratch");
+  assert.equal(resolveNeedlefishTempRoot(), path.resolve("relative", "scratch"));
+});
+
+test("startup reaper preserves a locked live directory and removes it after owner death", { skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const owner = spawnModule(`
+import { createManagedTempDirectory } from ${JSON.stringify(lifecycleUrl)};
+const directory = await createManagedTempDirectory();
+setInterval(() => {}, 1000);
+`, root);
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const directory = await waitForManagedDirectory(root);
+  assert.equal(path.dirname(directory), root);
+  assert.equal(existsSync(directory), true);
+
+  await reapManagedTempDirectories(root);
+  assert.equal(existsSync(directory), true, "a kernel-locked live directory must be preserved");
+
+  owner.kill("SIGKILL");
+  await waitForExit(owner);
+  for (let attempt = 0; attempt < 20 && existsSync(directory); attempt++) {
+    await reapManagedTempDirectories(root);
+    await delay(25);
+  }
+  assert.equal(existsSync(directory), false, "the unlocked orphan must be reaped");
+});
+
+test("startup reaper gives recent legacy directories an age grace", { skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const legacy = path.join(root, "needlefish-Ab12Cd");
+  mkdirSync(legacy);
+  writeFileSync(path.join(legacy, "payload"), "x");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  await reapManagedTempDirectories(root);
+  assert.equal(existsSync(legacy), true, "a recent markerless legacy directory must be preserved");
+
+  const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+  utimesSync(legacy, old, old);
+  await reapManagedTempDirectories(root);
+  assert.equal(existsSync(legacy), false, "a legacy directory past the grace must be reaped");
+});
+
+for (const [signal, expectedStatus] of [
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+] as const) {
+  test(`process ${signal} stops and kills the runner group without deleting its live tree`, { timeout: 10_000, skip: process.platform !== "linux" }, async (t) => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+    const termMarker = path.join(root, "runner-saw-tree");
+    const pidPath = path.join(root, "runner-pid");
+    const owner = spawnModule(`
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createManagedTempDirectory, disposeManagedTempDirectory } from ${JSON.stringify(lifecycleUrl)};
+import { spawnRunnerProcess } from ${JSON.stringify(runnerProcessUrl)};
+const directory = await createManagedTempDirectory();
+const runnerRepo = path.join(directory, "runner-repo");
+mkdirSync(runnerRepo);
+const runner = path.join(runnerRepo, "runner.js");
+writeFileSync(runner, ${JSON.stringify(`
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+const onSignal = () => {
+  fs.writeFileSync(${JSON.stringify(termMarker)}, String(fs.existsSync(process.cwd()) && fs.existsSync(__filename)));
+};
+process.on("SIGINT", onSignal);
+process.on("SIGTERM", onSignal);
+setInterval(() => {}, 1000);
+`)});
+const running = spawnRunnerProcess({
+  command: process.execPath,
+  args: [runner],
+  stdin: "",
+  repoPath: runnerRepo,
+  timeoutMs: 60_000,
+  env: process.env,
+});
+try {
+  await running;
+} finally {
+  await disposeManagedTempDirectory(directory);
+}
+`, root, {
+      NEEDLEFISH_RUNNER_TIMEOUT_GRACE_MS: "1000",
+      NEEDLEFISH_TERMINATION_GRACE_MS: "150",
+    });
+    const cleanup: { runnerPid?: number } = {};
+    t.after(() => {
+      killIfRunning(owner.pid);
+      if (cleanup.runnerPid !== undefined) killIfRunning(-cleanup.runnerPid);
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    const directory = await waitForManagedDirectory(root);
+    await waitForFile(pidPath);
+    const runnerPid = Number(readFileSync(pidPath, "utf8"));
+    cleanup.runnerPid = runnerPid;
+    const started = Date.now();
+    owner.kill(signal);
+    const [status, exitSignal] = await waitForExit(owner);
+
+    assert.equal(status, expectedStatus);
+    assert.equal(exitSignal, null);
+    assert.ok(Date.now() - started < 2000, "termination must stay bounded");
+    assert.equal(readFileSync(termMarker, "utf8"), "true");
+    assert.equal(existsSync(directory), true, "signal handling must leave deletion to the reaper");
+    assert.throws(() => process.kill(-runnerPid, 0), isMissingProcess);
+
+    await reapUntilGone(root, directory);
+    assert.equal(existsSync(directory), false);
+  });
+}
+
+test("all managed directories share one process owner lock and holder", { skip: process.platform !== "linux" }, async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const marker = path.join(root, "directories.json");
+  const owner = spawnModule(`
+import { writeFileSync } from "node:fs";
+import { createManagedTempDirectory } from ${JSON.stringify(lifecycleUrl)};
+const directories = await Promise.all([
+  createManagedTempDirectory(),
+  createManagedTempDirectory(),
+  createManagedTempDirectory(),
+]);
+writeFileSync(${JSON.stringify(marker)}, JSON.stringify(directories));
+setInterval(() => {}, 1000);
+`, root);
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  await waitForFile(marker);
+  const directories = JSON.parse(readFileSync(marker, "utf8")) as string[];
+  const ownerLocks = directories.map((directory) => {
+    const metadata = JSON.parse(
+      readFileSync(path.join(directory, ".needlefish-owner.json"), "utf8"),
+    ) as { ownerLock: string };
+    return metadata.ownerLock;
+  });
+  assert.equal(new Set(ownerLocks).size, 1, "all directories must reference one owner lock");
+
+  const children = readFileSync(`/proc/${owner.pid}/task/${owner.pid}/children`, "utf8")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  assert.equal(children.length, 1, "one needlefish process must have one persistent lock holder");
+});
+
+test("non-Linux lifecycle uses finally-cleaned legacy temp directories without flock", async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "needlefish-lifecycle-test-"));
+  const marker = path.join(root, "fallback.json");
+  const owner = spawnModule(`
+import { existsSync, writeFileSync } from "node:fs";
+import path from "node:path";
+Object.defineProperty(process, "platform", { value: "darwin" });
+const lifecycle = await import(${JSON.stringify(lifecycleUrl)});
+await lifecycle.initializeTempLifecycle();
+const directory = await lifecycle.createManagedTempDirectory();
+const name = path.basename(directory);
+await lifecycle.disposeManagedTempDirectory(directory);
+writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ name, exists: existsSync(directory) }));
+`, root, { PATH: "/needlefish-test-no-tools" });
+  t.after(() => {
+    killIfRunning(owner.pid);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const [status, signal] = await waitForExit(owner);
+  assert.equal(signal, null);
+  assert.equal(status, 0, owner.stderr.read()?.toString());
+  const result = JSON.parse(readFileSync(marker, "utf8")) as { name: string; exists: boolean };
+  assert.match(result.name, /^needlefish-[A-Za-z0-9]{6}$/);
+  assert.equal(result.exists, false);
+});
+
+for (const flag of ["--help", "--version"] as const) {
+  test(`${flag} bypasses temp lifecycle initialization`, async () => {
+    const importIndex = process.execArgv.indexOf("--import");
+    const importTarget = process.execArgv[importIndex + 1];
+    if (importIndex === -1 || importTarget === undefined) {
+      throw new Error("test process is missing its TypeScript import hook");
+    }
+    const child = spawn(
+      process.execPath,
+      ["--import", importTarget, path.resolve("src/cli.ts"), flag],
+      {
+        env: { ...process.env, NEEDLEFISH_TMPDIR: "/proc/needlefish-must-not-be-created" },
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    const [status, signal] = await waitForExit(child);
+    assert.equal(signal, null);
+    assert.equal(status, 0, child.stderr.read()?.toString());
+  });
+}
+
+function spawnModule(source: string, tmpRoot: string, extraEnv: NodeJS.ProcessEnv = {}): ChildProcessWithoutNullStreams {
+  const importIndex = process.execArgv.indexOf("--import");
+  const importTarget = process.execArgv[importIndex + 1];
+  if (importIndex === -1 || importTarget === undefined) {
+    throw new Error("test process is missing its TypeScript import hook");
+  }
+  return spawn(
+    process.execPath,
+    ["--import", importTarget, "--input-type=module", "--eval", source],
+    {
+      env: { ...process.env, ...extraEnv, NEEDLEFISH_TMPDIR: tmpRoot },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+}
+
+async function waitForFile(file: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (existsSync(file)) return;
+    await delay(20);
+  }
+  throw new Error(`timed out waiting for ${file}`);
+}
+
+async function waitForManagedDirectory(root: string): Promise<string> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const name = readdirSync(root).find((entry) => /^needlefish-managed-[A-Za-z0-9]{6}$/.test(entry));
+    if (name !== undefined) return path.join(root, name);
+    await delay(20);
+  }
+  throw new Error(`timed out waiting for a managed directory under ${root}`);
+}
+
+async function reapUntilGone(root: string, directory: string): Promise<void> {
+  for (let attempt = 0; attempt < 20 && existsSync(directory); attempt++) {
+    await reapManagedTempDirectories(root);
+    await delay(25);
+  }
+}
+
+async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<[number | null, NodeJS.Signals | null]> {
+  return await new Promise((resolve) => child.once("exit", (status, signal) => resolve([status, signal])));
+}
+
+function killIfRunning(pid: number | undefined): void {
+  if (pid === undefined) return;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if (!isMissingProcess(error)) throw error;
+  }
+}
+
+function isMissingProcess(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ESRCH";
+}

--- a/src/shared/temp-lifecycle.ts
+++ b/src/shared/temp-lifecycle.ts
@@ -42,8 +42,10 @@ interface ProcessOwner {
 }
 
 interface RunnerProcessGroup {
+  readonly directory: string | null;
   readonly terminate: (signal: NodeJS.Signals) => void;
   readonly kill: () => void;
+  readonly exited: Promise<void>;
 }
 
 const activeTempDirectories = new Set<string>();
@@ -59,15 +61,15 @@ function isLinux(): boolean {
 }
 
 export function installTerminationCoordinator(): void {
-  if (!isLinux() || coordinatorInstalled) return;
+  if (coordinatorInstalled) return;
   coordinatorInstalled = true;
   process.on("SIGINT", onSigint);
   process.on("SIGTERM", onSigterm);
 }
 
 export async function initializeTempLifecycle(): Promise<void> {
-  if (!isLinux()) return;
   installTerminationCoordinator();
+  if (!isLinux()) return;
   await ensureStartupSweep(resolveNeedlefishTempRoot());
 }
 
@@ -79,6 +81,8 @@ export function resolveNeedlefishTempRoot(): string {
 export async function createManagedTempDirectory(): Promise<string> {
   const root = resolveNeedlefishTempRoot();
   mkdirSync(root, { recursive: true, mode: 0o700 });
+  installTerminationCoordinator();
+  assertRunnerSchedulingAllowed();
 
   if (!isLinux()) {
     const directory = mkdtempSync(path.join(root, LEGACY_PREFIX));
@@ -86,8 +90,6 @@ export async function createManagedTempDirectory(): Promise<string> {
     return directory;
   }
 
-  installTerminationCoordinator();
-  assertRunnerSchedulingAllowed();
   await ensureStartupSweep(root);
   assertRunnerSchedulingAllowed();
 
@@ -120,13 +122,19 @@ export async function disposeManagedTempDirectory(directory: string): Promise<vo
 
 export function registerRunnerProcessGroup(
   pid: number,
+  repoPath: string,
   terminate: (signal: NodeJS.Signals) => void,
   kill: () => void,
+  exited: Promise<void>,
 ): () => void {
-  if (!isLinux()) return () => {};
   installTerminationCoordinator();
   assertRunnerSchedulingAllowed();
-  activeRunnerProcessGroups.set(pid, { terminate, kill });
+  activeRunnerProcessGroups.set(pid, {
+    directory: findRegisteredTempDirectory(repoPath),
+    terminate,
+    kill,
+    exited,
+  });
   return () => {
     if (terminationSignal === null) activeRunnerProcessGroups.delete(pid);
   };
@@ -215,16 +223,42 @@ function onSigterm(): void {
 
 function coordinateTermination(signal: "SIGINT" | "SIGTERM"): void {
   if (terminationSignal !== null) {
-    terminateNow(terminationSignal);
+    if (isLinux()) terminateNow(terminationSignal);
+    for (const group of activeRunnerProcessGroups.values()) group.kill();
     return;
   }
   terminationSignal = signal;
   for (const group of activeRunnerProcessGroups.values()) group.terminate(signal);
+  if (!isLinux()) {
+    void terminatePortable(signal);
+    return;
+  }
   if (activeRunnerProcessGroups.size === 0) {
     terminateNow(signal);
     return;
   }
   setTimeout(() => terminateNow(signal), terminationGraceMs());
+}
+
+async function terminatePortable(signal: "SIGINT" | "SIGTERM"): Promise<never> {
+  const groups = [...activeRunnerProcessGroups.values()];
+  if (groups.length > 0) await wait(terminationGraceMs());
+  for (const group of groups) group.kill();
+  const exited = await Promise.all(groups.map((group) => waitForExit(group)));
+  const unsafeDirectories = new Set<string>();
+  let unmappedRunnerIsAlive = false;
+  for (let index = 0; index < groups.length; index++) {
+    if (exited[index]) continue;
+    const directory = groups[index]?.directory;
+    if (directory === null || directory === undefined) unmappedRunnerIsAlive = true;
+    else unsafeDirectories.add(directory);
+  }
+  for (const directory of activeTempDirectories) {
+    if (unmappedRunnerIsAlive || unsafeDirectories.has(directory)) continue;
+    await rm(directory, { recursive: true, force: true });
+    activeTempDirectories.delete(directory);
+  }
+  process.exit(signal === "SIGINT" ? 130 : 143);
 }
 
 function terminateNow(signal: "SIGINT" | "SIGTERM"): never {
@@ -237,6 +271,31 @@ function terminationGraceMs(): number {
   if (configured === undefined || configured === "") return 5000;
   const parsed = Number(configured);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5000;
+}
+
+function findRegisteredTempDirectory(repoPath: string): string | null {
+  const resolvedRepoPath = path.resolve(repoPath);
+  for (const directory of activeTempDirectories) {
+    const relative = path.relative(directory, resolvedRepoPath);
+    if (relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))) {
+      return directory;
+    }
+  }
+  return null;
+}
+
+async function waitForExit(group: RunnerProcessGroup): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(false), terminationGraceMs());
+    group.exited.then(() => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+}
+
+async function wait(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 }
 
 export function assertRunnerSchedulingAllowed(): void {

--- a/src/shared/temp-lifecycle.ts
+++ b/src/shared/temp-lifecycle.ts
@@ -1,0 +1,381 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const MANAGED_PREFIX = "needlefish-managed-";
+const STAGING_PREFIX = ".needlefish-staging-";
+const LEGACY_PREFIX = "needlefish-";
+const QUARANTINE_PREFIX = ".needlefish-quarantine-";
+const OWNER_FILE = ".needlefish-owner.json";
+const PROCESS_LOCK_PREFIX = ".needlefish-owner-lock-";
+const SWEEP_LOCK = ".needlefish-sweep.lock";
+const LEGACY_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
+const LOCK_HOLDER = ': > "$1"; IFS= read -r _ || exit 0';
+
+interface HeldLock {
+  readonly child: ChildProcess;
+}
+
+interface OwnerMetadata {
+  readonly pid: number;
+  readonly processStartTime: string;
+  readonly bootId: string;
+  readonly ownerLock: string;
+  readonly createdAt: number;
+}
+
+interface ProcessOwner {
+  readonly lock: HeldLock;
+  readonly metadata: OwnerMetadata;
+}
+
+interface RunnerProcessGroup {
+  readonly terminate: (signal: NodeJS.Signals) => void;
+  readonly kill: () => void;
+}
+
+const activeTempDirectories = new Set<string>();
+const activeRunnerProcessGroups = new Map<number, RunnerProcessGroup>();
+const startupSweeps = new Map<string, Promise<void>>();
+let processOwnerPromise: Promise<ProcessOwner> | null = null;
+let coordinatorInstalled = false;
+let terminationSignal: "SIGINT" | "SIGTERM" | null = null;
+let lockSequence = 0;
+
+function isLinux(): boolean {
+  return process.platform === "linux";
+}
+
+export function installTerminationCoordinator(): void {
+  if (!isLinux() || coordinatorInstalled) return;
+  coordinatorInstalled = true;
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+}
+
+export async function initializeTempLifecycle(): Promise<void> {
+  if (!isLinux()) return;
+  installTerminationCoordinator();
+  await ensureStartupSweep(resolveNeedlefishTempRoot());
+}
+
+export function resolveNeedlefishTempRoot(): string {
+  const configured = process.env.NEEDLEFISH_TMPDIR?.trim();
+  return path.resolve(configured === undefined || configured === "" ? os.tmpdir() : configured);
+}
+
+export async function createManagedTempDirectory(): Promise<string> {
+  const root = resolveNeedlefishTempRoot();
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+
+  if (!isLinux()) {
+    const directory = mkdtempSync(path.join(root, LEGACY_PREFIX));
+    activeTempDirectories.add(directory);
+    return directory;
+  }
+
+  installTerminationCoordinator();
+  assertRunnerSchedulingAllowed();
+  await ensureStartupSweep(root);
+  assertRunnerSchedulingAllowed();
+
+  const owner = await ensureProcessOwner(root);
+  const staging = mkdtempSync(path.join(root, STAGING_PREFIX));
+  try {
+    assertRunnerSchedulingAllowed();
+    writeFileSync(path.join(staging, OWNER_FILE), `${JSON.stringify(owner.metadata)}\n`, {
+      mode: 0o600,
+    });
+    const suffix = path.basename(staging).slice(STAGING_PREFIX.length);
+    const managed = path.join(root, `${MANAGED_PREFIX}${suffix}`);
+    renameSync(staging, managed);
+    activeTempDirectories.add(managed);
+    return managed;
+  } catch (error) {
+    await rm(staging, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export async function disposeManagedTempDirectory(directory: string): Promise<void> {
+  if (!activeTempDirectories.has(directory)) {
+    throw new Error(`temp directory is not registered: ${directory}`);
+  }
+  if (terminationSignal !== null) return;
+  await rm(directory, { recursive: true, force: true });
+  activeTempDirectories.delete(directory);
+}
+
+export function registerRunnerProcessGroup(
+  pid: number,
+  terminate: (signal: NodeJS.Signals) => void,
+  kill: () => void,
+): () => void {
+  if (!isLinux()) return () => {};
+  installTerminationCoordinator();
+  assertRunnerSchedulingAllowed();
+  activeRunnerProcessGroups.set(pid, { terminate, kill });
+  return () => {
+    if (terminationSignal === null) activeRunnerProcessGroups.delete(pid);
+  };
+}
+
+export async function reapManagedTempDirectories(root = resolveNeedlefishTempRoot()): Promise<void> {
+  if (!isLinux()) return;
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  const sweepLock = await acquireLock(path.join(root, SWEEP_LOCK));
+  if (sweepLock === null) return;
+
+  try {
+    const quarantined: string[] = [];
+    let sequence = 0;
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const source = path.join(root, entry.name);
+      if (isManagedName(entry.name)) {
+        const owner = readOwnerMetadata(source);
+        if (owner === null || ownerIsAlive(owner) || !canTakeLock(owner.ownerLock)) continue;
+      } else if (isLegacyName(entry.name)) {
+        if (Date.now() - statSync(source).mtimeMs < LEGACY_GRACE_MS) continue;
+      } else if (!isQuarantineName(entry.name)) {
+        continue;
+      }
+
+      if (isQuarantineName(entry.name)) {
+        quarantined.push(source);
+        continue;
+      }
+      const quarantine = path.join(
+        root,
+        `${QUARANTINE_PREFIX}${process.pid}-${Date.now()}-${sequence++}`,
+      );
+      renameSync(source, quarantine);
+      quarantined.push(quarantine);
+    }
+
+    await Promise.all(quarantined.map((directory) => rm(directory, { recursive: true, force: true })));
+  } finally {
+    await releaseLock(sweepLock);
+  }
+}
+
+function ensureStartupSweep(root: string): Promise<void> {
+  const existing = startupSweeps.get(root);
+  if (existing !== undefined) return existing;
+  const sweep = reapManagedTempDirectories(root);
+  startupSweeps.set(root, sweep);
+  return sweep;
+}
+
+async function ensureProcessOwner(root: string): Promise<ProcessOwner> {
+  if (processOwnerPromise !== null) {
+    const owner = await processOwnerPromise;
+    if (owner.lock.child.exitCode !== null || owner.lock.child.signalCode !== null) {
+      throw new Error("needlefish process owner lock exited unexpectedly");
+    }
+    return owner;
+  }
+
+  processOwnerPromise = createProcessOwner(root);
+  return await processOwnerPromise;
+}
+
+async function createProcessOwner(root: string): Promise<ProcessOwner> {
+  const pid = process.pid;
+  const processStartTime = readProcessStartTime(pid);
+  const bootId = readBootId();
+  const ownerLock = path.join(root, `${PROCESS_LOCK_PREFIX}${bootId}-${pid}-${processStartTime}.lock`);
+  const lock = await acquireLock(ownerLock);
+  if (lock === null) throw new Error(`failed to acquire process owner lock: ${ownerLock}`);
+  return {
+    lock,
+    metadata: { pid, processStartTime, bootId, ownerLock, createdAt: Date.now() },
+  };
+}
+
+function onSigint(): void {
+  coordinateTermination("SIGINT");
+}
+
+function onSigterm(): void {
+  coordinateTermination("SIGTERM");
+}
+
+function coordinateTermination(signal: "SIGINT" | "SIGTERM"): void {
+  if (terminationSignal !== null) {
+    terminateNow(terminationSignal);
+    return;
+  }
+  terminationSignal = signal;
+  for (const group of activeRunnerProcessGroups.values()) group.terminate(signal);
+  if (activeRunnerProcessGroups.size === 0) {
+    terminateNow(signal);
+    return;
+  }
+  setTimeout(() => terminateNow(signal), terminationGraceMs());
+}
+
+function terminateNow(signal: "SIGINT" | "SIGTERM"): never {
+  for (const group of activeRunnerProcessGroups.values()) group.kill();
+  process.exit(signal === "SIGINT" ? 130 : 143);
+}
+
+function terminationGraceMs(): number {
+  const configured = process.env.NEEDLEFISH_TERMINATION_GRACE_MS?.trim();
+  if (configured === undefined || configured === "") return 5000;
+  const parsed = Number(configured);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5000;
+}
+
+export function assertRunnerSchedulingAllowed(): void {
+  if (terminationSignal !== null) {
+    throw new Error(`cannot schedule runner work while terminating from ${terminationSignal}`);
+  }
+}
+
+async function acquireLock(target: string): Promise<HeldLock | null> {
+  const readyPath = `${target}.ready-${process.pid}-${lockSequence++}`;
+  const child = spawn(
+    "flock",
+    [
+      "--exclusive",
+      "--nonblock",
+      "--no-fork",
+      target,
+      "sh",
+      "-c",
+      LOCK_HOLDER,
+      "needlefish-lock-holder",
+      readyPath,
+    ],
+    { detached: true, stdio: ["pipe", "ignore", "ignore"] },
+  );
+
+  return await new Promise<HeldLock | null>((resolve, reject) => {
+    let settled = false;
+    const finish = (result: HeldLock | null, error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearInterval(poll);
+      clearTimeout(timeout);
+      if (existsSync(readyPath)) unlinkSync(readyPath);
+      if (error !== undefined) reject(error);
+      else resolve(result);
+    };
+    const poll = setInterval(() => {
+      if (!existsSync(readyPath)) return;
+      const lock = { child };
+      child.unref();
+      const stdin = child.stdin as (NodeJS.WritableStream & { unref?: () => void }) | null;
+      stdin?.unref?.();
+      finish(lock);
+    }, 5);
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(null, new Error(`timed out acquiring lock: ${target}`));
+    }, 5000);
+    child.on("error", (error) => finish(null, error));
+    child.on("exit", (status) => {
+      if (status === 1) {
+        finish(null);
+        return;
+      }
+      finish(null, new Error(`flock exited ${status}`));
+    });
+  });
+}
+
+async function releaseLock(lock: HeldLock): Promise<void> {
+  if (lock.child.exitCode !== null || lock.child.signalCode !== null) return;
+  lock.child.ref();
+  const exited = new Promise<void>((resolve) => lock.child.once("exit", () => resolve()));
+  lock.child.stdin?.end();
+  await exited;
+}
+
+function canTakeLock(target: string): boolean {
+  const result = spawnSync("flock", ["--exclusive", "--nonblock", target, "true"], {
+    stdio: "ignore",
+  });
+  if (result.error !== undefined) throw result.error;
+  return result.status === 0;
+}
+
+function readBootId(): string {
+  const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+  if (!/^[A-Za-z0-9-]+$/.test(bootId)) throw new Error("invalid Linux boot ID");
+  return bootId;
+}
+
+function readProcessStartTime(pid: number): string {
+  const stat = readFileSync(`/proc/${pid}/stat`, "utf8").trim();
+  const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+  const startTime = fields[19];
+  if (startTime === undefined || !/^\d+$/.test(startTime)) {
+    throw new Error(`invalid /proc/${pid}/stat`);
+  }
+  return startTime;
+}
+
+function ownerIsAlive(owner: OwnerMetadata): boolean {
+  try {
+    return readBootId() === owner.bootId && readProcessStartTime(owner.pid) === owner.processStartTime;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function readOwnerMetadata(directory: string): OwnerMetadata | null {
+  const metadataPath = path.join(directory, OWNER_FILE);
+  if (!existsSync(metadataPath)) return null;
+  const value: unknown = JSON.parse(readFileSync(metadataPath, "utf8"));
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("pid" in value) ||
+    !Number.isInteger(value.pid) ||
+    typeof value.pid !== "number" ||
+    value.pid <= 0 ||
+    !("processStartTime" in value) ||
+    typeof value.processStartTime !== "string" ||
+    !/^\d+$/.test(value.processStartTime) ||
+    !("bootId" in value) ||
+    typeof value.bootId !== "string" ||
+    !/^[A-Za-z0-9-]+$/.test(value.bootId) ||
+    !("ownerLock" in value) ||
+    typeof value.ownerLock !== "string" ||
+    !path.isAbsolute(value.ownerLock) ||
+    !("createdAt" in value) ||
+    typeof value.createdAt !== "number"
+  ) {
+    return null;
+  }
+  const expectedLockName = `${PROCESS_LOCK_PREFIX}${value.bootId}-${value.pid}-${value.processStartTime}.lock`;
+  if (path.basename(value.ownerLock) !== expectedLockName) return null;
+  return value as OwnerMetadata;
+}
+
+function isManagedName(name: string): boolean {
+  return /^needlefish-managed-[A-Za-z0-9]{6}$/.test(name);
+}
+
+function isLegacyName(name: string): boolean {
+  return /^needlefish-[A-Za-z0-9]{6}$/.test(name);
+}
+
+function isQuarantineName(name: string): boolean {
+  return /^\.needlefish-quarantine-\d+-\d+-\d+$/.test(name);
+}

--- a/src/shared/temp-lifecycle.ts
+++ b/src/shared/temp-lifecycle.ts
@@ -13,6 +13,7 @@ import {
 import { rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { envFlagOn } from "./env.js";
 
 const MANAGED_PREFIX = "needlefish-managed-";
 const STAGING_PREFIX = ".needlefish-staging-";
@@ -22,6 +23,7 @@ const OWNER_FILE = ".needlefish-owner.json";
 const PROCESS_LOCK_PREFIX = ".needlefish-owner-lock-";
 const SWEEP_LOCK = ".needlefish-sweep.lock";
 const LEGACY_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
+const QUARANTINE_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
 const LOCK_HOLDER = ': > "$1"; IFS= read -r _ || exit 0';
 
 interface HeldLock {
@@ -51,10 +53,20 @@ interface RunnerProcessGroup {
 const activeTempDirectories = new Set<string>();
 const activeRunnerProcessGroups = new Map<number, RunnerProcessGroup>();
 const startupSweeps = new Map<string, Promise<void>>();
-let processOwnerPromise: Promise<ProcessOwner> | null = null;
+const processOwnerPromises = new Map<string, Promise<ProcessOwner>>();
 let coordinatorInstalled = false;
 let terminationSignal: "SIGINT" | "SIGTERM" | null = null;
+let forceTermination = false;
+const terminationWaiters = new Set<() => void>();
 let lockSequence = 0;
+
+export class RunnerTerminatingError extends Error {
+  readonly name = "RunnerTerminatingError";
+
+  constructor(signal: "SIGINT" | "SIGTERM") {
+    super(`cannot schedule runner work while terminating from ${signal}`);
+  }
+}
 
 function isLinux(): boolean {
   return process.platform === "linux";
@@ -129,15 +141,20 @@ export function registerRunnerProcessGroup(
 ): () => void {
   installTerminationCoordinator();
   assertRunnerSchedulingAllowed();
-  activeRunnerProcessGroups.set(pid, {
+  const group: RunnerProcessGroup = {
     directory: findRegisteredTempDirectory(repoPath),
     terminate,
     kill,
     exited,
-  });
-  return () => {
-    if (terminationSignal === null) activeRunnerProcessGroups.delete(pid);
   };
+  activeRunnerProcessGroups.set(pid, group);
+  const unregister = (): void => {
+    if (activeRunnerProcessGroups.get(pid) !== group) return;
+    activeRunnerProcessGroups.delete(pid);
+    notifyTerminationWaiters();
+  };
+  void exited.then(unregister, unregister);
+  return unregister;
 }
 
 export async function reapManagedTempDirectories(root = resolveNeedlefishTempRoot()): Promise<void> {
@@ -156,13 +173,21 @@ export async function reapManagedTempDirectories(root = resolveNeedlefishTempRoo
         const owner = readOwnerMetadata(source);
         if (owner === null || ownerIsAlive(owner) || !canTakeLock(owner.ownerLock)) continue;
       } else if (isLegacyName(entry.name)) {
+        if (!envFlagOn("NEEDLEFISH_REAP_LEGACY_TMPDIRS")) continue;
         if (Date.now() - statSync(source).mtimeMs < LEGACY_GRACE_MS) continue;
-      } else if (!isQuarantineName(entry.name)) {
-        continue;
-      }
-
-      if (isQuarantineName(entry.name)) {
+      } else if (isQuarantineName(entry.name)) {
+        const owner = readOwnerMetadata(source);
+        if (
+          owner === null ||
+          Date.now() - statSync(source).mtimeMs < QUARANTINE_GRACE_MS ||
+          ownerIsAlive(owner) ||
+          !canTakeLock(owner.ownerLock)
+        ) {
+          continue;
+        }
         quarantined.push(source);
+        continue;
+      } else {
         continue;
       }
       const quarantine = path.join(
@@ -174,6 +199,7 @@ export async function reapManagedTempDirectories(root = resolveNeedlefishTempRoo
     }
 
     await Promise.all(quarantined.map((directory) => rm(directory, { recursive: true, force: true })));
+    reapOrphanedProcessOwnerLocks(root);
   } finally {
     await releaseLock(sweepLock);
   }
@@ -188,16 +214,44 @@ function ensureStartupSweep(root: string): Promise<void> {
 }
 
 async function ensureProcessOwner(root: string): Promise<ProcessOwner> {
-  if (processOwnerPromise !== null) {
-    const owner = await processOwnerPromise;
-    if (owner.lock.child.exitCode !== null || owner.lock.child.signalCode !== null) {
-      throw new Error("needlefish process owner lock exited unexpectedly");
-    }
-    return owner;
-  }
+  const current = processOwnerPromises.get(root);
+  if (current === undefined) return await acquireProcessOwner(root);
 
-  processOwnerPromise = createProcessOwner(root);
-  return await processOwnerPromise;
+  let owner: ProcessOwner;
+  try {
+    owner = await current;
+  } catch (error) {
+    if (processOwnerPromises.get(root) === current) processOwnerPromises.delete(root);
+    throw error;
+  }
+  if (lockHolderIsAlive(owner.lock)) return owner;
+
+  if (processOwnerPromises.get(root) === current) {
+    processOwnerPromises.set(root, createProcessOwner(root));
+  }
+  const replacement = processOwnerPromises.get(root) ?? createProcessOwner(root);
+  processOwnerPromises.set(root, replacement);
+  try {
+    return await replacement;
+  } catch (error) {
+    if (processOwnerPromises.get(root) === replacement) processOwnerPromises.delete(root);
+    throw error;
+  }
+}
+
+async function acquireProcessOwner(root: string): Promise<ProcessOwner> {
+  const acquisition = createProcessOwner(root);
+  processOwnerPromises.set(root, acquisition);
+  try {
+    return await acquisition;
+  } catch (error) {
+    if (processOwnerPromises.get(root) === acquisition) processOwnerPromises.delete(root);
+    throw error;
+  }
+}
+
+function lockHolderIsAlive(lock: HeldLock): boolean {
+  return lock.child.exitCode === null && lock.child.signalCode === null;
 }
 
 async function createProcessOwner(root: string): Promise<ProcessOwner> {
@@ -223,37 +277,70 @@ function onSigterm(): void {
 
 function coordinateTermination(signal: "SIGINT" | "SIGTERM"): void {
   if (terminationSignal !== null) {
-    if (isLinux()) terminateNow(terminationSignal);
-    for (const group of activeRunnerProcessGroups.values()) group.kill();
+    forceTermination = true;
+    notifyTerminationWaiters();
+    if (isLinux()) terminateImmediately(terminationSignal);
+    signalRegisteredRunners("kill", terminationSignal);
     return;
   }
   terminationSignal = signal;
-  for (const group of activeRunnerProcessGroups.values()) group.terminate(signal);
-  if (!isLinux()) {
-    void terminatePortable(signal);
-    return;
-  }
+  signalRegisteredRunners("terminate", signal);
   if (activeRunnerProcessGroups.size === 0) {
-    terminateNow(signal);
+    terminateImmediately(signal);
     return;
   }
-  setTimeout(() => terminateNow(signal), terminationGraceMs());
+  void completeTermination(signal);
 }
 
-async function terminatePortable(signal: "SIGINT" | "SIGTERM"): Promise<never> {
-  const groups = [...activeRunnerProcessGroups.values()];
-  if (groups.length > 0) await wait(terminationGraceMs());
-  for (const group of groups) group.kill();
-  const exited = await Promise.all(groups.map((group) => waitForExit(group)));
+function notifyTerminationWaiters(): void {
+  for (const wake of [...terminationWaiters]) wake();
+}
+
+async function waitForRegisteredRunners(timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (activeRunnerProcessGroups.size > 0) {
+    if (forceTermination) return false;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        terminationWaiters.delete(finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, remaining);
+      terminationWaiters.add(finish);
+      if (activeRunnerProcessGroups.size === 0 || forceTermination) finish();
+    });
+  }
+  return true;
+}
+
+function signalRegisteredRunners(method: "terminate" | "kill", signal: "SIGINT" | "SIGTERM"): void {
+  for (const [pid, group] of [...activeRunnerProcessGroups.entries()]) {
+    if (activeRunnerProcessGroups.get(pid) !== group) continue;
+    if (method === "terminate") group.terminate(signal);
+    else group.kill();
+  }
+}
+
+async function completeTermination(signal: "SIGINT" | "SIGTERM"): Promise<never> {
+  const exitedDuringGrace = await waitForRegisteredRunners(terminationGraceMs());
+  if (!exitedDuringGrace) signalRegisteredRunners("kill", signal);
+
+  if (isLinux()) process.exit(signal === "SIGINT" ? 130 : 143);
+
+  await waitForRegisteredRunners(terminationGraceMs());
   const unsafeDirectories = new Set<string>();
   let unmappedRunnerIsAlive = false;
-  for (let index = 0; index < groups.length; index++) {
-    if (exited[index]) continue;
-    const directory = groups[index]?.directory;
-    if (directory === null || directory === undefined) unmappedRunnerIsAlive = true;
-    else unsafeDirectories.add(directory);
+  for (const group of activeRunnerProcessGroups.values()) {
+    if (group.directory === null) unmappedRunnerIsAlive = true;
+    else unsafeDirectories.add(group.directory);
   }
-  for (const directory of activeTempDirectories) {
+  for (const directory of [...activeTempDirectories]) {
     if (unmappedRunnerIsAlive || unsafeDirectories.has(directory)) continue;
     await rm(directory, { recursive: true, force: true });
     activeTempDirectories.delete(directory);
@@ -261,8 +348,8 @@ async function terminatePortable(signal: "SIGINT" | "SIGTERM"): Promise<never> {
   process.exit(signal === "SIGINT" ? 130 : 143);
 }
 
-function terminateNow(signal: "SIGINT" | "SIGTERM"): never {
-  for (const group of activeRunnerProcessGroups.values()) group.kill();
+function terminateImmediately(signal: "SIGINT" | "SIGTERM"): never {
+  signalRegisteredRunners("kill", signal);
   process.exit(signal === "SIGINT" ? 130 : 143);
 }
 
@@ -284,23 +371,9 @@ function findRegisteredTempDirectory(repoPath: string): string | null {
   return null;
 }
 
-async function waitForExit(group: RunnerProcessGroup): Promise<boolean> {
-  return await new Promise((resolve) => {
-    const timeout = setTimeout(() => resolve(false), terminationGraceMs());
-    group.exited.then(() => {
-      clearTimeout(timeout);
-      resolve(true);
-    });
-  });
-}
-
-async function wait(milliseconds: number): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
-}
-
 export function assertRunnerSchedulingAllowed(): void {
   if (terminationSignal !== null) {
-    throw new Error(`cannot schedule runner work while terminating from ${terminationSignal}`);
+    throw new RunnerTerminatingError(terminationSignal);
   }
 }
 
@@ -336,6 +409,11 @@ async function acquireLock(target: string): Promise<HeldLock | null> {
     const poll = setInterval(() => {
       if (!existsSync(readyPath)) return;
       const lock = { child };
+      if (!lockHolderIsAlive(lock) || canTakeLock(target) || !lockHolderIsAlive(lock)) {
+        child.kill("SIGKILL");
+        finish(null, new Error(`lock holder reported ready without holding the lock: ${target}`));
+        return;
+      }
       child.unref();
       const stdin = child.stdin as (NodeJS.WritableStream & { unref?: () => void }) | null;
       stdin?.unref?.();
@@ -389,6 +467,10 @@ function readProcessStartTime(pid: number): string {
 }
 
 function ownerIsAlive(owner: OwnerMetadata): boolean {
+  return ownerIdentityIsAlive(owner);
+}
+
+function ownerIdentityIsAlive(owner: Pick<OwnerMetadata, "pid" | "processStartTime" | "bootId">): boolean {
   try {
     return readBootId() === owner.bootId && readProcessStartTime(owner.pid) === owner.processStartTime;
   } catch (error) {
@@ -400,7 +482,13 @@ function ownerIsAlive(owner: OwnerMetadata): boolean {
 function readOwnerMetadata(directory: string): OwnerMetadata | null {
   const metadataPath = path.join(directory, OWNER_FILE);
   if (!existsSync(metadataPath)) return null;
-  const value: unknown = JSON.parse(readFileSync(metadataPath, "utf8"));
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(metadataPath, "utf8"));
+  } catch (error) {
+    if (error instanceof SyntaxError) return null;
+    throw error;
+  }
   if (
     typeof value !== "object" ||
     value === null ||
@@ -424,7 +512,44 @@ function readOwnerMetadata(directory: string): OwnerMetadata | null {
   }
   const expectedLockName = `${PROCESS_LOCK_PREFIX}${value.bootId}-${value.pid}-${value.processStartTime}.lock`;
   if (path.basename(value.ownerLock) !== expectedLockName) return null;
+  if (path.dirname(value.ownerLock) !== path.dirname(directory)) return null;
   return value as OwnerMetadata;
+}
+
+function parseProcessOwnerLock(name: string): Pick<OwnerMetadata, "pid" | "processStartTime" | "bootId"> | null {
+  const match = /^\.needlefish-owner-lock-(.+)-(\d+)-(\d+)\.lock$/.exec(name);
+  if (match === null) return null;
+  const [, bootId, pidText, processStartTime] = match;
+  if (
+    bootId === undefined ||
+    !/^[A-Za-z0-9-]+$/.test(bootId) ||
+    pidText === undefined ||
+    processStartTime === undefined
+  ) {
+    return null;
+  }
+  const pid = Number(pidText);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  return { pid, processStartTime, bootId };
+}
+
+function reapOrphanedProcessOwnerLocks(root: string): void {
+  const referencedLocks = new Set<string>();
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || (!isManagedName(entry.name) && !isQuarantineName(entry.name))) continue;
+    const owner = readOwnerMetadata(path.join(root, entry.name));
+    if (owner === null) continue;
+    referencedLocks.add(owner.ownerLock);
+  }
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const owner = parseProcessOwnerLock(entry.name);
+    if (owner === null) continue;
+    const ownerLock = path.join(root, entry.name);
+    if (referencedLocks.has(ownerLock) || ownerIdentityIsAlive(owner) || !canTakeLock(ownerLock)) continue;
+    unlinkSync(ownerLock);
+  }
 }
 
 function isManagedName(name: string): boolean {


### PR DESCRIPTION
## Why

Needlefish leaked its invocation temp directories on this machine until `/tmp` (a 4G tmpfs, so RAM) hit 86%. Root cause, proven and reproduced end to end: `runCodex` cleaned up in a `finally`, and **Node does not run `finally` on SIGTERM/SIGINT at default disposition**. Every signalled invocation stranded its whole sandbox.

The leak surfaced here because needlefish protects its *own* runner (`.env` `TMPDIR` + a `review.yml` preflight) but is invoked by *other* repos' runners, which had neither.

## What changed

- `createManagedTempDirectory` / `disposeManagedTempDirectory` replace the ad-hoc `mkdtempSync` + `finally` in `codex.ts`.
- A process-level termination coordinator: blocks new scheduling, signals runner groups, bounded grace, force-kill, then exit — instead of relying on a `finally` that never runs.
- Ownership is kernel-authoritative. A directory is staged under an excluded prefix, `flock`ed, stamped with pid + `/proc/<pid>/stat` start time + boot ID, then atomically renamed into the managed namespace. A sweeper that can take the lock knows the owner is gone. PID reuse cannot fool it.
- Startup sweep reaps orphans left by previous crashes, serialised by its own lock.
- Portable: the coordinator and both registries work on macOS and Windows; only the flock/proc sweep is Linux-gated. Windows `taskkill` sends a graceful close before escalating to `/F`.

## Review history

This branch was reviewed adversarially rather than diff-read. That mattered:

- **Round 1** shipped a change that broke the existing credential-leak regression test. Caught by running the suite, not by reading.
- **Round 2** (portability) passed review and mutation testing.
- **Round 3** — an independent adversarial pass found **nine defects while the suite was green at 504/504**, including two that could destroy data: shutdown could `SIGKILL` a recycled, unrelated process group, and the sweep could recursively delete any needlefish-shaped directory with no ownership marker required.
- **Round 4** fixed all nine. One fix did not survive verification — the orphan-lock reaper aborted silently whenever any unattributable directory was present, which is exactly the crash-leftover state it exists to handle — and was sent back and fixed.

The single most important fix is the last one on the list below: **the credential-leak security test could pass vacuously.** It redirected `TMPDIR`, but production resolves `NEEDLEFISH_TMPDIR` first. On every runner that exports that variable, the test inspected an empty directory. A real credential leak would have shipped green.

## Verification

`pnpm test` 516/516, `pnpm check`, `pnpm lint` clean.

Every fix was mutation-tested independently of the implementer — each defect was reintroduced and the suite confirmed to go red:

| reintroduced defect | result |
|---|---|
| unregister refuses during termination | 3 tests red |
| legacy reaping unconditional again | 1 test red |
| production ignores `NEEDLEFISH_TMPDIR` (test/prod divergence) | credential tests red |
| real credential leak, under adversarial ambient env | 6 tests red |
| orphan-lock reaper aborts on unattributable dir | 1 test red |
| non-Linux registration no-op restored | 3 tests red |
| portable shutdown deletes unconfirmed trees | 1 test red |

## Deploy note

Merging is not sufficient — the runners currently run release `53e4ed7b`. This needs a redeploy to take effect. Machine-side config (per-runner `TMPDIR` / `NEEDLEFISH_TMPDIR` on disk-backed storage, plus a workflow preflight in the calling repo) is already in place and is what is holding `/tmp` at 14%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)