### PR TITLE
修正 Needlefish runner 部署拓撲說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,10 @@ SHA so review jobs can fail before spending model tokens when a runner is stale.
    ```bash
    ssh termtek@ubuntu 'sh -s' < scripts/deploy-ubuntu.sh
    ```
-   The current production fleet uses one shared x64 installation plus two
-   separate ARM installations. Deploy the same release SHA to all three
-   installations and verify their installed metadata before trusting the fleet.
+   The current production fleet uses one shared x64 installation plus one
+   shared ARM installation used by two runner services. Deploy the same release
+   SHA to both installations and verify their installed metadata before trusting
+   the fleet.
 3. Ensure the runner has `gh` and the selected model CLI on `PATH`.
 4. On that runner, auth the selected CLI once. For Codex:
    ```bash

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -280,8 +280,9 @@ gh workflow run review.yml -R frankekn/needlefish --ref main \
    ```bash
    ssh termtek@ubuntu 'sh -s' < scripts/deploy-ubuntu.sh
    ```
-   目前 production fleet 是一份共用 x64 安裝加兩份獨立 ARM 安裝。三份安裝都要
-   部署相同 release SHA，並確認 installed metadata 一致。
+   目前 production fleet 是一份共用 x64 安裝，加上一份由兩個 runner service
+   共用的 ARM 安裝。兩份安裝都要部署相同 release SHA，並確認 installed
+   metadata 一致。
 3. 確認 `gh` 與選定的模型 CLI 位於 `PATH`。
 4. 以 runner service account 登入 CLI。Codex 例如：
    ```bash


### PR DESCRIPTION
## Summary
- 根據實際 deploy evidence，修正 production topology：1 份共用 x64 安裝、1 份由兩個 ARM runner services 共用的 ARM 安裝
- runtime 與 deployment workflow 不變

## Verification
- `git diff --check`
- ARM deploy run 30601927744：兩個 labels 均回報相同 hostname、HOME 與 release path