### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.1 — 2026-08-01
+
+- Runner: execute model CLIs inside disposable Git review sandboxes, verify the
+  sandbox after every call, and remove runner-specific opt-in gates that no
+  longer define the security boundary.
+- Runner: withhold prompt-bearing stderr from public process errors while
+  retaining raw output privately for eval anti-cheat tracing.
+- GitHub: route self-hosted runner worktree setup and teardown through managed
+  scripts and document the deployment topology and trust boundary.
+- Eval: record the guarded DeepSeek V4 Flash candidate run and targeted x3
+  confirmation, with explicit raw bait-exposure accounting.
+
 ## 0.4.0 — 2026-07-19
 
 - GitHub: default the reusable Codex review lane to `gpt-5.6-terra` at high

--- a/README.md
+++ b/README.md
@@ -104,18 +104,25 @@ unchanged heads skip the model entirely. Maintainers can comment
 Needlefish ships with a guarded evaluation harness (`eval/`) and is measured
 against it before any prompt or pipeline change ships. The fixture set is 84
 review scenarios — synthetic planted-bug/negative/honeypot cases plus fixtures
-mined from real PRs — each run 3 times. Anti-cheat guards are active on every
-recorded run: per-draw ephemeral `HOME`, a planted bait answer key with a
-per-run canary, and a full-transcript scan (`cheatDetectedCount: 0` on all
-numbers below; any structured bait use voids a report).
+mined from real PRs. Release baselines run each fixture 3 times; exploratory
+candidates may start with one full-set draw plus targeted x3 confirmation.
+Anti-cheat guards are active on every recorded run: per-draw ephemeral `HOME`,
+a planted bait answer key with a per-run canary, and a full-transcript scan
+(`cheatDetectedCount: 0` on all numbers below; any structured bait use voids a
+report).
 
-Production review lane (codex runner, `gpt-5.6-terra`, high reasoning effort):
+Current guarded runs (production remains codex `gpt-5.6-terra` @high):
 
-| Test date | Lane | Anchored recall | False-positive rate | Verdict match |
-| --- | --- | --- | --- | --- |
-| 2026-07-19 | terra high (current baseline) | 0.874 | 0.056 | 0.944 |
-| 2026-07-18 | terra high | 0.885 | 0.014 | 0.972 |
-| 2026-07-18 | sol medium (previous default) | 0.879 | 0.111 | 0.944 |
+| Test date | Lane | Draws | Anchored recall | False-positive rate | Verdict match |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 2026-07-31 | opencode DeepSeek V4 Flash free @max (candidate) | 1 | 0.897 | 0.000 | 0.940 |
+| 2026-07-19 | terra high (current baseline) | 3 | 0.874 | 0.056 | 0.944 |
+| 2026-07-18 | terra high | 3 | 0.885 | 0.014 | 0.972 |
+| 2026-07-18 | sol medium (previous default) | 3 | 0.879 | 0.111 | 0.944 |
+
+The DeepSeek candidate hit every tier-1 fixture and produced valid JSON on all
+84 draws, but its single full-set draw is not a promotion result. Six divergent
+fixtures received targeted x3 confirmation; see [`eval/RESULTS.md`](eval/RESULTS.md).
 
 Methodology notes, learned the hard way and enforced by the harness:
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Current guarded runs (production remains codex `gpt-5.6-terra` @high):
 
 The DeepSeek candidate hit every tier-1 fixture and produced valid JSON on all
 84 draws, but its single full-set draw is not a promotion result. Six divergent
-fixtures received targeted x3 confirmation; see [`eval/RESULTS.md`](eval/RESULTS.md).
+fixtures received targeted x3 confirmation; see
+[`eval/RESULTS.md`](https://github.com/frankekn/needlefish/blob/main/eval/RESULTS.md).
 
 Methodology notes, learned the hard way and enforced by the harness:
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -116,7 +116,7 @@ report 作廢）。
 
 DeepSeek candidate 命中所有 tier-1 fixture，84 個 draw 也都產生有效 JSON，但單次
 完整集不算 promotion result。六個分歧 fixture 另做了 x3 確認；詳見
-[`eval/RESULTS.md`](eval/RESULTS.md)。
+[`eval/RESULTS.md`](https://github.com/frankekn/needlefish/blob/main/eval/RESULTS.md)。
 
 從錯誤中學到、並由 harness 強制的方法論注記：
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -98,18 +98,25 @@ head 會跳過模型。維護者可以在 PR 留言
 
 Needlefish 內建一套有防護的評測 harness（`eval/`），任何 prompt 或 pipeline
 變更上線前都會先對它量測。fixture 集共 84 個審查情境——合成的 planted-bug／
-negative／honeypot 案例，加上從真實 PR 萃取的 fixture——每個各跑 3 次。每筆
-記錄的 run 都啟用 anti-cheat guards：per-draw ephemeral `HOME`、帶 per-run
-canary 的 planted bait answer key，以及全 transcript 掃描（下列所有數字皆
-`cheatDetectedCount: 0`；任何結構化的 bait 使用都會使該 report 作廢）。
+negative／honeypot 案例，加上從真實 PR 萃取的 fixture。發行 baseline
+每個 fixture 各跑 3 次；探索性 candidate 可先跑 1 次完整集，再對分歧案例
+做 x3 確認。每筆記錄的 run 都啟用 anti-cheat guards：per-draw ephemeral
+`HOME`、帶 per-run canary 的 planted bait answer key，以及全 transcript 掃描
+（下列所有數字皆 `cheatDetectedCount: 0`；任何結構化的 bait 使用都會使該
+report 作廢）。
 
-正式審查 lane（codex runner、`gpt-5.6-terra`、high reasoning effort）：
+目前受防護的 runs（正式 lane 仍是 codex `gpt-5.6-terra` @high）：
 
-| Test date | Lane | Anchored recall | False-positive rate | Verdict match |
-| --- | --- | --- | --- | --- |
-| 2026-07-19 | terra high (current baseline) | 0.874 | 0.056 | 0.944 |
-| 2026-07-18 | terra high | 0.885 | 0.014 | 0.972 |
-| 2026-07-18 | sol medium (previous default) | 0.879 | 0.111 | 0.944 |
+| Test date | Lane | Draws | Anchored recall | False-positive rate | Verdict match |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 2026-07-31 | opencode DeepSeek V4 Flash free @max (candidate) | 1 | 0.897 | 0.000 | 0.940 |
+| 2026-07-19 | terra high (current baseline) | 3 | 0.874 | 0.056 | 0.944 |
+| 2026-07-18 | terra high | 3 | 0.885 | 0.014 | 0.972 |
+| 2026-07-18 | sol medium (previous default) | 3 | 0.879 | 0.111 | 0.944 |
+
+DeepSeek candidate 命中所有 tier-1 fixture，84 個 draw 也都產生有效 JSON，但單次
+完整集不算 promotion result。六個分歧 fixture 另做了 x3 確認；詳見
+[`eval/RESULTS.md`](eval/RESULTS.md)。
 
 從錯誤中學到、並由 harness 強制的方法論注記：
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needlefish",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "description": "Strict local PR review agent.",


### PR DESCRIPTION
## What changed

- bump the package version to `0.4.1`
- add release notes for runner isolation, error redaction, and self-hosted worktree management
- publish the guarded DeepSeek V4 Flash benchmark in both README variants

## Why

`main` has consumer-facing runner and GitHub Action fixes since `v0.4.0`. A patch release advances npm and the floating `v0` Action tag.

## Validation

- `pnpm check`
- `pnpm test` (507 passed, 12 skipped)
- `pnpm pack:smoke` (`needlefish 0.4.1`)
- `git diff --check`
