### PR TITLE
fix(ci): run caller-pinned Needlefish release

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -170,7 +170,7 @@ jobs:
 
           echo "TMPDIR=$temp_root" >> "$GITHUB_ENV"
 
-      - name: Verify Needlefish release
+      - name: Select Needlefish release
         if: steps.refs.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -179,11 +179,35 @@ jobs:
           EXPECTED_NEEDLEFISH_SHA: ${{ inputs.needlefish_release_sha || github.event.inputs.needlefish_release_sha }}
           NEEDLEFISH_REPO: ${{ inputs.needlefish_repo || github.event.inputs.needlefish_repo || 'frankekn/needlefish' }}
         run: |
+          set -euo pipefail
+
+          report_release_failure() {
+            title="$1"
+            summary="$2"
+            gh api -X POST "repos/$REPO/check-runs" \
+              -f name="Needlefish" \
+              -f head_sha="$PR_HEAD_SHA" \
+              -f status="completed" \
+              -f conclusion="failure" \
+              -f "output[title]=$title" \
+              -f "output[summary]=$summary"
+            echo "$summary" >&2
+            exit 1
+          }
+
           if [ -z "$EXPECTED_NEEDLEFISH_SHA" ]; then
             EXPECTED_NEEDLEFISH_SHA="$(gh api "repos/$NEEDLEFISH_REPO/commits/main" --jq .sha)"
           fi
 
-          metadata="$HOME/.local/share/needlefish/current/release.json"
+          if [[ ! "$EXPECTED_NEEDLEFISH_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            report_release_failure \
+              "Invalid Needlefish release SHA" \
+              "Expected a full lowercase 40-character Needlefish commit SHA, received '$EXPECTED_NEEDLEFISH_SHA'."
+          fi
+
+          release="$HOME/.local/share/needlefish/releases/$EXPECTED_NEEDLEFISH_SHA"
+          metadata="$release/release.json"
+          binary="$release/bin/needlefish"
           actual_sha=""
           if [ -f "$metadata" ]; then
             actual_sha="$(node -e 'const fs = require("node:fs"); const json = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); if (typeof json.sha === "string") process.stdout.write(json.sha);' "$metadata" 2>/dev/null || true)"
@@ -191,16 +215,24 @@ jobs:
 
           if [ "$actual_sha" != "$EXPECTED_NEEDLEFISH_SHA" ]; then
             if [ -z "$actual_sha" ]; then actual_sha="missing"; fi
-            gh api -X POST "repos/$REPO/check-runs" \
-              -f name="Needlefish" \
-              -f head_sha="$PR_HEAD_SHA" \
-              -f status="completed" \
-              -f conclusion="failure" \
-              -f "output[title]=Needlefish release mismatch" \
-              -f "output[summary]=Expected Needlefish release $EXPECTED_NEEDLEFISH_SHA, found $actual_sha in $metadata."
-            echo "Needlefish release mismatch: expected $EXPECTED_NEEDLEFISH_SHA, found $actual_sha in $metadata." >&2
-            exit 1
+            report_release_failure \
+              "Needlefish release mismatch" \
+              "Expected Needlefish release $EXPECTED_NEEDLEFISH_SHA, found $actual_sha in $metadata."
           fi
+
+          if [ ! -x "$binary" ]; then
+            report_release_failure \
+              "Needlefish release is incomplete" \
+              "Needlefish release $EXPECTED_NEEDLEFISH_SHA is missing executable $binary."
+          fi
+
+          if ! "$binary" --version; then
+            report_release_failure \
+              "Needlefish release is not runnable" \
+              "Needlefish release $EXPECTED_NEEDLEFISH_SHA failed its version check at $binary."
+          fi
+
+          printf 'NEEDLEFISH_BIN=%s\n' "$binary" >> "$GITHUB_ENV"
 
       - name: Checkout review target (PR head)
         if: steps.refs.outputs.skip != 'true'
@@ -228,8 +260,8 @@ jobs:
           PI_BIN: /home/termtek/.npm-global/bin/pi
           NEEDLEFISH_RECHECK_INPUT: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
         run: |
-          if [ ! -x "$HOME/.local/bin/needlefish" ]; then
-            echo "Missing $HOME/.local/bin/needlefish. Run scripts/deploy-ubuntu.sh on the self-hosted runner." >&2
+          if [ -z "${NEEDLEFISH_BIN:-}" ] || [ ! -x "$NEEDLEFISH_BIN" ]; then
+            echo "Selected Needlefish release is unavailable. Run scripts/deploy-ubuntu.sh on the self-hosted runner." >&2
             exit 1
           fi
           args=(--github --pr "${{ inputs.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}")
@@ -246,4 +278,4 @@ jobs:
           if [ -n "$NEEDLEFISH_MODEL_INPUT" ]; then args+=(--model "$NEEDLEFISH_MODEL_INPUT"); fi
           if [ -n "$NEEDLEFISH_TIMEOUT_MS_INPUT" ]; then args+=(--timeout-ms "$NEEDLEFISH_TIMEOUT_MS_INPUT"); fi
           if [ -n "$NEEDLEFISH_RECHECK_INPUT" ]; then args+=(--recheck); fi
-          "$HOME/.local/bin/needlefish" "${args[@]}"
+          "$NEEDLEFISH_BIN" "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- GitHub: execute the exact immutable release selected by
+  `needlefish_release_sha`, so a newer deployment cannot invalidate or replace a
+  caller-pinned review runtime.
+
 ## 0.4.1 — 2026-08-01
 
 - Runner: execute model CLIs inside disposable Git review sandboxes, verify the

--- a/README.md
+++ b/README.md
@@ -321,12 +321,21 @@ gh workflow run review.yml -R frankekn/needlefish --ref main \
 All production model runners execute without their own process-level permission
 restrictions. Use them only on a self-hosted runner you control.
 
-Because the caller pins `@main`, fixes to needlefish's `review.yml` propagate to
-every target repo automatically. The runner must have needlefish deployed at
-`~/.local/bin/needlefish`; the workflow does not reinstall the tool on every PR.
-Hardened installed releases should also publish
-`~/.local/share/needlefish/current/release.json` with the installed Needlefish
-SHA so review jobs can fail before spending model tokens when a runner is stale.
+For reproducible reviews, pin the reusable workflow and
+`needlefish_release_sha` to the same full commit SHA. The workflow executes that
+immutable release from `~/.local/share/needlefish/releases/<sha>` even when a
+newer deployment has moved the shared `current` symlink. Callers using `@main`
+without an explicit release pin resolve the current Needlefish `main` SHA.
+The workflow never reinstalls the tool during a PR job; the selected release must
+already have been deployed on the runner.
+
+```yaml
+jobs:
+  review:
+    uses: frankekn/needlefish/.github/workflows/review.yml@<full-commit-sha>
+    with:
+      needlefish_release_sha: <full-commit-sha>
+```
 
 1. Register a **self-hosted runner** on the target repo (free, unlimited minutes).
    Keep it on a machine you control (EC2/pod/Mac).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -282,6 +282,21 @@ gh workflow run review.yml -R frankekn/needlefish --ref main \
 所有 production model runner 都不套用各 runner 自己的 process-level 權限限制，
 因此只能在你控制的 self-hosted runner 上使用。
 
+需要可重現的 review 時，reusable workflow ref 與
+`needlefish_release_sha` 必須 pin 到同一個完整 commit SHA。workflow 會直接執行
+`~/.local/share/needlefish/releases/<sha>` 的 immutable release；即使較新的部署
+切換了共用的 `current` symlink，已 pin 的 repo 也不受影響。使用 `@main` 且未
+指定 release SHA 時，workflow 會解析 Needlefish `main` 的目前 SHA。PR job
+不會重新安裝 Needlefish，因此該 release 必須已部署在 runner。
+
+```yaml
+jobs:
+  review:
+    uses: frankekn/needlefish/.github/workflows/review.yml@<full-commit-sha>
+    with:
+      needlefish_release_sha: <full-commit-sha>
+```
+
 1. 在目標 repo 註冊 self-hosted runner，並限制在自己控制的機器。
 2. 在 runner 部署 Needlefish；`main` 的 push 會觸發 `needlefish-deploy`：
    ```bash

--- a/scripts/review-workflow-release.test.mjs
+++ b/scripts/review-workflow-release.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const workflow = readFileSync(".github/workflows/review.yml", "utf8");
+
+function workflowScript(stepName) {
+	const escapedName = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const step = workflow.match(
+		new RegExp(`      - name: ${escapedName}\\n([\\s\\S]*?)(?=\\n      - name:|$)`),
+	);
+	assert.ok(step, `${stepName} step must exist`);
+	const runBlock = step[1].match(/        run: \|\n([\s\S]*)/);
+	assert.ok(runBlock, `${stepName} must have a run block`);
+	return runBlock[1]
+		.split("\n")
+		.map((line) => line.replace(/^          /, ""))
+		.join("\n");
+}
+
+const selectScript = workflowScript("Select Needlefish release");
+const reviewScript = workflowScript("Needlefish review");
+const pinnedSha = "a".repeat(40);
+const currentSha = "b".repeat(40);
+
+function installRelease(home, sha, { metadataSha = sha, withBinary = true } = {}) {
+	const release = join(home, ".local", "share", "needlefish", "releases", sha);
+	const bin = join(release, "bin");
+	mkdirSync(bin, { recursive: true });
+	writeFileSync(
+		join(release, "release.json"),
+		`${JSON.stringify({
+			sha: metadataSha,
+			version: "0.4.1",
+			repoUrl: "https://github.com/frankekn/needlefish.git",
+			deployedAt: "2026-08-10T00:00:00Z",
+			node: process.version,
+		}, null, 2)}\n`,
+	);
+	if (withBinary) {
+		writeFileSync(join(bin, "needlefish"), "#!/bin/sh\nprintf 'needlefish 0.4.1\\n'\n");
+		chmodSync(join(bin, "needlefish"), 0o755);
+	}
+	return release;
+}
+
+function runSelection({
+	expectedSha = pinnedSha,
+	mainSha = pinnedSha,
+	releases = [{ sha: pinnedSha }],
+	current = currentSha,
+} = {}) {
+	const root = mkdtempSync(join(tmpdir(), "needlefish-workflow-release-"));
+	const home = join(root, "home with spaces");
+	const fakeBin = join(root, "fake bin");
+	const githubEnv = join(root, "github-env");
+	const ghLog = join(root, "gh.log");
+	mkdirSync(home);
+	mkdirSync(fakeBin);
+
+	for (const release of releases) installRelease(home, release.sha, release);
+	if (current) {
+		const currentRelease = join(
+			home,
+			".local",
+			"share",
+			"needlefish",
+			"releases",
+			current,
+		);
+		if (!existsSync(currentRelease)) installRelease(home, current);
+		symlinkSync(
+			currentRelease,
+			join(home, ".local", "share", "needlefish", "current"),
+		);
+	}
+
+	writeFileSync(
+		join(fakeBin, "gh"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$GH_LOG"
+if [ "\${1:-}" = api ] && [[ "\${2:-}" == repos/*/commits/main ]]; then
+  printf '%s\\n' "$GH_MAIN_SHA"
+fi
+`,
+	);
+	chmodSync(join(fakeBin, "gh"), 0o755);
+
+	const result = spawnSync("bash", ["-c", selectScript], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			EXPECTED_NEEDLEFISH_SHA: expectedSha,
+			GH_LOG: ghLog,
+			GH_MAIN_SHA: mainSha,
+			GH_TOKEN: "test-token",
+			GITHUB_ENV: githubEnv,
+			HOME: home,
+			NEEDLEFISH_REPO: "frankekn/needlefish",
+			PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+			PR_HEAD_SHA: "c".repeat(40),
+			REPO: "frankekn/example",
+		},
+	});
+	const output = {
+		...result,
+		expectedBinary: join(
+			home,
+			".local",
+			"share",
+			"needlefish",
+			"releases",
+			expectedSha || mainSha,
+			"bin",
+			"needlefish",
+		),
+		ghLog: existsSync(ghLog) ? readFileSync(ghLog, "utf8") : "",
+		githubEnv: existsSync(githubEnv) ? readFileSync(githubEnv, "utf8") : "",
+	};
+	rmSync(root, { recursive: true, force: true });
+	return output;
+}
+
+test("selection executes the caller-pinned release even when current is newer", () => {
+	const result = runSelection();
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.stdout, "needlefish 0.4.1\n");
+	assert.equal(result.githubEnv, `NEEDLEFISH_BIN=${result.expectedBinary}\n`);
+	assert.doesNotMatch(selectScript, /needlefish\/current/);
+});
+
+test("selection resolves an omitted pin to the source repository main SHA", () => {
+	const result = runSelection({ expectedSha: "" });
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.ghLog, /api repos\/frankekn\/needlefish\/commits\/main --jq \.sha/);
+	assert.equal(result.githubEnv, `NEEDLEFISH_BIN=${result.expectedBinary}\n`);
+});
+
+test("selection fails closed and posts a check when the pinned release is absent", () => {
+	const result = runSelection({ releases: [], current: currentSha });
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, new RegExp(`found missing.*releases/${pinnedSha}/release\\.json`));
+	assert.match(result.ghLog, /api -X POST repos\/frankekn\/example\/check-runs/);
+	assert.equal(result.githubEnv, "");
+});
+
+test("selection rejects release metadata that does not match its immutable directory", () => {
+	const result = runSelection({
+		releases: [{ sha: pinnedSha, metadataSha: currentSha }],
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, new RegExp(`expected Needlefish release ${pinnedSha}`, "i"));
+	assert.match(result.stderr, new RegExp(`found ${currentSha}`));
+	assert.equal(result.githubEnv, "");
+});
+
+test("selection rejects invalid SHAs before constructing a release path", () => {
+	const result = runSelection({ expectedSha: "../../current", releases: [] });
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /full lowercase 40-character Needlefish commit SHA/);
+	assert.equal(result.githubEnv, "");
+});
+
+test("selection rejects an installed release without an executable", () => {
+	const result = runSelection({
+		releases: [{ sha: pinnedSha, withBinary: false }],
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /missing executable/);
+	assert.equal(result.githubEnv, "");
+});
+
+test("review invokes only the selected immutable release binary", () => {
+	assert.match(reviewScript, /"\$NEEDLEFISH_BIN" "\$\{args\[@\]\}"/);
+	assert.doesNotMatch(reviewScript, /\.local\/bin\/needlefish|needlefish\/current/);
+});


### PR DESCRIPTION
## Summary
- execute needlefish_release_sha from its immutable release directory
- validate SHA, metadata, executable, and runtime before review
- add shell-level regression coverage and pinning documentation

## Validation
- pnpm check
- pnpm lint
- node --test scripts/review-workflow-release.test.mjs (7/7)
- actionlint .github/workflows/review.yml
- full test suite cross-checked on host and Docker; unrelated environment-sensitive fake-df / process timing cases were isolated and reproduced outside this diff