### PR TITLE
fix(runner): recover stalled OpenCode reviews

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,6 +18,9 @@ on:
       timeout_ms:
         description: Optional per-call timeout in milliseconds
         required: false
+      idle_timeout_ms:
+        description: Optional opencode inactivity timeout in milliseconds
+        required: false
       codex_reasoning_effort:
         description: "Codex reasoning effort: medium, high, or xhigh"
         required: false
@@ -49,6 +52,10 @@ on:
         required: false
       timeout_ms:
         description: Optional per-call timeout in milliseconds
+        type: string
+        required: false
+      idle_timeout_ms:
+        description: Optional opencode inactivity timeout in milliseconds
         type: string
         required: false
       codex_reasoning_effort:
@@ -252,6 +259,7 @@ jobs:
           NEEDLEFISH_RUNNER_INPUT: ${{ inputs.runner || github.event.inputs.runner || 'codex' }}
           NEEDLEFISH_MODEL_INPUT: ${{ inputs.model || github.event.inputs.model }}
           NEEDLEFISH_TIMEOUT_MS_INPUT: ${{ inputs.timeout_ms || github.event.inputs.timeout_ms }}
+          OPENCODE_IDLE_TIMEOUT_MS_INPUT: ${{ inputs.idle_timeout_ms || github.event.inputs.idle_timeout_ms }}
           CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort || github.event.inputs.codex_reasoning_effort }}
           # ubuntu-needlefish routes pi through the local CLIProxyAPI (ccp);
           # credentials live in the proxy, provider registered in ~/.pi/agent/models.json.
@@ -277,5 +285,6 @@ jobs:
           if [ -n "$NEEDLEFISH_RUNNER_INPUT" ]; then args+=(--runner "$NEEDLEFISH_RUNNER_INPUT"); fi
           if [ -n "$NEEDLEFISH_MODEL_INPUT" ]; then args+=(--model "$NEEDLEFISH_MODEL_INPUT"); fi
           if [ -n "$NEEDLEFISH_TIMEOUT_MS_INPUT" ]; then args+=(--timeout-ms "$NEEDLEFISH_TIMEOUT_MS_INPUT"); fi
+          if [ -n "$OPENCODE_IDLE_TIMEOUT_MS_INPUT" ]; then export OPENCODE_IDLE_TIMEOUT_MS="$OPENCODE_IDLE_TIMEOUT_MS_INPUT"; fi
           if [ -n "$NEEDLEFISH_RECHECK_INPUT" ]; then args+=(--recheck); fi
           "$NEEDLEFISH_BIN" "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - GitHub: execute the exact immutable release selected by
   `needlefish_release_sha`, so a newer deployment cannot invalidate or replace a
   caller-pinned review runtime.
+- Runner: stop and retry opencode attempts after ten minutes without stdout or
+  stderr, independently of a longer per-call timeout, and preserve GitHub's
+  process-tracking marker so cancelled jobs do not leave detached runners.
 
 ## 0.4.1 — 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ jobs:
       # model: gpt-5.6-terra
       # codex_reasoning_effort: high
       # timeout_ms: "600000"
+      # idle_timeout_ms: "600000" # opencode only
     secrets: inherit
 ```
 
@@ -444,6 +445,11 @@ and `--timeout-ms`, or the matching env vars:
 | model | `NEEDLEFISH_MODEL` | runner default |
 | Codex reasoning effort | `CODEX_REASONING_EFFORT` | `medium` (reusable workflow: `high` for `gpt-5.6-terra`) |
 | timeout | `NEEDLEFISH_TIMEOUT_MS` | `600000` |
+| opencode idle timeout | `OPENCODE_IDLE_TIMEOUT_MS` | the smaller of the per-call timeout and `600000` |
+
+The opencode idle deadline resets whenever the CLI emits stdout or stderr. If a
+provider stream stops producing output, Needlefish terminates that attempt and
+uses the normal runner retry instead of waiting for an extended per-call timeout.
 
 Runner-specific binary env vars are `CODEX_BIN`, `CLAUDE_BIN`, `OPENCODE_BIN`,
 `GROK_BIN`, `PI_BIN`, and `NEEDLEFISH_ACP_BIN`. `NEEDLEFISH_ACP_BIN` is required
@@ -483,6 +489,9 @@ locale/proxy/path basics plus each runner's own `_BIN`/`_MODEL`-style
 variables are passed through. To pass an additional variable to the runner
 subprocess, set `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR1,VAR2` (comma-separated
 names).
+On GitHub Actions, the non-secret `RUNNER_TRACKING_ID` job marker is retained so
+the self-hosted runner can terminate detached model processes when a job is
+cancelled.
 
 ACP env authentication additionally requires an explicit credential declaration:
 set `NEEDLEFISH_ACP_AUTH_ENV_VARS` to the credential names and include those same

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -265,6 +265,7 @@ jobs:
       # model: gpt-5.6-terra
       # codex_reasoning_effort: high
       # timeout_ms: "600000"
+      # idle_timeout_ms: "600000" # 僅 opencode
     secrets: inherit
 ```
 
@@ -371,6 +372,11 @@ Fork PR 預設不會收到 secrets，workflow 會跳過它們；不要在不了�
 | model | `NEEDLEFISH_MODEL` | runner 預設值 |
 | Codex reasoning effort | `CODEX_REASONING_EFFORT` | `medium`（reusable workflow：`gpt-5.6-terra` 時為 `high`） |
 | timeout | `NEEDLEFISH_TIMEOUT_MS` | `600000` |
+| opencode idle timeout | `OPENCODE_IDLE_TIMEOUT_MS` | per-call timeout 與 `600000` 中較小者 |
+
+opencode CLI 每次產生 stdout 或 stderr 都會重設 idle deadline。若 provider
+stream 停止輸出，Needlefish 會終止該 attempt 並使用既有 runner retry，不再等待
+被拉長的完整 per-call timeout。
 
 Codex 使用 `--ignore-user-config --ignore-rules
 --dangerously-bypass-approvals-and-sandbox`，避免檢查命令遭 execpolicy rule、
@@ -395,6 +401,9 @@ Runner 只會收到 allowlist 環境，不會繼承完整的 parent `process.env
 ```bash
 NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR1,VAR2
 ```
+
+GitHub Actions 的非機密 `RUNNER_TRACKING_ID` job marker 會自動保留，讓
+self-hosted runner 在 job 被取消時能終止 detached model process。
 
 ACP 認證還需要宣告 `NEEDLEFISH_ACP_AUTH_ENV_VARS`，並把相同名稱放入
 `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH`；或者以

--- a/scripts/review-workflow-release.test.mjs
+++ b/scripts/review-workflow-release.test.mjs
@@ -193,3 +193,11 @@ test("review invokes only the selected immutable release binary", () => {
 	assert.match(reviewScript, /"\$NEEDLEFISH_BIN" "\$\{args\[@\]\}"/);
 	assert.doesNotMatch(reviewScript, /\.local\/bin\/needlefish|needlefish\/current/);
 });
+
+test("review forwards the optional opencode idle timeout without exporting an empty value", () => {
+	assert.match(workflow, /idle_timeout_ms:\n\s+description: Optional opencode inactivity timeout/);
+	assert.match(
+		reviewScript,
+		/if \[ -n "\$OPENCODE_IDLE_TIMEOUT_MS_INPUT" \]; then export OPENCODE_IDLE_TIMEOUT_MS="\$OPENCODE_IDLE_TIMEOUT_MS_INPUT"; fi/,
+	);
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -75,6 +75,7 @@ Env:
   CODEX_BIN               codex executable (default: codex)
   CLAUDE_BIN              claude executable (default: claude)
   OPENCODE_BIN            opencode executable (default: opencode)
+  OPENCODE_IDLE_TIMEOUT_MS opencode inactivity timeout (default: min of per-call timeout and 600000)
   PI_BIN                  pi executable (default: pi)
   NEEDLEFISH_ACP_BIN      ACP agent executable (required for acp)
 `;

--- a/src/shared/codex-runners.test.ts
+++ b/src/shared/codex-runners.test.ts
@@ -147,6 +147,63 @@ test("runCodex extracts opencode json text output", async (t) => {
 	});
 });
 
+test("runCodex retries an opencode attempt that stops producing output", async (t) => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "opencode-bin.js");
+	const attemptsPath = path.join(tmp, "attempts.txt");
+	const previous = {
+		bin: process.env.OPENCODE_BIN,
+		idleTimeout: process.env.OPENCODE_IDLE_TIMEOUT_MS,
+		noRetry: process.env.NEEDLEFISH_NO_RETRY,
+		retry: process.env.NEEDLEFISH_RETRY_MS,
+		runner: process.env.NEEDLEFISH_RUNNER,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.OPENCODE_BIN;
+		else process.env.OPENCODE_BIN = previous.bin;
+		if (previous.idleTimeout === undefined)
+			delete process.env.OPENCODE_IDLE_TIMEOUT_MS;
+		else process.env.OPENCODE_IDLE_TIMEOUT_MS = previous.idleTimeout;
+		if (previous.noRetry === undefined) delete process.env.NEEDLEFISH_NO_RETRY;
+		else process.env.NEEDLEFISH_NO_RETRY = previous.noRetry;
+		if (previous.retry === undefined) delete process.env.NEEDLEFISH_RETRY_MS;
+		else process.env.NEEDLEFISH_RETRY_MS = previous.retry;
+		if (previous.runner === undefined) delete process.env.NEEDLEFISH_RUNNER;
+		else process.env.NEEDLEFISH_RUNNER = previous.runner;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			`const attemptsPath = ${JSON.stringify(attemptsPath)};`,
+			"const attempt = fs.existsSync(attemptsPath) ? Number(fs.readFileSync(attemptsPath, 'utf8')) + 1 : 1;",
+			"fs.writeFileSync(attemptsPath, String(attempt));",
+			"if (attempt === 1) setInterval(() => {}, 1000);",
+			"else process.stdout.write(JSON.stringify({ type: 'text', part: { text: '{\\\"ok\\\":true}' } }) + '\\n');",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.OPENCODE_BIN = bin;
+	process.env.OPENCODE_IDLE_TIMEOUT_MS = "100";
+	delete process.env.NEEDLEFISH_NO_RETRY;
+	process.env.NEEDLEFISH_RETRY_MS = "1";
+	process.env.NEEDLEFISH_RUNNER = "opencode";
+
+	const startedAt = Date.now();
+	const output = await runCodex("prompt", {
+		repoPath: repo,
+		targetHeadSha: headSha(repo),
+		timeoutMs: 2000,
+	});
+
+	assert.ok(Date.now() - startedAt < 1000);
+	assert.equal(output, '{"ok":true}');
+	assert.equal(readFileSync(attemptsPath, "utf8"), "2");
+});
+
 test("runCodex rejects non-codex runners that dirty the target repo", async (t) => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
 	const repo = initRepo(tmp);

--- a/src/shared/codex.test.ts
+++ b/src/shared/codex.test.ts
@@ -338,12 +338,16 @@ test("runCodex passes allowlisted env vars to the runner subprocess", async (t) 
   const previous = {
     bin: process.env.CODEX_BIN,
     model: process.env.CODEX_MODEL,
+    runnerTrackingId: process.env.RUNNER_TRACKING_ID,
   };
   t.after(() => {
     if (previous.bin === undefined) delete process.env.CODEX_BIN;
     else process.env.CODEX_BIN = previous.bin;
     if (previous.model === undefined) delete process.env.CODEX_MODEL;
     else process.env.CODEX_MODEL = previous.model;
+    if (previous.runnerTrackingId === undefined)
+      delete process.env.RUNNER_TRACKING_ID;
+    else process.env.RUNNER_TRACKING_ID = previous.runnerTrackingId;
     rmSync(tmp, { recursive: true, force: true });
   });
   writeFileSync(
@@ -353,13 +357,14 @@ test("runCodex passes allowlisted env vars to the runner subprocess", async (t) 
       "const fs = require('node:fs');",
       "const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
       `const envDump = ${JSON.stringify(envDump)};`,
-      "fs.writeFileSync(envDump, JSON.stringify({ codexModel: process.env.CODEX_MODEL ?? null }));",
+      "fs.writeFileSync(envDump, JSON.stringify({ codexModel: process.env.CODEX_MODEL ?? null, runnerTrackingId: process.env.RUNNER_TRACKING_ID ?? null }));",
       "fs.writeFileSync(out, '{\"ok\":true}');",
     ].join("\n")
   );
   chmodSync(bin, 0o755);
   process.env.CODEX_BIN = bin;
   process.env.CODEX_MODEL = "test-model";
+  process.env.RUNNER_TRACKING_ID = "github-job-marker";
 
   await runCodex("prompt", {
     repoPath: repo,
@@ -368,8 +373,12 @@ test("runCodex passes allowlisted env vars to the runner subprocess", async (t) 
     timeoutMs: 1000,
   });
 
-  const dump = JSON.parse(readFileSync(envDump, "utf8")) as { codexModel: string | null };
+  const dump = JSON.parse(readFileSync(envDump, "utf8")) as {
+    codexModel: string | null;
+    runnerTrackingId: string | null;
+  };
   assert.equal(dump.codexModel, "test-model");
+  assert.equal(dump.runnerTrackingId, "github-job-marker");
 });
 
 test("runCodex strips non-allowlisted env vars from the runner subprocess", async (t) => {

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -52,6 +52,9 @@ const BASE_ENV_ALLOWLIST = [
 	"http_proxy",
 	"https_proxy",
 	"no_proxy",
+	// GitHub's self-hosted runner uses this non-secret job marker to find and
+	// terminate detached descendants when a workflow is cancelled.
+	"RUNNER_TRACKING_ID",
 ] as const;
 
 const RUNNER_ENV_ALLOWLIST: Record<RunnerName, readonly string[]> = {
@@ -670,6 +673,15 @@ function retryMsFor(runner: RunnerName): number {
 	return 5000;
 }
 
+function openCodeIdleTimeoutMs(totalTimeoutMs: number): number {
+	const configured = process.env.OPENCODE_IDLE_TIMEOUT_MS?.trim();
+	const idleTimeoutMs =
+		configured === undefined || configured === ""
+			? 600000
+			: parsePositiveInteger(configured, "OPENCODE_IDLE_TIMEOUT_MS");
+	return Math.min(totalTimeoutMs, idleTimeoutMs);
+}
+
 async function runRunner(
 	runner: RunnerName,
 	invocation: RunnerInvocation,
@@ -793,6 +805,7 @@ async function runOpenCode(
 		stdin: "",
 		repoPath: invocation.repoPath,
 		timeoutMs: invocation.timeoutMs,
+		idleTimeoutMs: openCodeIdleTimeoutMs(invocation.timeoutMs),
 		env: {
 			...invocation.env,
 			OPENCODE_CONFIG_CONTENT: unrestrictedConfig,

--- a/src/shared/runner-process.test.ts
+++ b/src/shared/runner-process.test.ts
@@ -38,6 +38,44 @@ test("readRunnerDurationMs treats empty runner timeout env as unset", () => {
   assert.equal(readRunnerDurationMs("0", 5000), 0);
 });
 
+test("spawnRunnerProcess stops a runner that becomes idle", { timeout: 3000 }, async () => {
+  const startedAt = Date.now();
+  const result = await spawnRunnerProcess({
+    command: process.execPath,
+    args: ["-e", "setInterval(() => {}, 1000)"],
+    stdin: "",
+    repoPath: process.cwd(),
+    timeoutMs: 2000,
+    idleTimeoutMs: 100,
+    env: process.env,
+  });
+
+  assert.ok(Date.now() - startedAt < 1000);
+  assert.equal(result.status, null);
+  assert.equal(result.signal, "SIGTERM");
+  assert.equal((result.error as Error & { code?: string }).code, "EIDLETIMEDOUT");
+  assert.match(result.error?.message ?? "", /EIDLETIMEDOUT/);
+});
+
+test("spawnRunnerProcess refreshes the idle deadline when output arrives", async () => {
+  const result = await spawnRunnerProcess({
+    command: process.execPath,
+    args: [
+      "-e",
+      "let count = 0; const timer = setInterval(() => { process.stdout.write('tick\\n'); count += 1; if (count === 4) { clearInterval(timer); } }, 60);",
+    ],
+    stdin: "",
+    repoPath: process.cwd(),
+    timeoutMs: 1000,
+    idleTimeoutMs: 120,
+    env: process.env,
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "tick\ntick\ntick\ntick\n");
+});
+
 test("spawnRunnerProcess kills a SIGTERM-trapping process group after timeout", { timeout: 10_000 }, async () => {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-runner-process-test-"));
   const runner = path.join(tmp, "zombie-runner.js");

--- a/src/shared/runner-process.ts
+++ b/src/shared/runner-process.ts
@@ -20,6 +20,7 @@ export interface RunnerProcessInvocation {
   readonly stdin: string;
   readonly repoPath: string;
   readonly timeoutMs: number;
+  readonly idleTimeoutMs?: number;
   readonly env: NodeJS.ProcessEnv;
 }
 
@@ -38,6 +39,7 @@ export interface ManagedRunnerProcessInvocation {
   readonly args: readonly string[];
   readonly repoPath: string;
   readonly timeoutMs: number;
+  readonly idleTimeoutMs?: number;
   readonly env: NodeJS.ProcessEnv;
   readonly onSpawn?: RunnerLifecycleHandler;
   readonly onStdout?: RunnerChunkHandler;
@@ -50,6 +52,14 @@ export class RunnerTimeoutError extends Error {
 
   constructor(command: string) {
     super(`spawn ${command} ETIMEDOUT`);
+  }
+}
+
+export class RunnerIdleTimeoutError extends Error {
+  readonly code = "EIDLETIMEDOUT";
+
+  constructor(command: string) {
+    super(`spawn ${command} EIDLETIMEDOUT`);
   }
 }
 
@@ -69,6 +79,9 @@ export async function spawnRunnerProcess(
     args: invocation.args,
     repoPath: invocation.repoPath,
     timeoutMs: invocation.timeoutMs,
+    ...(invocation.idleTimeoutMs === undefined
+      ? {}
+      : { idleTimeoutMs: invocation.idleTimeoutMs }),
     env: invocation.env,
     onSpawn: (controller) => controller.child.stdin.end(invocation.stdin),
   });
@@ -84,10 +97,11 @@ export async function runManagedRunnerProcess(
     const stdoutBytes = { count: 0 };
     const stderrBytes = { count: 0 };
     let settled = false;
-    let timedOut = false;
     let spawnError: Error | undefined;
     let bufferError: Error | undefined;
+    let timeoutError: Error | undefined;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
     let cancelTimer: ReturnType<typeof setTimeout> | null = null;
     let hardKillTimer: ReturnType<typeof setTimeout> | null = null;
     let giveUpTimer: ReturnType<typeof setTimeout> | null = null;
@@ -107,6 +121,10 @@ export async function runManagedRunnerProcess(
       if (timer !== null) {
         clearTimeout(timer);
         timer = null;
+      }
+      if (idleTimer !== null) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
       }
       if (cancelTimer !== null) {
         clearTimeout(cancelTimer);
@@ -133,6 +151,10 @@ export async function runManagedRunnerProcess(
         clearTimeout(timer);
         timer = null;
       }
+      if (idleTimer !== null) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
       if (cancelTimer !== null) {
         clearTimeout(cancelTimer);
         cancelTimer = null;
@@ -152,6 +174,7 @@ export async function runManagedRunnerProcess(
       if (settled) return;
       settled = true;
       if (timer !== null) clearTimeout(timer);
+      if (idleTimer !== null) clearTimeout(idleTimer);
       if (cancelTimer !== null) clearTimeout(cancelTimer);
       if (hardKillTimer !== null) clearTimeout(hardKillTimer);
       if (giveUpTimer !== null) clearTimeout(giveUpTimer);
@@ -163,7 +186,7 @@ export async function runManagedRunnerProcess(
         error:
           spawnError ??
           bufferError ??
-          (timedOut ? new RunnerTimeoutError(invocation.command) : undefined),
+          timeoutError,
       });
     };
 
@@ -214,10 +237,42 @@ export async function runManagedRunnerProcess(
       return text;
     };
 
+    const beginTimeout = (error: RunnerTimeoutError | RunnerIdleTimeoutError): void => {
+      if (settled || timeoutError !== undefined) return;
+      timeoutError = error;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (idleTimer !== null) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
+      if (invocation.onTimeout !== undefined) {
+        try {
+          invocation.onTimeout(controller);
+        } catch (handlerError) {
+          if (!(handlerError instanceof Error)) throw handlerError;
+        }
+      }
+      const cancelBeatMs = invocation.onTimeout === undefined ? 0 : runnerTimeoutCancelMs();
+      cancelTimer = setTimeout(() => beginKillSequence("SIGTERM"), cancelBeatMs);
+    };
+
+    const refreshIdleTimer = (): void => {
+      if (invocation.idleTimeoutMs === undefined || timeoutError !== undefined) return;
+      if (idleTimer !== null) clearTimeout(idleTimer);
+      idleTimer = setTimeout(
+        () => beginTimeout(new RunnerIdleTimeoutError(invocation.command)),
+        invocation.idleTimeoutMs,
+      );
+    };
+
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: unknown) => {
       const text = collect(stdout, stdoutBytes, chunk);
+      if (text !== null) refreshIdleTimer();
       if (text === null || invocation.onStdout === undefined) return;
       try {
         invocation.onStdout(text, controller);
@@ -227,6 +282,7 @@ export async function runManagedRunnerProcess(
     });
     child.stderr.on("data", (chunk: unknown) => {
       const text = collect(stderr, stderrBytes, chunk);
+      if (text !== null) refreshIdleTimer();
       if (text === null || invocation.onStderr === undefined) return;
       try {
         invocation.onStderr(text, controller);
@@ -235,7 +291,7 @@ export async function runManagedRunnerProcess(
       }
     });
     child.stdin.on("error", (error) => {
-      if (!timedOut && bufferError === undefined && spawnError === undefined) {
+      if (timeoutError === undefined && bufferError === undefined && spawnError === undefined) {
         spawnError = error;
       }
     });
@@ -248,18 +304,11 @@ export async function runManagedRunnerProcess(
       finish(status, signal);
     });
 
-    timer = setTimeout(() => {
-      timedOut = true;
-      if (invocation.onTimeout !== undefined) {
-        try {
-          invocation.onTimeout(controller);
-        } catch (error) {
-          if (!(error instanceof Error)) throw error;
-        }
-      }
-      const cancelBeatMs = invocation.onTimeout === undefined ? 0 : runnerTimeoutCancelMs();
-      cancelTimer = setTimeout(() => beginKillSequence("SIGTERM"), cancelBeatMs);
-    }, invocation.timeoutMs);
+    timer = setTimeout(
+      () => beginTimeout(new RunnerTimeoutError(invocation.command)),
+      invocation.timeoutMs,
+    );
+    refreshIdleTimer();
 
     if (invocation.onSpawn !== undefined) {
       try {


### PR DESCRIPTION
## Root cause

OpenCode can keep its process and TCP connection alive while the provider stream stops producing stdout/stderr. Needlefish previously had only the full per-call timeout, so a 2-hour workflow appeared hung and could not reach its retry.

Needlefish also stripped RUNNER_TRACKING_ID from the child environment. GitHub self-hosted runner cancellation therefore could not identify detached model descendants, leaving the OpenCode process orphaned after the job was cancelled.

## Fix

- add a configurable OpenCode inactivity timeout (default 10 minutes, capped by the per-call timeout)
- refresh the inactivity deadline on every stdout/stderr chunk and use the existing retry path after timeout
- preserve GitHub RUNNER_TRACKING_ID in the strict runner env allowlist
- expose idle_timeout_ms through the reusable workflow
- add red/green regressions for idle termination, output refresh, retry, tracking marker, and workflow forwarding

## Validation

- pnpm test: 530 passed, 0 failed
- pnpm check
- pnpm lint
- actionlint .github/workflows/review.yml
- git diff --check