### PR TITLE
fix(deploy): avoid system Corepack symlinks

### DIFF
--- a/scripts/deploy-ubuntu.sh
+++ b/scripts/deploy-ubuntu.sh
@@ -35,15 +35,14 @@ git checkout --detach FETCH_HEAD
 
 sha=$(git rev-parse HEAD)
 release="$releases/$sha"
-if ! command -v pnpm >/dev/null 2>&1; then
-	pnpm_version=$(node -p "require('./package.json').packageManager")
-	corepack enable
-	corepack prepare "$pnpm_version" --activate
-fi
 if [ -e "$release" ]; then
 	validate_release
 else
-	pnpm install --frozen-lockfile
+	if command -v pnpm >/dev/null 2>&1; then
+		pnpm install --frozen-lockfile
+	else
+		corepack pnpm install --frozen-lockfile
+	fi
 
 	version=$(node -p "require('./package.json').version")
 	node_version=$(node -p "process.version")

--- a/scripts/deploy-ubuntu.test.mjs
+++ b/scripts/deploy-ubuntu.test.mjs
@@ -8,6 +8,13 @@ test("deploy does not install an optional model runner", async () => {
   assert.doesNotMatch(script, /npm install -g @mariozechner\/pi/);
 });
 
+test("deploy uses Corepack without writing system pnpm shims", async () => {
+  const script = await readFile("scripts/deploy-ubuntu.sh", "utf8");
+
+  assert.doesNotMatch(script, /^\s*corepack enable$/m);
+  assert.match(script, /corepack pnpm install --frozen-lockfile/);
+});
+
 test("hosted action does not require runner permission opt-ins", async () => {
   const action = await readFile("action.yml", "utf8");
 


### PR DESCRIPTION
## Summary

- avoid `corepack enable`, which tries to create pnpm shims beside the system Corepack binary
- use `corepack pnpm install --frozen-lockfile` when pnpm is not already on PATH
- skip all package-manager setup when the immutable release already exists
- add a regression contract for non-root deployment

## Failure

Saiens Rails PR #783 self-healed Needlefish from `722b37b` to `f6c58ab`, but the installer failed with:

```text
EACCES: permission denied, symlink '../lib/node_modules/corepack/dist/pnpm.js' -> '/usr/bin/pnpm'
```

Failed job: https://github.com/frankekn/SaiensCreditSystemRails/actions/runs/31369971869/job/93396597383

## Verification

- `node --test scripts/deploy-ubuntu.test.mjs`
- `sh -n scripts/deploy-ubuntu.sh`
- `corepack pnpm --version` → `10.34.4`
- `corepack pnpm check`
- `corepack pnpm lint`
- `corepack pnpm test`
- autoreview: clean, patch correct (0.98), no findings
