### PR TITLE
feat(runner): CODEX_SERVICE_TIER env selects codex service tier

### DIFF
--- a/src/shared/codex-scope.test.ts
+++ b/src/shared/codex-scope.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import { runCodex } from "./codex";
 import { headSha, initRepo, readStringArray } from "./codex-runner-test-fixtures";
 
@@ -48,4 +48,82 @@ test("runCodex hides dirty target files from codex runner", async (t) => {
   const args = readStringArray(argsPath);
   assert.equal(args.includes("--ignore-user-config"), true);
   assert.equal(args.includes('model_reasoning_effort="medium"'), true);
+});
+
+function setupCodexStub(t: TestContext): { repo: string; argsPath: string } {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
+  const repo = initRepo(tmp);
+  const bin = path.join(tmp, "codex-bin.js");
+  const argsPath = path.join(tmp, "args.json");
+  const previousBin = process.env.CODEX_BIN;
+  const previousServiceTier = process.env.CODEX_SERVICE_TIER;
+  const previousNoRetry = process.env.NEEDLEFISH_NO_RETRY;
+  t.after(() => {
+    if (previousBin === undefined) delete process.env.CODEX_BIN;
+    else process.env.CODEX_BIN = previousBin;
+    if (previousServiceTier === undefined) delete process.env.CODEX_SERVICE_TIER;
+    else process.env.CODEX_SERVICE_TIER = previousServiceTier;
+    if (previousNoRetry === undefined) delete process.env.NEEDLEFISH_NO_RETRY;
+    else process.env.NEEDLEFISH_NO_RETRY = previousNoRetry;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+  writeFileSync(
+    bin,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      `fs.writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(args));`,
+      "const out = args[args.indexOf('--output-last-message') + 1];",
+      "fs.writeFileSync(out, 'ok');",
+    ].join("\n")
+  );
+  chmodSync(bin, 0o755);
+  process.env.CODEX_BIN = bin;
+  delete process.env.CODEX_SERVICE_TIER;
+  return { repo, argsPath };
+}
+
+function runStubbedCodex(repo: string): Promise<string> {
+  return runCodex("prompt", {
+    repoPath: repo,
+    runner: "codex",
+    targetHeadSha: headSha(repo),
+    timeoutMs: 1000,
+  });
+}
+
+test("runCodex omits service_tier when CODEX_SERVICE_TIER is unset", async (t) => {
+  const { repo, argsPath } = setupCodexStub(t);
+
+  await runStubbedCodex(repo);
+
+  const args = readStringArray(argsPath);
+  assert.equal(
+    args.some((arg) => arg.includes("service_tier")),
+    false
+  );
+});
+
+test("runCodex passes CODEX_SERVICE_TIER to codex as a -c override", async (t) => {
+  const { repo, argsPath } = setupCodexStub(t);
+  process.env.CODEX_SERVICE_TIER = "fast";
+
+  await runStubbedCodex(repo);
+
+  const args = readStringArray(argsPath);
+  const index = args.indexOf('service_tier="fast"');
+  assert.notEqual(index, -1);
+  assert.equal(args[index - 1], "-c");
+});
+
+test("runCodex rejects an invalid CODEX_SERVICE_TIER", async (t) => {
+  const { repo } = setupCodexStub(t);
+  process.env.CODEX_SERVICE_TIER = "bogus";
+  // Retry would run the same doomed invocation twice with a 5s backoff.
+  process.env.NEEDLEFISH_NO_RETRY = "1";
+
+  await assert.rejects(runStubbedCodex(repo), {
+    message: "CODEX_SERVICE_TIER must be one of: fast, priority",
+  });
 });

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -709,6 +709,7 @@ async function runCodexCli(
 ): Promise<RunnerResult> {
 	const lastMsg = path.join(invocation.tmp, "last.txt");
 	const reasoningEffort = resolveCodexReasoningEffort();
+	const serviceTier = resolveCodexServiceTier();
 	const args = [
 		"exec",
 		"--color",
@@ -722,6 +723,7 @@ async function runCodexCli(
 		"--output-last-message",
 		lastMsg,
 	];
+	if (serviceTier) args.push("-c", `service_tier="${serviceTier}"`);
 	if (invocation.model) args.push("-m", invocation.model);
 	if (invocation.reasoningEffort)
 		args.push("-c", `model_reasoning_effort=${invocation.reasoningEffort}`);
@@ -749,6 +751,13 @@ function resolveCodexReasoningEffort(): CodexReasoningEffort {
 	if (value === undefined || value === "") return "medium";
 	if (value === "medium" || value === "high" || value === "xhigh") return value;
 	throw new Error("CODEX_REASONING_EFFORT must be one of: medium, high, xhigh");
+}
+
+function resolveCodexServiceTier(): string | undefined {
+	const value = process.env.CODEX_SERVICE_TIER;
+	if (value === undefined || value === "") return undefined;
+	if (value === "fast" || value === "priority") return value;
+	throw new Error("CODEX_SERVICE_TIER must be one of: fast, priority");
 }
 
 async function runClaude(invocation: RunnerInvocation): Promise<RunnerResult> {


### PR DESCRIPTION
## Summary

`runCodexCli` passes `--ignore-user-config`, so the runner host's `config.toml` `service_tier` is silently ignored — reviews always run at the account-default serving tier with no way to choose. This adds an optional `CODEX_SERVICE_TIER` env (mirroring the existing `CODEX_REASONING_EFFORT` pattern, fail-closed): when set to `fast` or `priority`, codex gets `-c service_tier="<value>"`; unset keeps today's behavior byte-identical.

Measured on the production review runner (gha-needlefish-arm, gpt-5.6-terra, interleaved 3-round A/B): baseline median 17.4s vs `service_tier="priority"` median 11.7s on a fixed prompt — ~33% wall-clock, no server-side rejection. (`fast` is OpenAI's 2026-07-30 rename of priority; the wire value `priority` is what the backend accepts.)

## Verification

- `pnpm check` exit 0; `pnpm test`: 534 tests, 522 pass, 0 fail, 12 skipped
- New tests assert the externally observable argv via the stub-bin pattern: unset → no `service_tier` element (negative control); `fast` → `-c` adjacency; invalid → exact error message
- Mutation-checked: removing the `args.push` fails the override test
- `CODEX_SERVICE_TIER` deliberately NOT added to `RUNNER_ENV_ALLOWLIST` — consumed in the parent into a `-c` flag; the runner subprocess never sees it (no permission widening)

## Review

Tier-2 seam (runner invocation) per docs/operating-manual.md §3 — diff is 9 lines in `codex.ts` plus tests. README env table intentionally untouched (kept diff minimal); can follow up.