### PR TITLE
test(verdict): pin every deriveVerdict severity boundary

### DIFF
--- a/src/core/verdict.test.ts
+++ b/src/core/verdict.test.ts
@@ -33,3 +33,26 @@ test("deriveVerdict passes when no blocking evidence remains", () => {
 
   assert.equal(verdict, "pass");
 });
+
+test("deriveVerdict pins every severity boundary", () => {
+  const residual = [{ text: "deep pass failed", blocks: true }];
+  const cases: readonly {
+    label: string;
+    severity: Finding["severity"] | null;
+    residualBlocks: boolean;
+    expected: "changes_requested" | "needs_human" | "pass";
+  }[] = [
+    { label: "P0 alone", severity: "P0", residualBlocks: false, expected: "changes_requested" },
+    { label: "P1 alone", severity: "P1", residualBlocks: false, expected: "changes_requested" },
+    { label: "P2 alone", severity: "P2", residualBlocks: false, expected: "changes_requested" },
+    { label: "P3 alone", severity: "P3", residualBlocks: false, expected: "pass" },
+    { label: "blocking residual, no findings", severity: null, residualBlocks: true, expected: "needs_human" },
+    { label: "blocking finding plus blocking residual", severity: "P2", residualBlocks: true, expected: "changes_requested" },
+  ];
+
+  for (const { label, severity, residualBlocks, expected } of cases) {
+    const findings = severity === null ? [] : [{ ...finding, severity }];
+    const residualRisks = residualBlocks ? residual : [];
+    assert.equal(deriveVerdict(findings, residualRisks), expected, label);
+  }
+});


### PR DESCRIPTION
Closes #59.

## Problem

`deriveVerdict` blocks `P0`/`P1`/`P2` and permits `P3`, but every direct test in `src/core/verdict.test.ts` constructed a **P2** finding. The boundary was unpinned in all four directions that matter.

## Change

One table-driven characterization test in `src/core/verdict.test.ts`. No production code touched.

| Case | Expected |
|---|---|
| P0 alone | `changes_requested` |
| P1 alone | `changes_requested` |
| P2 alone | `changes_requested` |
| P3 alone | `pass` |
| blocking residual, no findings | `needs_human` |
| blocking finding + blocking residual | `changes_requested` (findings win) |

## Verification

Per operating manual §8 ("the green suite that tests nothing"), the test was **mutation-verified** — every mutation must turn it red, otherwise it only restates the implementation:

| Mutation to `verdict.ts` | Result |
|---|---|
| baseline (unmutated) | `pass 4 / fail 0` |
| drop `P0` from `BLOCKING` | `pass 3 / fail 1` ✅ |
| drop `P1` from `BLOCKING` | `pass 3 / fail 1` ✅ |
| add `P3` to `BLOCKING` | `pass 3 / fail 1` ✅ |
| check residual **before** findings | `pass 3 / fail 1` ✅ |

In each case only the new test fails; the three pre-existing tests stay green — confirming they never covered these boundaries. `verdict.ts` was restored byte-clean afterwards (`git diff` empty).

Full suite: `pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **535 pass / 0 fail** (exit 0).

## Risk / not verified

- Test-only diff; no production behavior changes.
- Unrelated pre-existing flake observed once in the full suite (an `assert.throws` case, `actual: undefined`) that did not reproduce on re-run. Being tracked separately — it cannot be caused by a test-only addition in `verdict.test.ts`, but it is disclosed rather than buried.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, mutation testing, review)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI, headless `--prompt-file`)