### PR TITLE
fix(local): skip dangling untracked symlinks instead of aborting review

### DIFF
--- a/src/adapters/local-uncommitted.test.ts
+++ b/src/adapters/local-uncommitted.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -84,6 +92,41 @@ test("runLocal skips tracked binary files while reviewing uncommitted text chang
   assert.equal(prompts.includes("diff --git a/tracked image.bin"), false);
   assert.equal(prompts.includes("Binary files"), false);
   assert.equal(prompts.includes('"path": "tracked image.bin"'), false);
+});
+
+test("runLocal reviews untracked files when a dangling symlink is present", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-dangling-review-"));
+  const repo = initRepo(tmp);
+  const { promptPath } = installFakeClaude(t, tmp);
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  gitText(["branch", "-M", "main"], repo);
+  writeFileSync(join(repo, "keep.ts"), "export const keep = 1;\n");
+  symlinkSync("missing-target-does-not-exist", join(repo, "dangling.link"));
+
+  const result = await runLocal(repo, { cacheDir: join(tmp, "cache") });
+
+  assert.match(
+    result.reviewTarget ?? "",
+    /Skipped untracked files: dangling\.link \(not a regular file\)/
+  );
+  const prompts = readFileSync(promptPath, "utf8");
+  assert.match(prompts, /diff --git a\/keep\.ts b\/keep\.ts/);
+  assert.equal(prompts.includes("diff --git a/dangling.link"), false);
+});
+
+test("runLocal reports a skipped dangling symlink when no reviewable uncommitted patch remains", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-dangling-only-"));
+  const repo = initRepo(tmp);
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  gitText(["branch", "-M", "main"], repo);
+  symlinkSync("missing-target-does-not-exist", join(repo, "dangling.link"));
+
+  await assert.rejects(
+    () => runLocal(repo, { cacheDir: join(tmp, "cache") }),
+    /No uncommitted changes to review\. Skipped files: dangling\.link \(not a regular file\)\./
+  );
 });
 
 test("runLocal reports skipped tracked binary files when no reviewable uncommitted patch remains", async (t) => {
@@ -170,6 +213,76 @@ test("buildUntrackedPatch records subsequent total-cap overflows", (t) => {
   ]);
   assert.equal(result.patch.includes("cap-5.md"), false);
   assert.equal(result.patch.includes("cap-6.md"), false);
+});
+
+test("buildUntrackedPatch skips a dangling untracked symlink and still includes regular files", (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-dangling-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  writeFileSync(join(tmp, "keep.ts"), "export const keep = 1;\n");
+  symlinkSync("missing-target-does-not-exist", join(tmp, "dangling.link"));
+
+  const result = buildUntrackedPatch(tmp, ["keep.ts", "dangling.link"]);
+
+  assert.match(result.patch, /diff --git a\/keep\.ts b\/keep\.ts/);
+  assert.match(result.patch, /\+export const keep = 1;/);
+  assert.equal(result.patch.includes("dangling.link"), false);
+  assert.deepEqual(result.paths, ["keep.ts"]);
+  assert.deepEqual(result.skipped, ["dangling.link (not a regular file)"]);
+  assert.deepEqual(result.untrackedSkipped, []);
+});
+
+test("buildUntrackedPatch skips directories, FIFOs, and live symlinks as not regular files", (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-nonregular-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  writeFileSync(join(tmp, "keep.ts"), "export const keep = 1;\n");
+  mkdirSync(join(tmp, "subdir"));
+  symlinkSync("keep.ts", join(tmp, "live.link"));
+  const fifo = join(tmp, "pipe.fifo");
+  const made = spawnSync("mkfifo", [fifo], { encoding: "utf8" });
+  assert.equal(made.status, 0, made.stderr);
+
+  const result = buildUntrackedPatch(tmp, ["keep.ts", "subdir", "live.link", "pipe.fifo"]);
+
+  assert.match(result.patch, /diff --git a\/keep\.ts b\/keep\.ts/);
+  assert.equal(result.patch.includes("live.link"), false);
+  assert.deepEqual(result.paths, ["keep.ts"]);
+  assert.deepEqual(result.skipped, [
+    "subdir (not a regular file)",
+    "live.link (not a regular file)",
+    "pipe.fifo (not a regular file)",
+  ]);
+  assert.deepEqual(result.untrackedSkipped, []);
+});
+
+test("buildUntrackedPatch skips a file that disappears before it is read", (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-disappeared-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  writeFileSync(join(tmp, "before.ts"), "export const before = 1;\n");
+  writeFileSync(join(tmp, "gone.ts"), "export const gone = 1;\n");
+  writeFileSync(join(tmp, "after.ts"), "export const after = 1;\n");
+  rmSync(join(tmp, "gone.ts"));
+
+  const result = buildUntrackedPatch(tmp, ["before.ts", "gone.ts", "after.ts"]);
+
+  assert.match(result.patch, /diff --git a\/before\.ts b\/before\.ts/);
+  assert.match(result.patch, /diff --git a\/after\.ts b\/after\.ts/);
+  assert.equal(result.patch.includes("gone.ts"), false);
+  assert.deepEqual(result.paths, ["before.ts", "after.ts"]);
+  assert.deepEqual(result.skipped, ["gone.ts (not a regular file)"]);
+  assert.deepEqual(result.untrackedSkipped, []);
+});
+
+test("buildUntrackedPatch still throws unexpected I/O errors", (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-eacces-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+  if (typeof process.getuid === "function" && process.getuid() === 0) {
+    t.skip("root can read mode 000 files");
+    return;
+  }
+  writeFileSync(join(tmp, "secret.ts"), "export const secret = 1;\n");
+  chmodSync(join(tmp, "secret.ts"), 0);
+
+  assert.throws(() => buildUntrackedPatch(tmp, ["secret.ts"]), { code: "EACCES" });
 });
 
 test("runLocal reviews all nonignored files on unborn HEAD", async (t) => {

--- a/src/adapters/local-uncommitted.ts
+++ b/src/adapters/local-uncommitted.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync, statSync } from "node:fs";
+import { lstatSync, readFileSync, type Stats } from "node:fs";
 import path from "node:path";
 import type { UntrackedSkippedFile } from "../shared/schema.js";
 
@@ -110,6 +110,11 @@ function statLine(filePath: string, insertions: number): string {
   return ` ${filePath} | ${insertions} ${pluses}`;
 }
 
+/** ENOENT only (dangling/missing). EACCES and other I/O errors stay fail-closed. */
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
 export function buildUntrackedPatch(cwd: string, files: readonly string[]): UntrackedPatch {
   const patches: string[] = [];
   const statLines: string[] = [];
@@ -120,8 +125,14 @@ export function buildUntrackedPatch(cwd: string, files: readonly string[]): Untr
 
   for (const file of files) {
     const absolutePath = path.join(cwd, file);
-    const stat = statSync(absolutePath);
-    if (!stat.isFile()) {
+    // lstat does not follow; a dangling symlink must not abort the whole review.
+    let stat: Stats | undefined;
+    try {
+      stat = lstatSync(absolutePath);
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+    }
+    if (stat === undefined || !stat.isFile()) {
       skipped.push(`${file} (not a regular file)`);
       continue;
     }
@@ -130,7 +141,14 @@ export function buildUntrackedPatch(cwd: string, files: readonly string[]): Untr
       untrackedSkipped.push({ path: file, bytes: stat.size, reason: "per_file_cap" });
       continue;
     }
-    const content = readFileSync(absolutePath);
+    let content: Buffer;
+    try {
+      content = readFileSync(absolutePath);
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+      skipped.push(`${file} (not a regular file)`);
+      continue;
+    }
     if (content.byteLength === 0) {
       skipped.push(`${file} (empty)`);
       continue;


### PR DESCRIPTION
Closes #56.

## Problem

`buildUntrackedPatch` called `statSync` before deciding whether an untracked path was a regular file. `statSync` **follows symlinks**, so one dangling untracked symlink threw `ENOENT` and aborted the whole default local review before any model call. `git ls-files --others --exclude-standard` lists dangling symlinks, so this is reachable in ordinary use — not a contrived input.

## Change

`src/adapters/local-uncommitted.ts` — switch to `lstatSync` (does not follow the target) and downgrade **only `ENOENT`** to a skip, at both the stat and the subsequent read:

```ts
/** ENOENT only (dangling/missing). EACCES and other I/O errors stay fail-closed. */
function isMissingPathError(error: unknown): boolean {
  return error instanceof Error && "code" in error && error.code === "ENOENT";
}
```

Every other errno still propagates. The existing skip reasons (over 200KB, empty, binary, total cap) and their `untrackedSkipped` entries are untouched.

**Intended side effect:** live symlinks now also skip as `(not a regular file)` instead of silently contributing their *target's* bytes as though the link were a regular file. This is what issue #56 asks for ("Directories, FIFOs/devices, and symlinks are skipped deterministically"), and it is the more correct semantic — git stores a symlink as a link, not as its target's contents.

## Verification

**The bug is real, demonstrated on a real dangling symlink** (temp repo, `ln -s /nonexistent/target dangling.link`):

| Implementation | Result on the same input |
|---|---|
| old `statSync` path | throws `ENOENT` ← the bug |
| new `lstatSync` path | `paths=['real.txt'] skipped=['dangling.link (not a regular file)']` |

**Mutation-verified** — the tests must go red when the fix is undone, or they prove nothing:

| Mutation | Result |
|---|---|
| baseline (fixed) | `pass 17 / fail 0` |
| remove the ENOENT guard | `pass 16 / fail 1` ✅ |
| revert `lstat` → `stat` | `pass 16 / fail 1` ✅ |
| restored | `pass 17 / fail 0` |

Full suite: `pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **540 pass / 0 fail** (exit 0).

Tests added exercise a real dangling symlink on disk (not a mock), plus directories/FIFOs/live symlinks, a file disappearing mid-collection, and an unexpected-I/O case that must still throw.

## Risk / not verified

- Behavior change for **live** symlinks (now skipped) is deliberate and specified by the issue, but it is a change: a user who relied on an untracked symlink's target being reviewed will now see it listed under skipped files instead.
- The disappeared-file case reuses the `(not a regular file)` message rather than a distinct "disappeared" one — consistent with the issue's "reported consistently" criterion, but the wording is approximate for that case.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, mutation testing, review)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI, headless `--prompt-file`)