### PR TITLE
fix(runner): parse the intended JSON response fence

### DIFF
--- a/src/shared/codex.test.ts
+++ b/src/shared/codex.test.ts
@@ -20,6 +20,97 @@ test("extractJson rejects output without a JSON object", () => {
   assert.throws(() => extractJson(text), /no JSON object found/);
 });
 
+test("extractJson parses an untagged fence", () => {
+  const text = "preface\n```\n{\"ok\":true}\n```\ntrailer";
+
+  const parsed = extractJson(text);
+
+  assert.deepEqual(parsed, { ok: true });
+});
+
+test("extractJson prefers a later json fence over a leading code fence", () => {
+  const text = [
+    "```ts",
+    '{"severity":"critical","wrong":true}',
+    "```",
+    "```json",
+    '{"ok":true}',
+    "```",
+  ].join("\n");
+
+  const parsed = extractJson(text);
+
+  assert.deepEqual(parsed, { ok: true });
+});
+
+test("extractJson rejects multiple json fences", () => {
+  const text = [
+    "```json",
+    '{"first":1}',
+    "```",
+    "```json",
+    '{"second":2}',
+    "```",
+  ].join("\n");
+
+  assert.throws(() => extractJson(text), /ambiguous JSON fences/);
+});
+
+test("extractJson rejects invalid JSON", () => {
+  const text = "```json\n{ok:true}\n```";
+
+  assert.throws(() => extractJson(text), /invalid JSON in codex output/);
+});
+
+test("extractJson parses a raw JSON document", () => {
+  const parsed = extractJson('{"ok":true}');
+
+  assert.deepEqual(parsed, { ok: true });
+});
+
+test("extractJson parses a raw JSON document that mentions json fences", () => {
+  const parsed = extractJson('{"note":"```json\\n{\\"ok\\":true}\\n```"}');
+
+  assert.deepEqual(parsed, { note: "```json\n{\"ok\":true}\n```" });
+});
+
+test("extractJson parses a single-line tagged json fence", () => {
+  const parsed = extractJson('```json {"summary":"ok"}```');
+
+  assert.deepEqual(parsed, { summary: "ok" });
+});
+
+test("extractJson parses a single-line untagged fence", () => {
+  const parsed = extractJson('```{"summary":"ok"}```');
+
+  assert.deepEqual(parsed, { summary: "ok" });
+});
+
+test("extractJson treats a single-line brace body as untagged not a language tag", () => {
+  const parsed = extractJson('```{"a":1}```');
+
+  assert.deepEqual(parsed, { a: 1 });
+});
+
+test("extractJson rejects a single tagged non-JSON fence", () => {
+  const text = "```ts\n{\"wrong\":true}\n```";
+
+  assert.throws(() => extractJson(text), /no JSON object found/);
+});
+
+test("extractJson rejects multiple untagged fences", () => {
+  const text = "```\n{\"a\":1}\n```\n```\n{\"b\":2}\n```";
+
+  assert.throws(() => extractJson(text), /ambiguous fenced output/);
+});
+
+test("extractJson rejects unfenced output that is not a single JSON document", () => {
+  assert.throws(
+    () => extractJson('{"ok":true} trailer'),
+    /invalid JSON in codex output/,
+  );
+});
+
 test("runCodex invokes Codex without approval or sandbox restrictions", async (t) => {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
   const repo = initRepo(tmp);

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -600,9 +600,7 @@ async function runCodexOnce(
 	}
 }
 
-export function extractJson(text: string): unknown {
-	const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
-	const raw = fence ? fence[1] : text;
+function parseJsonObject(raw: string): unknown {
 	const start = raw.indexOf("{");
 	const end = raw.lastIndexOf("}");
 	if (start === -1 || end === -1 || end <= start) {
@@ -618,6 +616,56 @@ export function extractJson(text: string): unknown {
 		}
 		throw error;
 	}
+}
+
+// Prompt contract: exactly one ```json fence. Prefer that tag so a leading
+// non-JSON fence cannot win; reject multiple JSON fences instead of guessing.
+// A fence-free response is admitted only when the whole text is one JSON object.
+// Same-line fences are valid; the tag is a language identifier, not `{...}`.
+export function extractJson(text: string): unknown {
+	const trimmed = text.trim();
+	let documentError: SyntaxError | undefined;
+	if (trimmed.startsWith("{")) {
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (isRecord(parsed)) return parsed;
+		} catch (error) {
+			if (!(error instanceof SyntaxError)) throw error;
+			documentError = error;
+		}
+	}
+
+	const fences: { tag: string; body: string }[] = [];
+	const fencePattern =
+		/```[ \t]*(?:([A-Za-z][\w+#.-]*)[ \t]*)?(?:\r?\n)?([\s\S]*?)```/g;
+	for (const match of text.matchAll(fencePattern)) {
+		const tag = (match[1] ?? "").toLowerCase();
+		fences.push({ tag, body: match[2] ?? "" });
+	}
+
+	const jsonFences = fences.filter((fence) => fence.tag === "json");
+	if (jsonFences.length > 1) {
+		throw new Error("ambiguous JSON fences in codex output");
+	}
+	if (jsonFences.length === 1) {
+		return parseJsonObject(jsonFences[0].body);
+	}
+
+	if (fences.length > 1) {
+		throw new Error("ambiguous fenced output in codex output");
+	}
+	if (fences.length === 1) {
+		const fence = fences[0];
+		if (fence.tag === "") return parseJsonObject(fence.body);
+		throw new Error("no JSON object found in codex output");
+	}
+
+	if (documentError) {
+		throw new Error(`invalid JSON in codex output: ${documentError.message}`, {
+			cause: documentError,
+		});
+	}
+	throw new Error("no JSON object found in codex output");
 }
 
 function resolveModel(


### PR DESCRIPTION
Closes #54.

## Problem

`extractJson` used `/```(?:json)?\s*([\s\S]*?)```/i`. The `json` tag is **optional**, so the pattern matched the **first fence of any language**. A response with a leading ` ```ts ` fence containing braces, and the real answer in a later ` ```json ` fence, silently parsed the wrong object — which then fed `normalizeReview` and `deriveVerdict`. This is a verdict-integrity hole, not a cosmetic parse bug.

## Change

`src/shared/codex.ts`, `extractJson` only:

- prefer the single explicitly-tagged ` ```json ` fence
- parse unfenced output **only** when the whole trimmed text is one JSON object
- reject multiple json fences — and multiple untagged fences — as ambiguous rather than guessing
- rejection throws, which is exactly what the existing retry path (`src/core/review.ts:295`) consumes; no new error channel

Single-line fences (` ```json {...}``` `, ` ```{...}``` `) are recognized as one fence. A tag must be a language identifier (`[A-Za-z][\w+#.-]*`), so ` ```{"a":1}``` ` is untagged with body `{"a":1}` rather than a fence tagged `{"a":1}`.

## Verification

Full behavior matrix, executed against the built code (not asserted from reading it):

| Input shape | Expected | Result |
|---|---|---|
| **leading ```ts + later ```json** (the bug) | parse the json one | ✅ `{"s":"real"}` |
| single ```json fence | parse | ✅ |
| single untagged fence | parse | ✅ |
| raw JSON document | parse | ✅ |
| prose around a ```json fence | parse | ✅ |
| single-line ```json {…}``` | parse | ✅ |
| single-line ```{…}``` | parse | ✅ |
| multiple ```json fences | reject | ✅ `ambiguous JSON fences in codex output` |
| multiple untagged fences | reject | ✅ `ambiguous fenced output in codex output` |
| only a ```ts fence | reject | ✅ `no JSON object found in codex output` |
| prose + unfenced JSON | reject | ✅ (see risk below) |
| invalid JSON inside a json fence | reject | ✅ `invalid JSON in codex output: …` |

**Mutation-verified:** restoring the old fence regex turns **6** of the new tests red; restoring the fix returns them to green.

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **546 pass / 0 fail** (exit 0).

## Risk / disclosed

**Deliberate tightening beyond the reported bug:** unfenced JSON *surrounded by prose* (`Here is my review:\n{...}`) was previously accepted via `indexOf("{")`/`lastIndexOf("}")` and is now rejected. The prompt contract asks for exactly one json block, so that shape was always a contract violation, and failing closed sends it to retry rather than guessing which braces were the answer — but it **is** a behavior change, and a runner that habitually emits that shape would now burn retries. The common real shape (prose *around* a properly tagged json fence) was explicitly tested and still parses.

Not verified: no live model run was performed against a real runner; the matrix above is synthetic input to the real function.

Also noted while verifying — unrelated to this diff: `runCodex kills a runner that ignores SIGTERM on timeout` asserts a `< 5000ms` wall-clock bound and fails when invoked without `NEEDLEFISH_RUNNER_TIMEOUT_GRACE_MS=100`, which `scripts/test.mjs` sets. Under `pnpm test` it passes; it is load-sensitive.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, behavior-matrix and mutation testing, review; caught and sent back a single-line-fence regression in the first implementation)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI, headless `--prompt-file`, one corrective round)