### PR TITLE
fix(eval): match fixture anchor paths on component boundaries

### DIFF
--- a/eval/shared/score.test.ts
+++ b/eval/shared/score.test.ts
@@ -1,0 +1,299 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Finding, Verdict } from "../../src/shared/schema";
+import {
+	fileMatchesAnchor,
+	matchEvidence,
+	matchesSpec,
+	score,
+} from "./score";
+import type { Expected } from "./types";
+
+function finding(
+	partial: Partial<Finding> &
+		Pick<Finding, "title" | "whyItBreaks" | "file" | "lineStart">,
+): Finding {
+	return {
+		severity: "P2",
+		category: "bug",
+		lineEnd: partial.lineStart,
+		confidence: 0.8,
+		suggestedFix: "",
+		validation: "",
+		...partial,
+	};
+}
+
+test("fileMatchesAnchor: shorthand, exact, and character-suffix collision", () => {
+	assert.equal(fileMatchesAnchor("src/cache.ts", "cache.ts"), true);
+	assert.equal(fileMatchesAnchor("src/notcache.ts", "cache.ts"), false);
+	assert.equal(fileMatchesAnchor("cache.ts", "cache.ts"), true);
+	assert.equal(fileMatchesAnchor("src/cache.ts", "src/cache.ts"), true);
+	assert.equal(fileMatchesAnchor("src/cache.ts", "notcache.ts"), false);
+	assert.equal(fileMatchesAnchor("", "cache.ts"), false);
+	assert.equal(fileMatchesAnchor("src/cache.ts", ""), false);
+	// POSIX-only: backslash is an ordinary character, not a separator.
+	assert.equal(fileMatchesAnchor("src\\cache.ts", "cache.ts"), false);
+});
+
+test("fileMatchesAnchor: nested packages match at a component boundary, not a character suffix", () => {
+	// Uniform rule: a shorter anchor matches any finding whose remaining
+	// suffix is the anchor after a slash. `other/pkg/a/src/cache.ts` therefore
+	// matches `pkg/a/src/cache.ts`. Exact-only matching for multi-component
+	// anchors is not implemented.
+	assert.equal(
+		fileMatchesAnchor("other/pkg/a/src/cache.ts", "pkg/a/src/cache.ts"),
+		true,
+	);
+	assert.equal(
+		fileMatchesAnchor("pkg/a/src/cache.ts", "pkg/a/src/cache.ts"),
+		true,
+	);
+	assert.equal(
+		fileMatchesAnchor("xother/pkg/a/src/cache.ts", "other/pkg/a/src/cache.ts"),
+		false,
+	);
+	assert.equal(fileMatchesAnchor("foosrc/cache.ts", "src/cache.ts"), false);
+});
+
+test("matchesSpec: per-spec file uses component-boundary matching", () => {
+	const hit = finding({
+		title: "ttl inverted",
+		whyItBreaks: "cache returns expired entries",
+		file: "src/cache.ts",
+		lineStart: 12,
+	});
+	const collision = finding({
+		title: "ttl inverted",
+		whyItBreaks: "cache returns expired entries",
+		file: "src/notcache.ts",
+		lineStart: 12,
+	});
+	assert.equal(matchesSpec(hit, { pattern: "ttl", file: "cache.ts" }), true);
+	assert.equal(matchesSpec(hit, { pattern: "ttl", file: "src/cache.ts" }), true);
+	assert.equal(
+		matchesSpec(collision, { pattern: "ttl", file: "cache.ts" }),
+		false,
+	);
+});
+
+test("score: character-suffix collision does not grant recall", () => {
+	const expected: Expected = {
+		verdict: "changes_requested",
+		mustFind: [{ pattern: "ttl", file: "cache.ts" }],
+	};
+	const collision = {
+		verdict: "changes_requested" as Verdict,
+		findings: [
+			finding({
+				title: "ttl inverted",
+				whyItBreaks: "expired entries served",
+				file: "src/notcache.ts",
+				lineStart: 12,
+			}),
+		],
+	};
+	const hit = {
+		verdict: "changes_requested" as Verdict,
+		findings: [
+			finding({
+				title: "ttl inverted",
+				whyItBreaks: "expired entries served",
+				file: "src/cache.ts",
+				lineStart: 12,
+			}),
+		],
+	};
+	assert.equal(score(collision, expected, "recall-collision").recall, false);
+	assert.equal(score(hit, expected, "recall-hit").recall, true);
+});
+
+test("score: lineAnchorValid uses the same path semantics", () => {
+	const withMustFind: Expected = {
+		verdict: "changes_requested",
+		mustFind: [{ pattern: "ttl" }],
+		anchorFile: "cache.ts",
+		anchorLineRange: [10, 14],
+	};
+	const collisionMust = {
+		verdict: "changes_requested" as Verdict,
+		findings: [
+			finding({
+				title: "ttl inverted",
+				whyItBreaks: "expired",
+				file: "src/notcache.ts",
+				lineStart: 12,
+			}),
+		],
+	};
+	const hitMust = {
+		verdict: "changes_requested" as Verdict,
+		findings: [
+			finding({
+				title: "ttl inverted",
+				whyItBreaks: "expired",
+				file: "src/cache.ts",
+				lineStart: 12,
+			}),
+		],
+	};
+	assert.equal(
+		score(collisionMust, withMustFind, "anchor-must-collision").lineAnchorValid,
+		false,
+	);
+	assert.equal(
+		score(hitMust, withMustFind, "anchor-must-hit").lineAnchorValid,
+		true,
+	);
+
+	// Negatives with an anchor and no mustFind: any-finding check, same rule.
+	const noMustFind: Expected = {
+		verdict: "pass",
+		noBlockingFindings: true,
+		anchorFile: "cache.ts",
+	};
+	const collisionNeg = {
+		verdict: "pass" as Verdict,
+		findings: [
+			finding({
+				title: "nit",
+				whyItBreaks: "style",
+				file: "src/notcache.ts",
+				lineStart: 1,
+				severity: "P3",
+			}),
+		],
+	};
+	const hitNeg = {
+		verdict: "pass" as Verdict,
+		findings: [
+			finding({
+				title: "nit",
+				whyItBreaks: "style",
+				file: "src/cache.ts",
+				lineStart: 1,
+				severity: "P3",
+			}),
+		],
+	};
+	assert.equal(
+		score(collisionNeg, noMustFind, "anchor-neg-collision").lineAnchorValid,
+		false,
+	);
+	assert.equal(score(hitNeg, noMustFind, "anchor-neg-hit").lineAnchorValid, true);
+});
+
+test("score: mayFind uses the same path semantics", () => {
+	const expected: Expected = {
+		verdict: "changes_requested",
+		mustFind: [{ pattern: "viewer", file: "handler.ts" }],
+		mayFind: [{ pattern: "buffer", file: "cache.ts" }],
+	};
+	const siblingCollision = finding({
+		title: "buffer cap removed",
+		whyItBreaks: "large diff aborts",
+		file: "src/notcache.ts",
+		lineStart: 3,
+		severity: "P1",
+	});
+	const siblingHit = finding({
+		title: "buffer cap removed",
+		whyItBreaks: "large diff aborts",
+		file: "src/cache.ts",
+		lineStart: 3,
+		severity: "P1",
+	});
+	const mustHit = finding({
+		title: "viewer branch unreachable",
+		whyItBreaks: "blocked",
+		file: "src/handler.ts",
+		lineStart: 18,
+	});
+
+	const miss = score(
+		{ verdict: "changes_requested", findings: [siblingCollision, mustHit] },
+		expected,
+		"mayfind-collision",
+	);
+	assert.equal(miss.recall, true);
+	assert.equal(
+		miss.noiseFindingCount,
+		1,
+		"character-suffix sibling is still noise",
+	);
+
+	const exempt = score(
+		{ verdict: "changes_requested", findings: [siblingHit, mustHit] },
+		expected,
+		"mayfind-hit",
+	);
+	assert.equal(exempt.recall, true);
+	assert.equal(exempt.noiseFindingCount, 0);
+});
+
+test("score: mustNotFind / false-positive matching uses the same path semantics", () => {
+	const expected: Expected = {
+		verdict: "pass",
+		mustNotFind: [{ pattern: "secret", file: "cache.ts" }],
+	};
+	const collision = {
+		verdict: "changes_requested" as Verdict,
+		findings: [
+			finding({
+				title: "secret leaked",
+				whyItBreaks: "token in source",
+				file: "src/notcache.ts",
+				lineStart: 4,
+			}),
+		],
+	};
+	const hit = {
+		verdict: "changes_requested" as Verdict,
+		findings: [
+			finding({
+				title: "secret leaked",
+				whyItBreaks: "token in source",
+				file: "src/cache.ts",
+				lineStart: 4,
+			}),
+		],
+	};
+	assert.equal(
+		score(collision, expected, "fp-collision").falsePositive,
+		false,
+		"wrong-file mustNotFind hit is not that spec",
+	);
+	assert.equal(score(hit, expected, "fp-hit").falsePositive, true);
+});
+
+test("matchEvidence: uses the same path semantics", () => {
+	const expected: Expected = {
+		verdict: "changes_requested",
+		anchorFile: "cache.ts",
+		mustFind: [{ pattern: "ttl" }, { pattern: "queue", file: "queue.ts" }],
+	};
+	const collision = [
+		finding({
+			title: "ttl inverted",
+			whyItBreaks: "expired",
+			file: "src/notcache.ts",
+			lineStart: 12,
+		}),
+	];
+	const hit = [
+		finding({
+			title: "ttl inverted",
+			whyItBreaks: "expired",
+			file: "src/cache.ts",
+			lineStart: 12,
+		}),
+	];
+	assert.deepEqual(matchEvidence(collision, expected), [
+		{ pattern: "ttl", file: "cache.ts", findingIndex: null },
+		{ pattern: "queue", file: "queue.ts", findingIndex: null },
+	]);
+	assert.deepEqual(matchEvidence(hit, expected), [
+		{ pattern: "ttl", file: "cache.ts", findingIndex: 0 },
+		{ pattern: "queue", file: "queue.ts", findingIndex: null },
+	]);
+});

--- a/eval/shared/score.ts
+++ b/eval/shared/score.ts
@@ -13,12 +13,19 @@ import type {
 
 const BLOCKING: Severity[] = ["P0", "P1", "P2"];
 
+// Fixture anchors match a finding path when they are identical or when the
+// finding path ends with "/" + anchor. Character suffixes (`notcache.ts`
+// vs `cache.ts`) must not count: that would grant recall on the wrong file.
+export function fileMatchesAnchor(file: string, anchor: string): boolean {
+	return anchor.length > 0 && (file === anchor || file.endsWith(`/${anchor}`));
+}
+
 export function matchesSpec(
 	finding: FindingMatchFields,
 	spec: MatchSpec,
 ): boolean {
 	if (spec.category && finding.category !== spec.category) return false;
-	if (spec.file && !finding.file.endsWith(spec.file)) return false;
+	if (spec.file && !fileMatchesAnchor(finding.file, spec.file)) return false;
 	if (
 		spec.lineRange &&
 		(finding.lineStart < spec.lineRange[0] ||
@@ -115,7 +122,7 @@ function lineAnchorValid(
 	if (mustFind.length === 0) {
 		// No mustFind (negatives with an anchor): keep the old any-finding check.
 		return findings.some((f) => {
-			if (!f.file.endsWith(expected.anchorFile!)) return false;
+			if (!fileMatchesAnchor(f.file, expected.anchorFile!)) return false;
 			if (!range) return true;
 			return f.lineStart >= range[0] && f.lineStart <= range[1];
 		});

--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -153,10 +153,16 @@ function isDrawFinding(finding) {
     && typeof finding.whyItBreaks === "string";
 }
 
+// Deliberate duplicate of fileMatchesAnchor in eval/shared/score.ts (source of
+// truth). This file must not import TypeScript; keep the two in sync.
+function fileMatchesAnchor(file, anchor) {
+  return anchor.length > 0 && (file === anchor || file.endsWith(`/${anchor}`));
+}
+
 function evidenceMatches(entry, finding) {
   if (!isDrawFinding(finding)) return false;
   if (entry.category && finding.category !== entry.category) return false;
-  if (entry.file && !finding.file.endsWith(entry.file)) return false;
+  if (entry.file && !fileMatchesAnchor(finding.file, entry.file)) return false;
   if (entry.lineRange
     && (finding.lineStart < entry.lineRange[0] || finding.lineStart > entry.lineRange[1])) return false;
   return new RegExp(entry.pattern, "i").test(`${finding.title} ${finding.whyItBreaks}`);

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -389,6 +389,50 @@ test("re-executes evidence and rejects a fabricated recall claim", () => {
   ]);
 });
 
+function ttlFinding(file) {
+  return {
+    severity: "P1",
+    category: "bug",
+    file,
+    lineStart: 12,
+    lineEnd: 12,
+    title: "ttl inverted",
+    whyItBreaks: "expired entries served",
+  };
+}
+
+function reportWithEvidence(file, specFile) {
+  const report = baseReport();
+  Object.assign(report.results[0], {
+    findings: [ttlFinding(file)],
+    matchEvidence: [{ pattern: "ttl", file: specFile, findingIndex: 0 }],
+  });
+  report.results[0].score.mustFindHits = 1;
+  report.results[0].score.mustFindTotal = 1;
+  return report;
+}
+
+test("evidence matching accepts an exact file path", () => {
+  const result = run(reportWithEvidence("src/cache.ts", "src/cache.ts"), baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("evidence matching accepts a component-boundary shorthand", () => {
+  const result = run(reportWithEvidence("src/cache.ts", "cache.ts"), baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("evidence matching rejects a character-suffix collision", () => {
+  const result = run(reportWithEvidence("src/notcache.ts", "cache.ts"), baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, [
+    "unexplainable-evidence:obvious-bug",
+    "recall-without-evidence:obvious-bug",
+  ]);
+});
+
 test("missing evidence fails closed", () => {
   const report = baseReport();
   delete report.results[0].findings;


### PR DESCRIPTION
Closes #55.

## Problem

`matchesSpec` and `lineAnchorValid` compared finding paths to fixture anchors with raw `endsWith`. Fixture anchors intentionally use a **shorthand** (`cache.ts` for `src/cache.ts`), but `endsWith` matches on *character* suffixes, so a finding on `src/notcache.ts` also satisfied the anchor `cache.ts`.

Recall is what `scripts/gate-verdict.mjs` reads to authorize shipping prompt/pipeline changes, so a collision here inflates the number that gates releases.

## Change

One helper, `fileMatchesAnchor(file, anchor)` — identical path, or a suffix beginning at a `/` boundary. Recall, evidence, line-anchor, `mayFind`, and false-positive matching all route through it.

`scripts/gate-verdict.mjs`'s `evidenceMatches` had the same raw `endsWith` and is aligned too — the acceptance criteria name evidence matching, and leaving the gate looser than the scorer keeps two divergent notions of "same file" inside one pipeline. That file cannot import TypeScript, so the rule is duplicated there with a comment naming `score.ts` as the source of truth.

## ⚠️ This invalidates every recorded baseline

**Measured, not inferred:**

| | `computeScorerHash()` |
|---|---|
| `main` | `a424d3bb59a40443` |
| newest recorded report (`eval/results/weekly/2026-08-09.json`) | `a424d3bb59a40443` ← matches main |
| this branch | `bd85218ae8ae948f` |

So every report under `eval/results/` and `eval/baselines/` will now fail the gate with `scorer-hash-mismatch`, and `--resume` / `--compare` will refuse them, **until a maintainer re-runs the full fixture set**.

This is the correct direction — a report scored by the buggy matcher is not comparable to one scored correctly — but it is a required operational follow-up, not a free change. `promptHash` (covers `prompts/{review,deep,critic,map}.md`) and `fixtureSetHash` are unaffected.

## Verification

Semantics, executed against the real helper:

| finding path | anchor | result | |
|---|---|---|---|
| `src/cache.ts` | `cache.ts` | ✅ true | shorthand preserved |
| `src/notcache.ts` | `cache.ts` | ✅ false | **the bug** |
| `cache.ts` | `cache.ts` | ✅ true | exact, no directory |
| `a/b/cache.ts` | `b/cache.ts` | ✅ true | multi-component boundary |
| `xother/pkg/cache.ts` | `other/pkg/cache.ts` | ✅ false | character suffix rejected |
| `src/cache.tsx` | `cache.ts` | ✅ false | extension suffix rejected |
| `src/cache.ts` | `""` | ✅ false | empty anchor never matches |

**Fixture regression scan:** all 84 specs under `eval/fixtures/` and `eval/fixtures-real/` (63 anchor values) compared old vs new semantics — **0 collisions**, no fixture edited. The only slash-free anchor is `Dockerfile`, which is an exact file key.

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 55 / fail 0` |
| scorer helper → raw `endsWith` | `pass 47 / fail 8` ✅ |
| gate helper → raw `endsWith` | `pass 54 / fail 1` ✅ |
| restored | `pass 55 / fail 0` |

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **545 pass / 0 fail** (exit 0).

## Deliberately not done

The optional "reject finding paths absent from the fixture's materialized file set" idea: `score()` never receives the fixture's file set, and threading it through `run.ts`, robustness, and every caller is far larger than this bug warrants. Left out, flagged rather than silently skipped.

## Merge note

Touches `scripts/gate-verdict.mjs`, as does the pending #45 work — different functions, but expect a possible textual conflict.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, scorerHash impact measurement, mutation testing, scope authorization)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI; correctly stopped at the two-file scope and asked before widening to the gate — widening was then authorized)