### PR TITLE
fix(eval): checkpoint every completed draw, not only under --resume

### DIFF
--- a/eval/run.checkpoint.test.ts
+++ b/eval/run.checkpoint.test.ts
@@ -330,6 +330,90 @@ test("resumeSlots: reuses already-checkpointed draws from a partially-completed 
 	);
 });
 
+// A positional `good[draw]` lookup relabels results: if draw 0 failed
+// format and draw 1 succeeded, the one entry in `good` (draw 1's own
+// result) sits at position 0 and would be mislabeled as draw 0, backfilling
+// the failed draw with a stranger's result while the untouched draw 1 slot
+// gets needlessly rescheduled. Reuse must be keyed by each draw's own
+// recorded draw number.
+test("resumeSlots: reuses a draw only under its own recorded draw number, never a stranger's", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(
+		path.join(tmpdir(), "needlefish-checkpoint-draw-index-"),
+	);
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const spec = checkpointSpec("checkpoint-draw-index");
+	const specs = [spec];
+	const writeArgs = parseArgs(["--draws", "2", "--report", reportPath]);
+	const failedDraw0 = makeDraw(spec, 0);
+	const goodDraw1 = makeDraw(spec, 1);
+	const invalidDraw0 = {
+		...failedDraw0,
+		score: { ...failedDraw0.score, formatOk: false },
+	};
+	writeReport(writeArgs, [invalidDraw0, goodDraw1], specs);
+
+	const resumeArgs = parseArgs([
+		"--draws",
+		"2",
+		"--report",
+		reportPath,
+		"--resume",
+		reportPath,
+	]);
+	const work = [
+		{ spec, draw: 0 },
+		{ spec, draw: 1 },
+	];
+	const resumed = resumeSlots(resumeArgs, specs, work);
+
+	assert.equal(
+		resumed.slots[0],
+		null,
+		"draw 0's own result was invalid and must be rerun under its own index, not backfilled from draw 1",
+	);
+	assert.notEqual(
+		resumed.slots[1],
+		null,
+		"draw 1's own good result must be reused under its own index",
+	);
+	assert.equal(resumed.slots[1]?.draw, 1);
+
+	// Gate-integrity check: a resumed run must not understate the invalid
+	// rate versus an uninterrupted run of the exact same two attempts. A
+	// non-resumed run of [invalid draw 0, good draw 1] would report
+	// invalidJsonRate 0.5; if resume silently drops the invalid draw (by
+	// mislabeling a good draw over it and never truly retrying slot 0), the
+	// gate would see a better number than reality.
+	const baselineReport = writeReport(
+		parseArgs(["--draws", "2", "--report", path.join(dir, "baseline.json")]),
+		[invalidDraw0, goodDraw1],
+		specs,
+	);
+	assert.equal(baselineReport.aggregates.invalidJsonRate, 0.5);
+
+	// The resumed process retries slot 0 (the invalid draw) and, in this
+	// scenario, reproduces the same failure again.
+	const rerunDraw0 = {
+		...makeDraw(spec, 0),
+		score: { ...makeDraw(spec, 0).score, formatOk: false },
+	};
+	const finalResults = [rerunDraw0, resumed.slots[1]!];
+	const finalReport = writeReport(resumeArgs, finalResults, specs);
+
+	assert.equal(
+		finalReport.results.length,
+		2,
+		"every draw must be accounted for in the final report",
+	);
+	assert.equal(
+		finalReport.aggregates.invalidJsonRate,
+		baselineReport.aggregates.invalidJsonRate,
+		"resume must not understate the invalid-draw rate relative to an uninterrupted run",
+	);
+});
+
 test("checkpoint: an interrupted fresh run leaves a partial report a later process --resume continues", (t) => {
 	withGuardEnv(t);
 	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-resume-"));

--- a/eval/run.checkpoint.test.ts
+++ b/eval/run.checkpoint.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import {
+	copyFileSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
@@ -148,6 +149,80 @@ test("writeReport: a later smaller checkpoint does not overwrite a larger one", 
 		[0, 1, 2, 3],
 	);
 	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+// lastCheckpointCounts is a process-local high-water mark, empty at process
+// start. Without seeding it from whatever is already on disk, a FRESH run
+// (no --resume) that reuses a --report path already holding a complete
+// report from a prior process would have its own first partial checkpoint
+// (as small as one draw) pass the guard trivially and destroy that report —
+// and a crash before the new run finishes would leave only a partial file
+// behind, with the previously-good report unrecoverably gone. This
+// simulates the prior process by writing the "existing" complete report via
+// copyFileSync (not writeReport), so this test's own lastCheckpointCounts
+// has no entry for reportPath when the "fresh run" begins.
+test("writeReport: a fresh run's interrupted partial checkpoint does not destroy a complete report already on disk", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(
+		path.join(tmpdir(), "needlefish-checkpoint-preserve-existing-"),
+	);
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const stagingPath = path.join(dir, "staging.json");
+
+	// A prior process's complete report: 2 fixtures x 2 draws = 4 results.
+	const specA = checkpointSpec("checkpoint-preserve-existing-a");
+	const specB = checkpointSpec("checkpoint-preserve-existing-b");
+	const priorSpecs = [specA, specB];
+	const priorResults = [
+		makeDraw(specA, 0),
+		makeDraw(specA, 1),
+		makeDraw(specB, 0),
+		makeDraw(specB, 1),
+	];
+	const priorArgs = parseArgs(["--draws", "2", "--report", stagingPath]);
+	const priorReport = writeReport(priorArgs, priorResults, priorSpecs);
+	assert.equal(isCompleteReport(priorReport, priorSpecs.map((s) => s.id)), true);
+	copyFileSync(stagingPath, reportPath);
+
+	// A fresh, unrelated, non-resumed run targets the same --report path
+	// with a smaller, different fixture set. Only its first draw completes
+	// before the process is "interrupted" (simulated by simply not issuing
+	// any further writeReport call).
+	const specC = checkpointSpec("checkpoint-preserve-existing-c");
+	const freshSpecs = [specC];
+	const freshArgs = parseArgs(["--draws", "2", "--report", reportPath]);
+	writeReport(freshArgs, [makeDraw(specC, 0)], freshSpecs);
+
+	const afterPartial = readReport(reportPath);
+	assert.equal(
+		afterPartial.results.length,
+		4,
+		"an interrupted fresh run's partial checkpoint must not destroy the complete report already on disk",
+	);
+	assert.equal(isCompleteReport(afterPartial, priorSpecs.map((s) => s.id)), true);
+
+	// The fresh run continues and reaches its OWN completion (2 draws for
+	// its 1 fixture = 2 results) — smaller than the old report's 4, but
+	// structurally complete on its own terms. A legitimate finished rerun
+	// must still be able to replace an old complete report; the guard must
+	// not make --report unusable for an intentional smaller rerun.
+	const finalReport = writeReport(
+		freshArgs,
+		[makeDraw(specC, 0), makeDraw(specC, 1)],
+		freshSpecs,
+	);
+	assert.equal(isCompleteReport(finalReport, freshSpecs.map((s) => s.id)), true);
+	const afterFinal = readReport(reportPath);
+	assert.equal(
+		afterFinal.results.length,
+		2,
+		"a legitimately completed fresh run must still be able to replace an old complete report",
+	);
+	assert.deepEqual(
+		afterFinal.results.map((r) => r.fixtureId),
+		[specC.id, specC.id],
+	);
 });
 
 test("writeReport: the completed report atomically supersedes a partial checkpoint", (t) => {

--- a/eval/run.checkpoint.test.ts
+++ b/eval/run.checkpoint.test.ts
@@ -3,11 +3,14 @@ import assert from "node:assert/strict";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import {
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
+	readlinkSync,
 	rmSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -178,6 +181,66 @@ test("writeReport: a failed replace does not leave a temp file", (t) => {
 	const args = parseArgs(["--draws", "1", "--report", reportPath]);
 
 	assert.throws(() => writeReport(args, [makeDraw(spec, 0)], [spec]));
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+// rename(2) does not dereference a symlink in its final path component:
+// a naive rename(tempPath, targetPath) over a symlinked --report path would
+// unlink the symlink and install a plain file, silently destroying the
+// alias. writeReport must instead write through to the symlink's resolved
+// destination and leave the symlink itself in place.
+test("writeReport: a symlinked --report target stays a symlink and is written through", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-symlink-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const realPath = path.join(dir, "real-report.json");
+	const linkPath = path.join(dir, "report.json");
+	writeFileSync(realPath, "placeholder");
+	symlinkSync(realPath, linkPath);
+	const spec = checkpointSpec("checkpoint-symlink");
+	const args = parseArgs(["--draws", "1", "--report", linkPath]);
+
+	writeReport(args, [makeDraw(spec, 0)], [spec]);
+
+	assert.equal(
+		lstatSync(linkPath).isSymbolicLink(),
+		true,
+		"the --report path must remain a symlink after checkpointing",
+	);
+	assert.equal(readlinkSync(linkPath), realPath);
+	const onDiskViaLink = readReport(linkPath);
+	assert.equal(onDiskViaLink.results.length, 1);
+	assert.equal(onDiskViaLink.results[0]?.fixtureId, spec.id);
+	const onDiskViaReal = readReport(realPath);
+	assert.equal(onDiskViaReal.results.length, 1);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+// A dangling symlink (pointing at a path that doesn't exist yet) must still
+// resolve: realpathSync fails for a dangling link, so the fallback has to
+// resolve the link's own text relative to its directory instead of
+// replacing the link with a plain file.
+test("writeReport: a dangling symlinked --report target is written through and stays a symlink", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-dangling-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const realPath = path.join(dir, "not-yet-created.json");
+	const linkPath = path.join(dir, "report.json");
+	symlinkSync(realPath, linkPath);
+	const spec = checkpointSpec("checkpoint-dangling");
+	const args = parseArgs(["--draws", "1", "--report", linkPath]);
+
+	writeReport(args, [makeDraw(spec, 0)], [spec]);
+
+	assert.equal(
+		lstatSync(linkPath).isSymbolicLink(),
+		true,
+		"the --report path must remain a symlink after checkpointing",
+	);
+	assert.equal(readlinkSync(linkPath), realPath);
+	assert.equal(existsSync(realPath), true);
+	const onDiskViaLink = readReport(linkPath);
+	assert.equal(onDiskViaLink.results.length, 1);
 	assert.deepEqual(leftoverTemps(dir), []);
 });
 

--- a/eval/run.checkpoint.test.ts
+++ b/eval/run.checkpoint.test.ts
@@ -1,0 +1,368 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+	fixtureSetHash,
+	mapLimit,
+	parseArgs,
+	resumeSlots,
+	writeReport,
+} from "./run";
+import { isCompleteReport } from "./shared/report-completeness";
+import { score } from "./shared/score";
+import type { DrawResult, FixtureSpec, Report } from "./shared/types";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function checkpointSpec(id: string): FixtureSpec {
+	return {
+		id,
+		kind: "positive",
+		defectClass: "test",
+		description: "test",
+		baseFiles: {},
+		headFiles: {},
+		expected: { verdict: "pass", mustFind: [{ pattern: "x" }] },
+	};
+}
+
+function makeDraw(spec: FixtureSpec, draw: number): DrawResult {
+	return {
+		fixtureId: spec.id,
+		draw,
+		score: score({ verdict: "pass", findings: [] }, spec.expected, spec.id),
+		durationMs: 1,
+		calls: 1,
+		retries: 0,
+	};
+}
+
+function readReport(reportPath: string): Report {
+	const parsed: unknown = JSON.parse(readFileSync(reportPath, "utf8"));
+	assert.equal(typeof parsed, "object");
+	assert.notEqual(parsed, null);
+	return parsed as Report;
+}
+
+function leftoverTemps(dir: string): string[] {
+	return readdirSync(dir).filter((name) => name.includes(".tmp"));
+}
+
+function withGuardEnv(t: { after: (fn: () => void) => void }): void {
+	const previous = {
+		home: process.env.NEEDLEFISH_EPHEMERAL_HOME,
+		trace: process.env.NEEDLEFISH_EVAL_TRACE,
+	};
+	process.env.NEEDLEFISH_EPHEMERAL_HOME = "1";
+	process.env.NEEDLEFISH_EVAL_TRACE = "1";
+	t.after(() => {
+		if (previous.home === undefined) delete process.env.NEEDLEFISH_EPHEMERAL_HOME;
+		else process.env.NEEDLEFISH_EPHEMERAL_HOME = previous.home;
+		if (previous.trace === undefined) delete process.env.NEEDLEFISH_EVAL_TRACE;
+		else process.env.NEEDLEFISH_EVAL_TRACE = previous.trace;
+	});
+}
+
+test("writeReport: a fresh run without --resume still writes a structurally valid partial report", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-fresh-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const specA = checkpointSpec("checkpoint-fresh-a");
+	const specB = checkpointSpec("checkpoint-fresh-b");
+	const args = parseArgs(["--draws", "1", "--report", reportPath]);
+	assert.equal(args.resume, null);
+
+	writeReport(args, [makeDraw(specA, 0)], [specA, specB]);
+
+	const onDisk = readReport(reportPath);
+	assert.equal(onDisk.results.length, 1);
+	assert.equal(onDisk.results[0]?.fixtureId, specA.id);
+	assert.deepEqual(onDisk.fixtures, [specA.id, specB.id]);
+	assert.equal(onDisk.promptHash.length > 0, true);
+	assert.equal(onDisk.fixtureSetHash, fixtureSetHash([specA, specB]));
+	assert.equal(typeof onDisk.scorerHash, "string");
+	const fixtureKinds = (onDisk as { fixtureKinds?: Readonly<Record<string, string>> })
+		.fixtureKinds;
+	assert.equal(fixtureKinds?.[specA.id], "positive");
+	assert.equal(fixtureKinds?.[specB.id], "positive");
+	assert.equal(typeof onDisk.aggregates, "object");
+	assert.equal(isCompleteReport(onDisk), false);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+// Atomic replacement is the rename(2) of a same-directory temp over the
+// target; this test only checks that the temp is not left behind. A plain
+// writeFileSync to the target would also pass the leftover check.
+test("writeReport: leaves no temp files behind", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-atomic-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const spec = checkpointSpec("checkpoint-atomic");
+	const args = parseArgs(["--draws", "2", "--report", reportPath]);
+
+	writeReport(args, [makeDraw(spec, 0)], [spec]);
+	writeReport(args, [makeDraw(spec, 0), makeDraw(spec, 1)], [spec]);
+
+	const onDisk = readReport(reportPath);
+	assert.equal(onDisk.results.length, 2);
+	assert.equal(isCompleteReport(onDisk), true);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+test("writeReport: a later smaller checkpoint does not overwrite a larger one", async (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-monotonic-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const spec = checkpointSpec("checkpoint-monotonic");
+	const args = parseArgs(["--draws", "4", "--report", reportPath]);
+	const draws = [0, 1, 2, 3].map((draw) => makeDraw(spec, draw));
+
+	await mapLimit([4, 3, 2, 1], 4, async (count) => {
+		await Promise.resolve();
+		writeReport(args, draws.slice(0, count), [spec]);
+	});
+
+	const onDisk = readReport(reportPath);
+	assert.equal(onDisk.results.length, 4);
+	assert.deepEqual(
+		onDisk.results.map((result) => result.draw),
+		[0, 1, 2, 3],
+	);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+test("writeReport: the completed report atomically supersedes a partial checkpoint", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-final-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const specA = checkpointSpec("checkpoint-final-a");
+	const specB = checkpointSpec("checkpoint-final-b");
+	const args = parseArgs(["--draws", "1", "--report", reportPath]);
+	const drawA = makeDraw(specA, 0);
+	const drawB = makeDraw(specB, 0);
+
+	writeReport(args, [drawA], [specA, specB]);
+	assert.equal(isCompleteReport(readReport(reportPath)), false);
+
+	writeReport(args, [drawA, drawB], [specA, specB]);
+	const onDisk = readReport(reportPath);
+	assert.equal(onDisk.results.length, 2);
+	assert.equal(isCompleteReport(onDisk), true);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+test("writeReport: a failed replace does not leave a temp file", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-fail-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	mkdirSync(reportPath);
+	const spec = checkpointSpec("checkpoint-fail");
+	const args = parseArgs(["--draws", "1", "--report", reportPath]);
+
+	assert.throws(() => writeReport(args, [makeDraw(spec, 0)], [spec]));
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+test("checkpoint: an interrupted fresh run leaves a partial report a later process --resume continues", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-resume-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const specA = checkpointSpec("checkpoint-resume-a");
+	const specB = checkpointSpec("checkpoint-resume-b");
+	const drawA = makeDraw(specA, 0);
+	const drawB = makeDraw(specB, 0);
+	const specs = [specA, specB];
+
+	writeReport(parseArgs(["--draws", "1", "--report", reportPath]), [drawA], specs);
+
+	const withoutResume = resumeSlots(
+		parseArgs(["--draws", "1", "--report", reportPath]),
+		specs,
+		specs.map((spec) => ({ spec, draw: 0 })),
+	);
+	assert.equal(withoutResume.skipped, 0, "--resume remains the opt-in for loading");
+	assert.deepEqual(withoutResume.slots, [null, null]);
+
+	const childPath = path.join(dir, "continue.ts");
+	writeFileSync(
+		childPath,
+		`import { parseArgs, resumeSlots, writeReport } from ${JSON.stringify(pathToFileURL(path.join(__dirname, "run.ts")).href)};
+
+const specs = ${JSON.stringify(specs)};
+const draws = ${JSON.stringify([drawA, drawB])};
+const reportPath = ${JSON.stringify(reportPath)};
+const args = parseArgs(["--draws", "1", "--report", reportPath, "--resume", reportPath]);
+const work = specs.map((spec) => ({ spec, draw: 0 }));
+const resumed = resumeSlots(args, specs, work);
+if (resumed.skipped !== 1) {
+	throw new Error("expected 1 skipped fixture, got " + resumed.skipped);
+}
+if (resumed.slots[0] === null || resumed.slots[1] !== null) {
+	throw new Error("expected the completed fixture reused and the rest pending");
+}
+writeReport(args, draws, specs);
+process.stdout.write(JSON.stringify({ skipped: resumed.skipped }) + "\\n");
+`,
+	);
+
+	const child = spawnSync(process.execPath, ["--import", "tsx", childPath], {
+		encoding: "utf8",
+		timeout: 60_000,
+		env: {
+			...process.env,
+			NEEDLEFISH_EPHEMERAL_HOME: "1",
+			NEEDLEFISH_EVAL_TRACE: "1",
+		},
+	});
+	assert.equal(
+		child.status,
+		0,
+		`fresh-process resume must succeed, stderr: ${child.stderr}`,
+	);
+	const childOut: unknown = JSON.parse(child.stdout.trim());
+	assert.equal(typeof childOut, "object");
+	assert.equal((childOut as { skipped: number }).skipped, 1);
+
+	const onDisk = readReport(reportPath);
+	assert.equal(onDisk.results.length, 2);
+	assert.deepEqual(
+		onDisk.results.map((result) => result.fixtureId),
+		[specA.id, specB.id],
+	);
+	assert.equal(isCompleteReport(onDisk), true);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+function collectOutput(child: ChildProcess): { stdout: string; stderr: string } {
+	const output = { stdout: "", stderr: "" };
+	child.stdout?.setEncoding("utf8");
+	child.stderr?.setEncoding("utf8");
+	child.stdout?.on("data", (chunk: string) => {
+		output.stdout += chunk;
+	});
+	child.stderr?.on("data", (chunk: string) => {
+		output.stderr += chunk;
+	});
+	return output;
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (child.exitCode !== null || child.signalCode !== null) {
+			resolve();
+			return;
+		}
+		const timer = setTimeout(() => {
+			reject(new Error("eval child did not exit after SIGKILL"));
+		}, timeoutMs);
+		child.once("exit", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+}
+
+// Drives eval/run.ts main(), not writeReport: a fresh weekly-shaped run
+// (no --resume) must checkpoint after each draw. Gating that callback on
+// args.resume is the issue #58 bug and must fail this test.
+test("eval CLI: an interrupted dry-run without --resume leaves a partial report", async (t) => {
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-cli-"));
+	const childTmp = path.join(dir, "tmp");
+	mkdirSync(childTmp);
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const draws = 20;
+	const child = spawn(
+		process.execPath,
+		[
+			"--import",
+			"tsx",
+			path.resolve(__dirname, "run.ts"),
+			"--dry-run",
+			"--runner",
+			"codex",
+			"--draws",
+			String(draws),
+			"--concurrency",
+			"1",
+			"--fixtures",
+			"^neg-style-only$",
+			"--report",
+			reportPath,
+		],
+		{
+			cwd: path.resolve(__dirname, ".."),
+			env: {
+				...process.env,
+				TMPDIR: childTmp,
+				TMP: childTmp,
+				NEEDLEFISH_EPHEMERAL_HOME: "1",
+				NEEDLEFISH_EVAL_TRACE: "1",
+			},
+			stdio: ["ignore", "pipe", "pipe"],
+		},
+	);
+	const output = collectOutput(child);
+	t.after(() => {
+		if (child.exitCode === null && child.signalCode === null) {
+			child.kill("SIGKILL");
+		}
+	});
+
+	const deadline = Date.now() + 30_000;
+	while (!existsSync(reportPath) && Date.now() < deadline) {
+		if (child.exitCode !== null || child.signalCode !== null) {
+			break;
+		}
+		await delay(15);
+	}
+
+	assert.equal(
+		existsSync(reportPath),
+		true,
+		`fresh run must checkpoint before exit; status=${child.exitCode} signal=${child.signalCode} stderr=${output.stderr}`,
+	);
+	assert.equal(
+		child.exitCode,
+		null,
+		`report appeared only after the process finished (final write, not a per-draw checkpoint); stderr=${output.stderr}`,
+	);
+	child.kill("SIGKILL");
+	await waitForExit(child, 10_000);
+
+	const onDisk = readReport(reportPath);
+	assert.ok(
+		onDisk.results.length >= 1,
+		"interrupted run must have completed at least one draw",
+	);
+	assert.ok(
+		onDisk.results.length < draws,
+		`expected a partial checkpoint, got ${onDisk.results.length}/${draws} draws (final write, not per-draw)`,
+	);
+	assert.equal(onDisk.draws, draws);
+	assert.deepEqual(onDisk.fixtures, ["neg-style-only"]);
+	assert.equal(typeof onDisk.promptHash, "string");
+	assert.equal(onDisk.promptHash.length > 0, true);
+	assert.equal(typeof onDisk.fixtureSetHash, "string");
+	assert.equal(typeof onDisk.aggregates, "object");
+	assert.equal(isCompleteReport(onDisk), false);
+});

--- a/eval/run.checkpoint.test.ts
+++ b/eval/run.checkpoint.test.ts
@@ -244,6 +244,92 @@ test("writeReport: a dangling symlinked --report target is written through and s
 	assert.deepEqual(leftoverTemps(dir), []);
 });
 
+// A single hop of a dangling chain is not enough: rename(2) would still
+// unlink an *intermediate* symlink (link -> mid -> real, where real doesn't
+// exist yet) and replace it with a plain file, leaving `link` broken. The
+// whole chain must be walked to the final (possibly nonexistent) target.
+test("writeReport: a multi-hop dangling symlink chain is written through and every link survives", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-chain-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const realPath = path.join(dir, "not-yet-created.json");
+	const midPath = path.join(dir, "mid-link.json");
+	const linkPath = path.join(dir, "report.json");
+	symlinkSync(realPath, midPath);
+	symlinkSync(midPath, linkPath);
+	const spec = checkpointSpec("checkpoint-chain");
+	const args = parseArgs(["--draws", "1", "--report", linkPath]);
+
+	writeReport(args, [makeDraw(spec, 0)], [spec]);
+
+	assert.equal(
+		lstatSync(linkPath).isSymbolicLink(),
+		true,
+		"the outer --report symlink must survive",
+	);
+	assert.equal(readlinkSync(linkPath), midPath);
+	assert.equal(
+		lstatSync(midPath).isSymbolicLink(),
+		true,
+		"the intermediate symlink must survive, not be replaced by the report file",
+	);
+	assert.equal(readlinkSync(midPath), realPath);
+	assert.equal(existsSync(realPath), true, "the chain's final target must be created");
+	const onDiskViaLink = readReport(linkPath);
+	assert.equal(onDiskViaLink.results.length, 1);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
+// resumeSlots gated ALL of a fixture's slot reuse on the fixture having
+// args.draws good results. A fixture interrupted partway through (the exact
+// case the per-draw checkpoint exists to survive) would have its
+// already-good draws discarded and rerun from scratch on --resume,
+// defeating the checkpoint's purpose at fixture granularity.
+test("resumeSlots: reuses already-checkpointed draws from a partially-completed fixture", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(
+		path.join(tmpdir(), "needlefish-checkpoint-partial-resume-"),
+	);
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const spec = checkpointSpec("checkpoint-partial-resume");
+	const specs = [spec];
+	const writeArgs = parseArgs(["--draws", "2", "--report", reportPath]);
+	// Only draw 0 completed before the process was interrupted; draw 1 never ran.
+	writeReport(writeArgs, [makeDraw(spec, 0)], specs);
+
+	const resumeArgs = parseArgs([
+		"--draws",
+		"2",
+		"--report",
+		reportPath,
+		"--resume",
+		reportPath,
+	]);
+	const work = [
+		{ spec, draw: 0 },
+		{ spec, draw: 1 },
+	];
+	const resumed = resumeSlots(resumeArgs, specs, work);
+
+	assert.equal(
+		resumed.skipped,
+		0,
+		"the fixture is not fully complete and must not count as skipped",
+	);
+	assert.notEqual(
+		resumed.slots[0],
+		null,
+		"the already-checkpointed draw 0 must be reused, not rerun",
+	);
+	assert.equal(resumed.slots[0]?.draw, 0);
+	assert.equal(
+		resumed.slots[1],
+		null,
+		"draw 1 was never completed and must still be scheduled",
+	);
+});
+
 test("checkpoint: an interrupted fresh run leaves a partial report a later process --resume continues", (t) => {
 	withGuardEnv(t);
 	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-resume-"));

--- a/eval/run.checkpoint.test.ts
+++ b/eval/run.checkpoint.test.ts
@@ -225,6 +225,74 @@ test("writeReport: a fresh run's interrupted partial checkpoint does not destroy
 	);
 });
 
+// Raw result count is a weak proxy for "more complete": a same-sized (or
+// even larger) checkpoint can be differently composed and silently drop a
+// fixture x draw pair the prior checkpoint already covered. The guard must
+// compare actual coverage, not cardinality.
+test("writeReport: an equal-count but worse-coverage checkpoint does not overwrite", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(
+		path.join(tmpdir(), "needlefish-checkpoint-coverage-"),
+	);
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const specA = checkpointSpec("checkpoint-coverage-a");
+	const specB = checkpointSpec("checkpoint-coverage-b");
+	const specs = [specA, specB];
+	const args = parseArgs(["--draws", "2", "--report", reportPath]);
+
+	// First checkpoint: draw 0 for both fixtures (2 results), covering
+	// {A:0, B:0}.
+	writeReport(args, [makeDraw(specA, 0), makeDraw(specB, 0)], specs);
+	assert.equal(readReport(reportPath).results.length, 2);
+
+	// A same-sized checkpoint that is differently composed: {A:0, A:1} is
+	// still 2 results (equal count, so a pure count check would let it
+	// through) but drops B:0's coverage in favor of A:1. It must be
+	// blocked because it does not retain everything the prior checkpoint
+	// already covered.
+	writeReport(args, [makeDraw(specA, 0), makeDraw(specA, 1)], specs);
+
+	const onDisk = readReport(reportPath);
+	assert.deepEqual(
+		onDisk.results.map((r) => `${r.fixtureId}:${r.draw}`).sort(),
+		["checkpoint-coverage-a:0", "checkpoint-coverage-b:0"],
+		"an equal-count checkpoint that drops previously-covered pairs must not overwrite",
+	);
+});
+
+// Only a confirmed ENOENT proves nothing is at --report. Any other read
+// failure (garbage content that isn't valid JSON, here — a real failure
+// exercised through the actual JSON.parse path, not a mocked throw) means
+// something IS there and must be treated as maximally protected: fail
+// closed with an actionable error rather than silently treating it as
+// absent and overwriting it.
+test("writeReport: an unreadable existing report at --report is never treated as absent", (t) => {
+	withGuardEnv(t);
+	const dir = mkdtempSync(
+		path.join(tmpdir(), "needlefish-checkpoint-unreadable-"),
+	);
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	const reportPath = path.join(dir, "report.json");
+	const garbage = "{ this is not valid json";
+	writeFileSync(reportPath, garbage);
+	const spec = checkpointSpec("checkpoint-unreadable");
+	const args = parseArgs(["--draws", "2", "--report", reportPath]);
+
+	assert.throws(
+		() => writeReport(args, [makeDraw(spec, 0)], [spec]),
+		/not valid JSON/,
+		"an existing file that can't be parsed as a report must fail closed, not be treated as absent",
+	);
+
+	assert.equal(
+		readFileSync(reportPath, "utf8"),
+		garbage,
+		"a fail-closed refusal must leave the unreadable file untouched",
+	);
+	assert.deepEqual(leftoverTemps(dir), []);
+});
+
 test("writeReport: the completed report atomically supersedes a partial checkpoint", (t) => {
 	withGuardEnv(t);
 	const dir = mkdtempSync(path.join(tmpdir(), "needlefish-checkpoint-final-"));
@@ -270,7 +338,11 @@ test("writeReport: a symlinked --report target stays a symlink and is written th
 	t.after(() => rmSync(dir, { recursive: true, force: true }));
 	const realPath = path.join(dir, "real-report.json");
 	const linkPath = path.join(dir, "report.json");
-	writeFileSync(realPath, "placeholder");
+	// Valid-but-empty report JSON, not arbitrary garbage: this file only
+	// needs to make the symlink non-dangling for this test's purpose (the
+	// symlink surviving a write-through); real garbage content is its own,
+	// separately-tested case (see "an unreadable existing report...").
+	writeFileSync(realPath, JSON.stringify({ results: [] }));
 	symlinkSync(realPath, linkPath);
 	const spec = checkpointSpec("checkpoint-symlink");
 	const args = parseArgs(["--draws", "1", "--report", linkPath]);

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -502,40 +502,95 @@ export function aggregateMustFindHitRates(
 	return { mustFindHitRateByFixture, mustFindHitRate };
 }
 
-// Per-process high-water mark of results flushed to each report path.
-// Concurrent draw completions can invoke writeReport with snapshots taken
-// at different sizes; a later call must not replace a larger checkpoint.
+// Per-process high-water mark of coverage flushed to each report path,
+// tracked as the SET of (fixtureId, draw) pairs a checkpoint has written —
+// not a raw count. Count is a weak proxy for "more complete": two
+// checkpoints can be the same size (or the later one even larger) while the
+// later one drops pairs the earlier one already covered, e.g. a
+// differently-composed concurrent completion. Only the actual coverage set
+// proves a checkpoint strictly retains everything already on record.
 //
 // This map starts empty in every process. Without seeding it from disk, a
 // FRESH run (no --resume) pointed at a --report path that already holds a
 // complete report from a prior invocation would have its own first partial
-// checkpoint (as small as one draw) pass this guard trivially — lastCount
-// is undefined, so incomingCount < lastCount is never true — and
+// checkpoint (as small as one draw) pass this guard trivially and
 // atomically overwrite the old complete report. A crash before the new run
 // finishes then leaves only a partial file that isCompleteReport rejects,
 // with the previously-good report unrecoverably gone: the checkpoint
 // feature this guard belongs to (crash resilience, #58) would have
 // destroyed the very artifact it exists to protect.
-const lastCheckpointCounts = new Map<string, number>();
+const lastCheckpointCoverage = new Map<string, ReadonlySet<string>>();
 
-// Reads whatever report already sits at `targetPath` (if any) so a fresh
+function coverageKey(fixtureId: string, draw: number): string {
+	return `${fixtureId} ${draw}`;
+}
+
+function coverageOf(
+	results: readonly { fixtureId: string; draw: number }[],
+): Set<string> {
+	const pairs = new Set<string>();
+	for (const r of results) pairs.add(coverageKey(r.fixtureId, r.draw));
+	return pairs;
+}
+
+type ExistingReportProbe =
+	| { readonly kind: "absent" }
+	| { readonly kind: "coverage"; readonly pairs: ReadonlySet<string> };
+
+// Probes whatever is already at `targetPath` (if anything) so a fresh
 // process can seed its high-water mark from disk instead of starting blind.
 // readFileSync follows the symlink chain to read the real file, same as any
 // normal read — only rename(2)'s no-dereference-on-final-component behavior
 // (handled separately by resolveWriteDestination) needs manual walking.
-function readExistingReportCount(targetPath: string): number | undefined {
+//
+// Only a confirmed ENOENT proves nothing is there. Every other failure —
+// permission denied, an I/O error, a directory in the way, content that
+// isn't valid JSON, or JSON that isn't shaped like a Report — means
+// something IS at that path and this call could not establish what it is.
+// Treating that the same as "nothing to protect" (as an earlier version of
+// this guard did) is a fail-open on a data-loss guard: silently
+// unprotected instead of maximally protected. Throw instead, with an
+// actionable message, so the operator hits this at the very first
+// checkpoint (seconds into a run) rather than the run silently losing its
+// crash-resilience guarantee for its whole duration, or a real report
+// being silently destroyed at the very end.
+function probeExistingReport(targetPath: string): ExistingReportProbe {
 	let raw: string;
 	try {
 		raw = readFileSync(targetPath, "utf8");
-	} catch {
-		return undefined;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return { kind: "absent" };
+		}
+		throw new Error(
+			`--report target ${targetPath} exists but could not be read (${
+				(error as NodeJS.ErrnoException).code ?? String(error)
+			}). Refusing to checkpoint over it without knowing what it contains — ` +
+				"move or delete the file, fix its permissions, or point --report elsewhere, then retry.",
+			{ cause: error },
+		);
 	}
+	let parsed: unknown;
 	try {
-		const parsed = JSON.parse(raw) as { results?: unknown };
-		return Array.isArray(parsed.results) ? parsed.results.length : undefined;
-	} catch {
-		return undefined;
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw new Error(
+			`--report target ${targetPath} exists but is not valid JSON. Refusing to ` +
+				"checkpoint over it without knowing what it contains — move or delete the file, or point --report elsewhere, then retry.",
+			{ cause: error },
+		);
 	}
+	const existingResults = (parsed as { results?: unknown }).results;
+	if (!Array.isArray(existingResults)) {
+		throw new Error(
+			`--report target ${targetPath} exists but does not look like a Report (no results array). ` +
+				"Refusing to checkpoint over it without knowing what it contains — move or delete the file, or point --report elsewhere, then retry.",
+		);
+	}
+	return {
+		kind: "coverage",
+		pairs: coverageOf(existingResults as { fixtureId: string; draw: number }[]),
+	};
 }
 
 // Symlink chains can be arbitrarily long; this is comfortably above what any
@@ -736,33 +791,46 @@ export function writeReport(
 		readonly fixtureKinds: Readonly<Record<string, FixtureKind>>;
 	};
 	const targetPath = path.resolve(args.report);
-	const incomingCount = results.length;
-	if (!lastCheckpointCounts.has(targetPath)) {
+	if (!lastCheckpointCoverage.has(targetPath)) {
 		// First checkpoint attempt this process has made to this path: seed
-		// the high-water mark from whatever report is already on disk so this
-		// run's own first (necessarily small) partial checkpoint cannot
-		// silently destroy a prior report before this run has produced
-		// anything at least as complete.
-		lastCheckpointCounts.set(targetPath, readExistingReportCount(targetPath) ?? 0);
+		// the high-water mark from whatever report is already on disk (this
+		// throws if something is there and unreadable — see
+		// probeExistingReport) so this run's own first (necessarily small)
+		// partial checkpoint cannot silently destroy a prior report before
+		// this run has produced anything at least as complete.
+		const probe = probeExistingReport(targetPath);
+		lastCheckpointCoverage.set(
+			targetPath,
+			probe.kind === "coverage" ? probe.pairs : new Set(),
+		);
 	}
-	const lastCount = lastCheckpointCounts.get(targetPath) as number;
-	// A partial (still in-progress) checkpoint must never regress below
-	// whatever is already the most-complete artifact at this path — from a
-	// prior process's on-disk report or from this run's own earlier
-	// checkpoints. But a report that is itself structurally complete (every
-	// fixture x draw pair present) is this run's deliberate final artifact
-	// and always wins, even if its own count is smaller than what preceded
-	// it (e.g. a rerun with --draws intentionally lowered) — otherwise
-	// --report would become unusable for a legitimate rerun.
+	const lastCoverage = lastCheckpointCoverage.get(targetPath) as ReadonlySet<string>;
+	const incomingCoverage = coverageOf(results);
+	// A partial (still in-progress) checkpoint must never drop any pair
+	// already covered at this path — from a prior process's on-disk report
+	// or from this run's own earlier checkpoints. Comparing sets (not
+	// counts) catches the case count-comparison misses: an equal- or
+	// larger-sized checkpoint that is differently composed and silently
+	// drops a pair the prior checkpoint had. But a report that is itself
+	// structurally complete (every fixture x draw pair present) is this
+	// run's deliberate final artifact and always wins, even over pairs it
+	// does not itself retain (e.g. a rerun with --draws intentionally
+	// lowered, or a different fixture set) — otherwise --report would
+	// become unusable for a legitimate rerun.
 	const incomingComplete = isCompleteReport(
 		report,
 		specs.map((s) => s.id),
 	);
-	if (!incomingComplete && incomingCount < lastCount) {
+	const retainsAllPriorCoverage = [...lastCoverage].every((key) =>
+		incomingCoverage.has(key),
+	);
+	if (!incomingComplete && !retainsAllPriorCoverage) {
 		return report;
 	}
 	atomicWriteFile(targetPath, JSON.stringify(report, null, 2));
-	lastCheckpointCounts.set(targetPath, Math.max(incomingCount, lastCount));
+	const merged = new Set(lastCoverage);
+	for (const key of incomingCoverage) merged.add(key);
+	lastCheckpointCoverage.set(targetPath, merged);
 	return report;
 }
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -340,6 +340,18 @@ export function resumeSlots(
 			arr.push(r);
 			byFixture.set(r.fixtureId, arr);
 		}
+		// Index good draws by their OWN recorded draw number, not by position
+		// in completion order. Draws land in `existing.results` in whatever
+		// order they finished (concurrent runs), and a failed draw is
+		// filtered out of "good" — so a positional `good[draw]` lookup (the
+		// prior approach) silently relabels one draw's result as another's:
+		// e.g. draws=2 with draw 0 failed and draw 1 good leaves `good` with
+		// one entry whose OWN draw number is 1, but a positional lookup would
+		// hand it to slot 0 under a false draw-0 label while slot 1 (which
+		// has no result at all) gets rescheduled. Reusing a draw must mean
+		// "this exact draw number already has a good result on disk", never
+		// "some good result exists nearby".
+		//
 		// `skipped` counts fully-completed fixtures (kept for the existing
 		// stderr/return contract); it does not gate which individual draws
 		// are reused below. A fixture interrupted partway through a run — the
@@ -347,25 +359,32 @@ export function resumeSlots(
 		// survive — still has its already-good draws on disk and must not
 		// have them thrown away just because the fixture as a whole isn't
 		// done.
+		const goodByFixture = new Map<string, Map<number, DrawResult>>();
 		for (const spec of specs) {
-			const draws = byFixture.get(spec.id) ?? [];
-			const good = draws.filter((d) => d.score.formatOk);
-			if (good.length >= args.draws) {
-				skipped++;
+			const goodByDraw = new Map<number, DrawResult>();
+			for (const d of byFixture.get(spec.id) ?? []) {
+				if (d.score.formatOk) goodByDraw.set(d.draw, d);
 			}
+			goodByFixture.set(spec.id, goodByDraw);
+			let complete = true;
+			for (let draw = 0; draw < args.draws; draw++) {
+				if (!goodByDraw.has(draw)) {
+					complete = false;
+					break;
+				}
+			}
+			if (complete) skipped++;
 		}
 		let reusedDraws = 0;
 		for (let i = 0; i < work.length; i++) {
 			const { spec, draw } = work[i];
-			const good = (byFixture.get(spec.id) ?? []).filter(
-				(d) => d.score.formatOk,
-			);
-			if (draw >= good.length) continue;
+			const match = goodByFixture.get(spec.id)?.get(draw);
+			if (!match) continue;
 			slots[i] = {
-				...good[draw],
+				...match,
 				draw,
-				calls: good[draw].calls ?? 0,
-				retries: good[draw].retries ?? 0,
+				calls: match.calls ?? 0,
+				retries: match.retries ?? 0,
 			};
 			reusedDraws++;
 		}

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -505,7 +505,38 @@ export function aggregateMustFindHitRates(
 // Per-process high-water mark of results flushed to each report path.
 // Concurrent draw completions can invoke writeReport with snapshots taken
 // at different sizes; a later call must not replace a larger checkpoint.
+//
+// This map starts empty in every process. Without seeding it from disk, a
+// FRESH run (no --resume) pointed at a --report path that already holds a
+// complete report from a prior invocation would have its own first partial
+// checkpoint (as small as one draw) pass this guard trivially — lastCount
+// is undefined, so incomingCount < lastCount is never true — and
+// atomically overwrite the old complete report. A crash before the new run
+// finishes then leaves only a partial file that isCompleteReport rejects,
+// with the previously-good report unrecoverably gone: the checkpoint
+// feature this guard belongs to (crash resilience, #58) would have
+// destroyed the very artifact it exists to protect.
 const lastCheckpointCounts = new Map<string, number>();
+
+// Reads whatever report already sits at `targetPath` (if any) so a fresh
+// process can seed its high-water mark from disk instead of starting blind.
+// readFileSync follows the symlink chain to read the real file, same as any
+// normal read — only rename(2)'s no-dereference-on-final-component behavior
+// (handled separately by resolveWriteDestination) needs manual walking.
+function readExistingReportCount(targetPath: string): number | undefined {
+	let raw: string;
+	try {
+		raw = readFileSync(targetPath, "utf8");
+	} catch {
+		return undefined;
+	}
+	try {
+		const parsed = JSON.parse(raw) as { results?: unknown };
+		return Array.isArray(parsed.results) ? parsed.results.length : undefined;
+	} catch {
+		return undefined;
+	}
+}
 
 // Symlink chains can be arbitrarily long; this is comfortably above what any
 // real --report path would use and matches the ballpark of the OS's own
@@ -706,12 +737,32 @@ export function writeReport(
 	};
 	const targetPath = path.resolve(args.report);
 	const incomingCount = results.length;
-	const lastCount = lastCheckpointCounts.get(targetPath);
-	if (lastCount !== undefined && incomingCount < lastCount) {
+	if (!lastCheckpointCounts.has(targetPath)) {
+		// First checkpoint attempt this process has made to this path: seed
+		// the high-water mark from whatever report is already on disk so this
+		// run's own first (necessarily small) partial checkpoint cannot
+		// silently destroy a prior report before this run has produced
+		// anything at least as complete.
+		lastCheckpointCounts.set(targetPath, readExistingReportCount(targetPath) ?? 0);
+	}
+	const lastCount = lastCheckpointCounts.get(targetPath) as number;
+	// A partial (still in-progress) checkpoint must never regress below
+	// whatever is already the most-complete artifact at this path — from a
+	// prior process's on-disk report or from this run's own earlier
+	// checkpoints. But a report that is itself structurally complete (every
+	// fixture x draw pair present) is this run's deliberate final artifact
+	// and always wins, even if its own count is smaller than what preceded
+	// it (e.g. a rerun with --draws intentionally lowered) — otherwise
+	// --report would become unusable for a legitimate rerun.
+	const incomingComplete = isCompleteReport(
+		report,
+		specs.map((s) => s.id),
+	);
+	if (!incomingComplete && incomingCount < lastCount) {
 		return report;
 	}
 	atomicWriteFile(targetPath, JSON.stringify(report, null, 2));
-	lastCheckpointCounts.set(targetPath, incomingCount);
+	lastCheckpointCounts.set(targetPath, Math.max(incomingCount, lastCount));
 	return report;
 }
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -4,6 +4,8 @@ import {
 	writeFileSync,
 	existsSync,
 	mkdirSync,
+	renameSync,
+	unlinkSync,
 } from "node:fs";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
@@ -472,6 +474,30 @@ export function aggregateMustFindHitRates(
 	return { mustFindHitRateByFixture, mustFindHitRate };
 }
 
+// Per-process high-water mark of results flushed to each report path.
+// Concurrent draw completions can invoke writeReport with snapshots taken
+// at different sizes; a later call must not replace a larger checkpoint.
+const lastCheckpointCounts = new Map<string, number>();
+
+function atomicWriteFile(targetPath: string, contents: string): void {
+	const directory = path.dirname(targetPath);
+	mkdirSync(directory, { recursive: true });
+	const tempPath = path.join(
+		directory,
+		`.${path.basename(targetPath)}.${randomUUID()}.tmp`,
+	);
+	try {
+		writeFileSync(tempPath, contents);
+		renameSync(tempPath, targetPath);
+	} finally {
+		try {
+			unlinkSync(tempPath);
+		} catch {
+			// rename consumes the temp path; a failed create never produced one.
+		}
+	}
+}
+
 function aggregate(
 	results: readonly DrawResult[],
 	specs: readonly FixtureSpec[],
@@ -608,8 +634,14 @@ export function writeReport(
 		readonly fixtures: readonly string[];
 		readonly fixtureKinds: Readonly<Record<string, FixtureKind>>;
 	};
-	mkdirSync(path.dirname(path.resolve(args.report)), { recursive: true });
-	writeFileSync(args.report, JSON.stringify(report, null, 2));
+	const targetPath = path.resolve(args.report);
+	const incomingCount = results.length;
+	const lastCount = lastCheckpointCounts.get(targetPath);
+	if (lastCount !== undefined && incomingCount < lastCount) {
+		return report;
+	}
+	atomicWriteFile(targetPath, JSON.stringify(report, null, 2));
+	lastCheckpointCounts.set(targetPath, incomingCount);
 	return report;
 }
 
@@ -766,10 +798,16 @@ async function main(): Promise<void> {
 		// Threaded through fixture materialization and scoring; a finding that
 		// contains it means the runner copied the planted answer key.
 		const canary = randomUUID();
+		// Checkpoint after every completed draw. --resume only controls whether
+		// we LOAD a compatible prior report; a crash of a fresh run must still
+		// leave a structurally valid partial file at args.report.
+		const checkpoint = (partial: readonly DrawResult[]): void => {
+			writeReport(args, partial, specs);
+		};
 
 		if (args.compare) {
 			const slots: (DrawResult | null)[] = new Array(work.length).fill(null);
-			const results = await runWork(args, work, slots, canary);
+			const results = await runWork(args, work, slots, canary, checkpoint);
 			const report = writeReport(args, results, specs);
 			cheatAlert(report);
 			compare(args.compare, report);
@@ -785,10 +823,7 @@ async function main(): Promise<void> {
 		);
 
 		const { slots } = resumeSlots(args, specs, work);
-		const onDrawComplete = args.resume
-			? (partial: readonly DrawResult[]) => writeReport(args, partial, specs)
-			: undefined;
-		const results = await runWork(args, work, slots, canary, onDrawComplete);
+		const results = await runWork(args, work, slots, canary, checkpoint);
 
 		const report = writeReport(args, results, specs);
 		cheatAlert(report);

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -6,7 +6,6 @@ import {
 	existsSync,
 	lstatSync,
 	mkdirSync,
-	realpathSync,
 	renameSync,
 	unlinkSync,
 } from "node:fs";
@@ -341,30 +340,37 @@ export function resumeSlots(
 			arr.push(r);
 			byFixture.set(r.fixtureId, arr);
 		}
-		const doneFixtures = new Set<string>();
+		// `skipped` counts fully-completed fixtures (kept for the existing
+		// stderr/return contract); it does not gate which individual draws
+		// are reused below. A fixture interrupted partway through a run — the
+		// exact scenario the per-draw checkpoint (issue #58) exists to
+		// survive — still has its already-good draws on disk and must not
+		// have them thrown away just because the fixture as a whole isn't
+		// done.
 		for (const spec of specs) {
 			const draws = byFixture.get(spec.id) ?? [];
 			const good = draws.filter((d) => d.score.formatOk);
 			if (good.length >= args.draws) {
-				doneFixtures.add(spec.id);
 				skipped++;
 			}
 		}
+		let reusedDraws = 0;
 		for (let i = 0; i < work.length; i++) {
 			const { spec, draw } = work[i];
-			if (!doneFixtures.has(spec.id)) continue;
 			const good = (byFixture.get(spec.id) ?? []).filter(
 				(d) => d.score.formatOk,
 			);
+			if (draw >= good.length) continue;
 			slots[i] = {
 				...good[draw],
 				draw,
 				calls: good[draw].calls ?? 0,
 				retries: good[draw].retries ?? 0,
 			};
+			reusedDraws++;
 		}
 		process.stderr.write(
-			`resume: reused ${skipped} fixture(s) with ${args.draws} good draws, re-running the rest\n`,
+			`resume: reused ${reusedDraws} draw(s) across ${skipped} fully-completed fixture(s), re-running the rest\n`,
 		);
 	} catch (err) {
 		process.stderr.write(
@@ -482,39 +488,49 @@ export function aggregateMustFindHitRates(
 // at different sizes; a later call must not replace a larger checkpoint.
 const lastCheckpointCounts = new Map<string, number>();
 
-function atomicWriteFile(targetPath: string, contents: string): void {
-	// rename(2) does not dereference a symlink in its final path component:
-	// renaming a temp file onto a symlinked targetPath would unlink the
-	// symlink itself and install a plain file in its place, silently
-	// destroying the alias. Resolve a symlinked target to its real
-	// destination first and rename into *that* (same-filesystem) directory,
-	// so the symlink survives and the rename stays atomic.
-	let resolvedTarget = targetPath;
-	try {
-		if (lstatSync(targetPath).isSymbolicLink()) {
-			try {
-				resolvedTarget = realpathSync(targetPath);
-			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-					throw error;
-				}
-				// Dangling symlink: realpathSync fails because the pointed-to
-				// file doesn't exist yet. Resolve the link's own text relative
-				// to its directory — the same way the OS follows a relative
-				// symlink — so the alias becomes valid after this write
-				// instead of being replaced by a plain file.
-				resolvedTarget = path.resolve(
-					path.dirname(targetPath),
-					readlinkSync(targetPath),
-				);
+// Symlink chains can be arbitrarily long; this is comfortably above what any
+// real --report path would use and matches the ballpark of the OS's own
+// ELOOP threshold (Linux: 40). It exists to fail closed on a cycle rather
+// than hang, not to be a realistic chain length.
+const MAX_SYMLINK_CHAIN = 40;
+
+// rename(2) does not dereference a symlink in its final path component:
+// renaming a temp file onto a symlinked target would unlink the symlink
+// itself (or, mid-chain, an intermediate link) and install a plain file in
+// its place, silently destroying the alias. Walk the chain by hand — one
+// lstat+readlink hop at a time — rather than leaning on realpathSync, so a
+// live chain, a chain broken at its final hop (dangling), and no symlink at
+// all are all resolved by the same logic to the same real write
+// destination. A dangling final hop resolves to the path it points at
+// (which this write will then create) instead of stopping at the last
+// intermediate link.
+function resolveWriteDestination(targetPath: string): string {
+	let current = targetPath;
+	for (let hops = 0; hops < MAX_SYMLINK_CHAIN; hops++) {
+		let stat;
+		try {
+			stat = lstatSync(current);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				throw error;
 			}
+			// Nothing at `current`: either targetPath never existed, or we
+			// walked a chain of symlinks to a dangling final link. Either
+			// way, this is the real write destination.
+			return current;
 		}
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-			throw error;
+		if (!stat.isSymbolicLink()) {
+			return current;
 		}
-		// Nothing at targetPath yet; write straight through as before.
+		current = path.resolve(path.dirname(current), readlinkSync(current));
 	}
+	throw new Error(
+		`symlink chain too deep resolving --report target: ${targetPath}`,
+	);
+}
+
+function atomicWriteFile(targetPath: string, contents: string): void {
+	const resolvedTarget = resolveWriteDestination(targetPath);
 	const directory = path.dirname(resolvedTarget);
 	mkdirSync(directory, { recursive: true });
 	const tempPath = path.join(

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -1,9 +1,12 @@
 import {
 	readdirSync,
 	readFileSync,
+	readlinkSync,
 	writeFileSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
+	realpathSync,
 	renameSync,
 	unlinkSync,
 } from "node:fs";
@@ -480,15 +483,47 @@ export function aggregateMustFindHitRates(
 const lastCheckpointCounts = new Map<string, number>();
 
 function atomicWriteFile(targetPath: string, contents: string): void {
-	const directory = path.dirname(targetPath);
+	// rename(2) does not dereference a symlink in its final path component:
+	// renaming a temp file onto a symlinked targetPath would unlink the
+	// symlink itself and install a plain file in its place, silently
+	// destroying the alias. Resolve a symlinked target to its real
+	// destination first and rename into *that* (same-filesystem) directory,
+	// so the symlink survives and the rename stays atomic.
+	let resolvedTarget = targetPath;
+	try {
+		if (lstatSync(targetPath).isSymbolicLink()) {
+			try {
+				resolvedTarget = realpathSync(targetPath);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+					throw error;
+				}
+				// Dangling symlink: realpathSync fails because the pointed-to
+				// file doesn't exist yet. Resolve the link's own text relative
+				// to its directory — the same way the OS follows a relative
+				// symlink — so the alias becomes valid after this write
+				// instead of being replaced by a plain file.
+				resolvedTarget = path.resolve(
+					path.dirname(targetPath),
+					readlinkSync(targetPath),
+				);
+			}
+		}
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+		// Nothing at targetPath yet; write straight through as before.
+	}
+	const directory = path.dirname(resolvedTarget);
 	mkdirSync(directory, { recursive: true });
 	const tempPath = path.join(
 		directory,
-		`.${path.basename(targetPath)}.${randomUUID()}.tmp`,
+		`.${path.basename(resolvedTarget)}.${randomUUID()}.tmp`,
 	);
 	try {
 		writeFileSync(tempPath, contents);
-		renameSync(tempPath, targetPath);
+		renameSync(tempPath, resolvedTarget);
 	} finally {
 		try {
 			unlinkSync(tempPath);


### PR DESCRIPTION
Closes #58.

## Problem

`writeReport` was wired as `onDrawComplete` **only when `--resume` was set**:

```ts
const onDrawComplete = args.resume
    ? (partial) => writeReport(args, partial, specs)
    : undefined;
```

`.github/workflows/weekly-eval.yml` does not pass `--resume`, so a crash near the end of a full-set × 3-draws run on the self-hosted runner discarded **every** completed draw. Checkpoint *writing* and checkpoint *consumption* are separate concerns; `--resume` now controls only whether prior work is **loaded**.

## Change

- Checkpoint after every completed draw, unconditionally.
- `writeReport` owns atomicity: write to a sibling temp file, `renameSync` over the target. A crash mid-write cannot leave a truncated file that a later `--resume` parses as authoritative.
- A per-process high-water mark keyed by resolved report path prevents an out-of-order concurrent completion from replacing a larger checkpoint with a smaller one — `mapLimit` hands `writeReport` snapshots taken at different sizes.
- No schema change.

## Verification

**Behavior, executed against the real code:**

| Step | Result |
|---|---|
| fresh partial write (no `--resume`) | valid JSON, 1 result |
| larger checkpoint | 2 results |
| **smaller** checkpoint | stays 2 ✅ |
| final full write | 4 results |
| leftover `.tmp` files | 0 ✅ |

**A partial cannot authorize shipping** — real partial fed to the real gate:

```
$ node scripts/gate-verdict.mjs partial.json --criteria crit.json
{"pass":false,"reasons":["missing-draws:f1","missing-draws:f2"],...}   exit=1
```

Also checked: `weekly-eval.yml`'s "Compare with previous week and commit report" step has no `if:`, so it is skipped when the eval step fails — a partial is never committed as next week's baseline.

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 7 / fail 0` |
| restore resume-only checkpointing (**the original bug**) | `pass 6 / fail 1` ✅ |
| remove the monotonic guard | `pass 6 / fail 1` ✅ |
| restored | `pass 7 / fail 0` |

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **541 pass / 0 fail** (exit 0).

## Review note — the first round's tests did not test the fix

Worth recording, because it is the failure mode `docs/operating-manual.md` §8 names. The initial implementation's six tests all called `writeReport` directly. Reverting the production wiring back to `args.resume ? checkpoint : undefined` — i.e. reintroducing the exact bug this issue reports — left the suite **fully green**. They tested the helper; the bug was in the caller.

Fixed by adding `eval CLI: an interrupted dry-run without --resume leaves a partial report`, which spawns the real CLI (`--dry-run --concurrency 1 --draws 20`, no `--resume`), polls until the report appears, SIGKILLs the child, and asserts a genuine per-draw partial (`1 <= results.length < 20`). That test goes red under the reverted wiring.

Separately, a test named `…replaces the target atomically and leaves no temp files` passed even when the temp+rename block was replaced by a plain `writeFileSync` — the name overclaimed. Renamed to `writeReport: leaves no temp files behind`, with a comment recording that atomicity rests on `rename(2)` within a filesystem, not on a test. A torn-write observer would be flaky; honest naming is the right bar.

## Risk / not verified

- Atomicity is argued from `rename(2)` semantics, not demonstrated by a crash-mid-write harness.
- The `--compare` path now also checkpoints (it previously did not). It writes the same file it would write at the end; noted as a deliberate widening.
- The high-water mark is per process, so two concurrent processes writing the same report path could still race. No caller does that today.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, gate/partial proof, mutation testing — caught that the first round's tests did not fail when the fix was undone, and sent it back)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI, one corrective round)