### PR TITLE
fix(ci): resolve the PR number through env and validate it

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -256,6 +256,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BASE_SHA: ${{ steps.refs.outputs.base }}
           PR_HEAD_SHA: ${{ steps.refs.outputs.head }}
+          PR_NUM: ${{ inputs.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}
           NEEDLEFISH_RUNNER_INPUT: ${{ inputs.runner || github.event.inputs.runner || 'codex' }}
           NEEDLEFISH_MODEL_INPUT: ${{ inputs.model || github.event.inputs.model }}
           NEEDLEFISH_TIMEOUT_MS_INPUT: ${{ inputs.timeout_ms || github.event.inputs.timeout_ms }}
@@ -272,7 +273,11 @@ jobs:
             echo "Selected Needlefish release is unavailable. Run scripts/deploy-ubuntu.sh on the self-hosted runner." >&2
             exit 1
           fi
-          args=(--github --pr "${{ inputs.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}")
+          if [[ ! "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
+            echo "PR number must be a positive integer, received '$PR_NUM'." >&2
+            exit 1
+          fi
+          args=(--github --pr "$PR_NUM")
           if [ -z "$NEEDLEFISH_MODEL_INPUT" ]; then
             case "$NEEDLEFISH_RUNNER_INPUT" in
               codex|pi) NEEDLEFISH_MODEL_INPUT="gpt-5.6-terra" ;;

--- a/scripts/review-workflow-pr-number.test.mjs
+++ b/scripts/review-workflow-pr-number.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+// GitHub Actions interpolates ${{ }} into the run script before bash parses it.
+// Double quotes do not stop command substitution: $(...) and backticks in a
+// substituted value become program text and execute. That is the exploitable
+// class. Passing the PR number through env: and expanding "$PR_NUM" keeps the
+// value out of the script, which is the structural fix. The integer check is a
+// second gate, not a reason to put ${{ }} back into the run block.
+
+const workflow = readFileSync(".github/workflows/review.yml", "utf8");
+const step = workflow.match(
+	/      - name: Needlefish review\n([\s\S]*?)(?=\n      - name:|$)/,
+);
+assert.ok(step, "Needlefish review step must exist");
+const runBlock = step[1].match(/        run: \|\n([\s\S]*)/);
+assert.ok(runBlock, "Needlefish review must have a run block");
+const script = runBlock[1]
+	.split("\n")
+	.map((line) => line.replace(/^          /, ""))
+	.join("\n");
+
+function runReview(prNum) {
+	const root = mkdtempSync(join(tmpdir(), "needlefish-workflow-pr-"));
+	const fakeBin = join(root, "fake bin");
+	const argvLog = join(root, "argv.log");
+	const needlefishBin = join(fakeBin, "needlefish");
+	mkdirSync(fakeBin);
+	writeFileSync(
+		needlefishBin,
+		`#!/usr/bin/env bash
+set -euo pipefail
+for arg in "$@"; do printf '<%s>\\n' "$arg" >> "$ARGV_LOG"; done
+`,
+	);
+	chmodSync(needlefishBin, 0o755);
+
+	const result = spawnSync("bash", ["-c", script], {
+		cwd: root,
+		encoding: "utf8",
+		env: {
+			...process.env,
+			ARGV_LOG: argvLog,
+			CODEX_REASONING_EFFORT: "",
+			NEEDLEFISH_BIN: needlefishBin,
+			NEEDLEFISH_MODEL_INPUT: "",
+			NEEDLEFISH_RECHECK_INPUT: "",
+			NEEDLEFISH_RUNNER_INPUT: "",
+			NEEDLEFISH_TIMEOUT_MS_INPUT: "",
+			OPENCODE_IDLE_TIMEOUT_MS_INPUT: "",
+			PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+			PR_NUM: prNum,
+		},
+	});
+	const output = {
+		...result,
+		argvLog: existsSync(argvLog) ? readFileSync(argvLog, "utf8") : "",
+		pwned: existsSync(join(root, "pwned")),
+	};
+	rmSync(root, { recursive: true, force: true });
+	return output;
+}
+
+test("review resolves the PR number through env and quoted expansion", () => {
+	assert.match(
+		step[1],
+		/PR_NUM: \$\{\{ inputs\.pr_number \|\| github\.event\.inputs\.pr_number \|\| github\.event\.pull_request\.number \}\}/,
+	);
+	assert.match(script, /args=\(--github --pr "\$PR_NUM"\)/);
+	assert.match(script, /"\$NEEDLEFISH_BIN" "\$\{args\[@\]\}"/);
+	assert.doesNotMatch(script, /\$\{\{/);
+});
+
+test("review invokes needlefish with a valid numeric PR number", () => {
+	const result = runReview("42");
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.argvLog, /<--github>\n<--pr>\n<42>\n/);
+});
+
+test("review rejects PR number 0 before invoking needlefish", () => {
+	const result = runReview("0");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+});
+
+test("review rejects PR number -1 before invoking needlefish", () => {
+	const result = runReview("-1");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+});
+
+test("review rejects PR number abc before invoking needlefish", () => {
+	const result = runReview("abc");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+});
+
+test("review rejects a trailing-command PR number before invoking needlefish", () => {
+	const result = runReview("1; touch pwned");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+	assert.equal(result.pwned, false);
+});
+
+test("review rejects an empty PR number before invoking needlefish", () => {
+	const result = runReview("");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+});
+
+test("review rejects command substitution $(touch pwned) before invoking needlefish", () => {
+	const result = runReview("$(touch pwned)");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+	assert.equal(result.pwned, false);
+});
+
+test("review rejects backtick command substitution before invoking needlefish", () => {
+	const result = runReview("`touch pwned`");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+	assert.equal(result.pwned, false);
+});
+
+test("review rejects command substitution appended to a numeric PR number before invoking needlefish", () => {
+	const result = runReview("1$(touch pwned)");
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+	assert.equal(result.pwned, false);
+});
+
+test("review rejects a quote-breaking PR number before invoking needlefish", () => {
+	const result = runReview(`1" ; touch pwned ; "`);
+
+	assert.notEqual(result.status, 0);
+	assert.equal(result.argvLog, "");
+	assert.equal(result.pwned, false);
+});


### PR DESCRIPTION
Closes #50.

## Problem

`.github/workflows/review.yml` interpolated a workflow input expression **directly into Bash source**:

```bash
args=(--github --pr "${{ inputs.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}")
```

Actions substitutes expressions *before* Bash parses the script, so the value becomes part of the program. `workflow_call` declares `pr_number` as `type: string`, `workflow_dispatch` inputs are free-form, and every other value in that same step already went through `env:` — this line was the lone outlier.

## What was actually exploitable

I simulated the old line by substituting each payload into `args=(--github --pr "<VALUE>")` before bash parsed it, which is what Actions does:

| payload | old behavior |
|---|---|
| `1; touch pwned` | one literal argument `<1; touch pwned>` — **not exploitable** (it sits inside the quotes) |
| `1" ; touch pwned ; "` | array-assignment **syntax error** — denial of service, not execution |
| `$(touch pwned)` | **EXECUTED — `pwned` created.** Double quotes do not stop command substitution. **This was the real hole.** |

Worth stating plainly because the obvious-looking `;` payload is the one that *doesn't* work; the class that matters is command substitution.

## Change

- `PR_NUM` moves into the step's `env:`, mirroring the existing `Resolve PR refs` pattern.
- `args=(--github --pr "$PR_NUM")` — quoted expansion of an env var; the value never enters the program text.
- Validation before any GitHub mutation:
  ```bash
  if [[ ! "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
    echo "PR number must be a positive integer, received '$PR_NUM'." >&2
    exit 1
  fi
  ```

Triggers, permissions, `runs-on`, concurrency, `if:` conditions, and the runner/model/timeout arg construction are untouched.

## Verification

`scripts/review-workflow-pr-number.test.mjs` extracts the **live** `Needlefish review` `run:` block from the YAML (so it cannot drift), stubs `$NEEDLEFISH_BIN` to log argv, and covers:

| payload | class | asserted |
|---|---|---|
| `42` | valid | exit 0, `--pr 42` |
| `0`, `-1`, `abc`, `""` | malformed | non-zero, needlefish never invoked |
| `1; touch pwned` | trailing command (not exploitable) | rejected, no `pwned` |
| `$(touch pwned)` | **command substitution (was RCE)** | rejected, no `pwned` |
| `` `touch pwned` `` | **command substitution (was RCE)** | rejected, no `pwned` |
| `1$(touch pwned)` | **substitution after a valid number** | rejected, no `pwned` |
| `1" ; touch pwned ; "` | quote break (was DoS) | rejected, no `pwned` |

Plus the structural assertion that matters most: `assert.doesNotMatch(script, /\$\{\{/)` — the run block contains **no** Actions expression at all.

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 11 / fail 0` |
| remove the validation block | `pass 2 / fail 9` ✅ |
| put `${{ }}` back in the run block | `pass 9 / fail 2` ✅ |
| restored | `pass 11 / fail 0` |

YAML parses (`yaml.safe_load`) ✅ · `pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **545 pass / 0 fail** (exit 0).

## Risk / not verified

- Not exercised against a live Actions run; the tests execute the extracted script under local bash, which matches how Actions runs it but is not the same environment.
- Validation is defense in depth — the `env:` indirection is the structural fix. A comment in the test file records this so the indirection is not later "simplified" away as cosmetic.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, exploitability measurement, mutation testing — caught that the first round's "injection payload" was not actually exploitable and sent it back for the real command-substitution class)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI, one corrective round)