### PR TITLE
fix(ci): gate @needlefish commands on effective repository permission

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -19,13 +19,55 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.issue.pull_request &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       startsWith(github.event.comment.body, '@needlefish ')
     outputs:
       command: ${{ steps.cmd.outputs.command }}
       finding: ${{ steps.cmd.outputs.finding }}
     steps:
+      - name: Check repository permission
+        id: auth
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          echo "allowed=false" >> "$GITHUB_OUTPUT"
+          : "${REPO:?REPO is required}"
+          : "${COMMENTER:?COMMENTER is required}"
+
+          payload="$(gh api "repos/${REPO}/collaborators/${COMMENTER}/permission")" || {
+            echo "Failed to look up repository permission for the commenter" >&2
+            exit 1
+          }
+
+          # Effective access: .permission maps maintain→write and triage→read.
+          # Allow admin/maintain/write on either field; everything else denies.
+          role="$(printf '%s\n' "$payload" | node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync(0, "utf8")); if (typeof data.role_name === "string") process.stdout.write(data.role_name);')" || {
+            echo "Invalid permission payload" >&2
+            exit 1
+          }
+          perm="$(printf '%s\n' "$payload" | node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync(0, "utf8")); if (typeof data.permission === "string") process.stdout.write(data.permission);')" || {
+            echo "Invalid permission payload" >&2
+            exit 1
+          }
+
+          allowed=false
+          case "$role" in
+            admin|maintain|write) allowed=true ;;
+          esac
+          case "$perm" in
+            admin|maintain|write) allowed=true ;;
+          esac
+
+          if [ "$allowed" != true ]; then
+            echo "Denied: commenter lacks write permission on this repository" >&2
+            exit 1
+          fi
+
+          echo "allowed=true" >> "$GITHUB_OUTPUT"
       - name: Parse command
+        if: steps.auth.outputs.allowed == 'true'
         id: cmd
         env:
           BODY: ${{ github.event.comment.body }}
@@ -47,13 +89,13 @@ jobs:
             echo "finding=$finding"
           } >> "$GITHUB_OUTPUT"
       - name: Acknowledge
-        if: steps.cmd.outputs.command != ''
+        if: steps.auth.outputs.allowed == 'true' && steps.cmd.outputs.command != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api -X POST "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
       - name: Dispatch recheck
-        if: steps.cmd.outputs.command == 'recheck'
+        if: steps.auth.outputs.allowed == 'true' && steps.cmd.outputs.command == 'recheck'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ in place (fresh / still-open / resolved) instead of stacking new ones.
 
 Cost: 2 model calls per review on small PRs (~56s at the workflow default,
 `gpt-5.6-terra` at `high` effort), 1 map + N deep calls + 1 critic on large ones. Docs-only PRs and
-unchanged heads skip the model entirely. Maintainers can comment
-`@needlefish recheck` or `@needlefish explain <finding>` on the PR.
+unchanged heads skip the model entirely. Maintainers with write access to
+this repository can comment `@needlefish recheck` or
+`@needlefish explain <finding>` on the PR.
 
 ## Benchmarks
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -91,7 +91,7 @@ fresh／still-open／resolved，不會不斷堆疊新 review。
 
 小型 PR 每次審查使用 2 次模型呼叫（workflow 預設 `gpt-5.6-terra` @ `high`，約 56 秒）；大型 PR 使用
 1 次 map、N 次 deep（預設並行數 3）及 1 次 critic。純文件 PR 與未變更的
-head 會跳過模型。維護者可以在 PR 留言
+head 會跳過模型。對此儲存庫具有寫入權限的維護者可以在 PR 留言
 `@needlefish recheck` 或 `@needlefish explain <finding>`。
 
 ## Benchmarks

--- a/scripts/commands-workflow-auth.test.mjs
+++ b/scripts/commands-workflow-auth.test.mjs
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const workflow = readFileSync(".github/workflows/commands.yml", "utf8");
+
+function workflowScript(stepName) {
+	const escapedName = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const step = workflow.match(
+		new RegExp(`      - name: ${escapedName}\\n([\\s\\S]*?)(?=\\n      - name:|$)`),
+	);
+	assert.ok(step, `${stepName} step must exist`);
+	const runBlock = step[1].match(/        run: \|\n([\s\S]*)/);
+	assert.ok(runBlock, `${stepName} must have a run block`);
+	return runBlock[1]
+		.split("\n")
+		.map((line) => line.replace(/^          /, ""))
+		.join("\n");
+}
+
+const script = workflowScript("Check repository permission");
+
+const ROLE_TO_PERMISSION = {
+	admin: "admin",
+	maintain: "write",
+	write: "write",
+	triage: "read",
+	read: "read",
+	none: "none",
+};
+
+function lastOutput(text, key) {
+	let value = "";
+	for (const line of text.split("\n")) {
+		if (line.startsWith(`${key}=`)) value = line.slice(key.length + 1);
+	}
+	return value;
+}
+
+function runGate({
+	payload,
+	apiFailure = false,
+	commenter = "alice",
+	repo = "acme/widgets",
+} = {}) {
+	const root = mkdtempSync(join(tmpdir(), "needlefish-commands-auth-"));
+	const fakeBin = join(root, "fake-bin");
+	const githubOutput = join(root, "github-output");
+	const ghLog = join(root, "gh.log");
+	mkdirSync(fakeBin);
+	writeFileSync(githubOutput, "");
+	writeFileSync(
+		join(fakeBin, "gh"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$GH_LOG"
+if [ "\${GH_API_FAIL:-}" = "1" ]; then
+  echo "gh api failed" >&2
+  exit 1
+fi
+printf '%s\\n' "\$GH_PAYLOAD"
+`,
+	);
+	chmodSync(join(fakeBin, "gh"), 0o755);
+
+	const result = spawnSync("bash", ["-c", script], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			COMMENTER: commenter,
+			GH_API_FAIL: apiFailure ? "1" : "",
+			GH_LOG: ghLog,
+			GH_PAYLOAD: payload ?? "",
+			GH_TOKEN: "test-token",
+			GITHUB_OUTPUT: githubOutput,
+			PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+			REPO: repo,
+		},
+	});
+	const output = {
+		...result,
+		ghLog: existsSync(ghLog) ? readFileSync(ghLog, "utf8") : "",
+		githubOutput: existsSync(githubOutput)
+			? readFileSync(githubOutput, "utf8")
+			: "",
+	};
+	rmSync(root, { recursive: true, force: true });
+	return output;
+}
+
+function payloadFor(role, permission = ROLE_TO_PERMISSION[role]) {
+	const body = { permission };
+	if (role !== undefined) body.role_name = role;
+	return JSON.stringify(body);
+}
+
+test("cheap prefilter requires a PR comment with the command prefix", () => {
+	const parseJob = workflow.match(/\n  parse:\n([\s\S]*?)\n  explain:/);
+	assert.ok(parseJob, "parse job must exist");
+	assert.match(parseJob[1], /github\.event\.issue\.pull_request/);
+	assert.match(
+		parseJob[1],
+		/startsWith\(github\.event\.comment\.body, '@needlefish '\)/,
+	);
+	assert.doesNotMatch(parseJob[1], /author_association/);
+});
+
+test("permission lookup is on ubuntu-latest before any side effect or self-hosted work", () => {
+	const parseIndex = workflow.indexOf("\n  parse:");
+	const explainIndex = workflow.indexOf("\n  explain:");
+	const authIndex = workflow.indexOf(
+		"      - name: Check repository permission",
+	);
+	const parseStepIndex = workflow.indexOf("      - name: Parse command");
+	const ackIndex = workflow.indexOf("      - name: Acknowledge");
+	const dispatchIndex = workflow.indexOf("      - name: Dispatch recheck");
+	const selfHostedIndex = workflow.indexOf("runs-on: self-hosted");
+
+	assert.ok(parseIndex !== -1 && parseIndex < authIndex);
+	assert.ok(authIndex < parseStepIndex);
+	assert.ok(parseStepIndex < ackIndex);
+	assert.ok(ackIndex < dispatchIndex);
+	assert.ok(dispatchIndex < explainIndex);
+	assert.ok(selfHostedIndex > explainIndex);
+	assert.match(
+		workflow.slice(parseIndex, explainIndex),
+		/runs-on: ubuntu-latest/,
+	);
+	assert.doesNotMatch(
+		workflow.slice(parseIndex, explainIndex),
+		/self-hosted/,
+	);
+});
+
+test("acknowledgement and dispatch require the permission gate", () => {
+	assert.match(
+		workflow,
+		/      - name: Parse command\n        if: steps\.auth\.outputs\.allowed == 'true'$/m,
+	);
+	assert.match(
+		workflow,
+		/      - name: Acknowledge\n        if: steps\.auth\.outputs\.allowed == 'true' && steps\.cmd\.outputs\.command != ''$/m,
+	);
+	assert.match(
+		workflow,
+		/      - name: Dispatch recheck\n        if: steps\.auth\.outputs\.allowed == 'true' && steps\.cmd\.outputs\.command == 'recheck'$/m,
+	);
+});
+
+test("command parsing is unchanged", () => {
+	const parseScript = workflowScript("Parse command");
+	assert.match(parseScript, /first_line="\$\{BODY%%\$'\\n'\*\}"/);
+	assert.match(parseScript, /"@needlefish recheck"\)/);
+	assert.match(parseScript, /"@needlefish explain "\*\)/);
+	assert.match(parseScript, /finding="\$\{first_line#@needlefish explain \}"/);
+});
+
+test("workflow permissions are not widened", () => {
+	assert.match(
+		workflow,
+		/^permissions:\n  contents: read\n  pull-requests: write\n  actions: write\n/m,
+	);
+	assert.doesNotMatch(workflow, /administration:|members:|contents: write/);
+});
+
+test("gate script does not use association and only looks up collaborator permission", () => {
+	assert.doesNotMatch(script, /author_association|OWNER|MEMBER|COLLABORATOR/);
+	assert.match(
+		script,
+		/gh api "repos\/\$\{REPO\}\/collaborators\/\$\{COMMENTER\}\/permission"/,
+	);
+	assert.doesNotMatch(script, /reactions|workflow run|-X POST/);
+});
+
+for (const role of ["admin", "maintain", "write"]) {
+	test(`${role} is authorized`, () => {
+		const result = runGate({ payload: payloadFor(role) });
+
+		assert.equal(result.status, 0, result.stderr);
+		assert.equal(lastOutput(result.githubOutput, "allowed"), "true");
+		assert.match(
+			result.ghLog,
+			/api repos\/acme\/widgets\/collaborators\/alice\/permission/,
+		);
+		assert.doesNotMatch(result.ghLog, /POST|reactions|workflow run/);
+	});
+}
+
+for (const role of ["triage", "read", "none"]) {
+	test(`${role} is denied`, () => {
+		const result = runGate({ payload: payloadFor(role) });
+
+		assert.notEqual(result.status, 0);
+		assert.notEqual(lastOutput(result.githubOutput, "allowed"), "true");
+		assert.match(result.stderr, /Denied: commenter lacks write permission/);
+		assert.match(
+			result.ghLog,
+			/api repos\/acme\/widgets\/collaborators\/alice\/permission/,
+		);
+		assert.doesNotMatch(result.ghLog, /POST|reactions|workflow run/);
+	});
+}
+
+test("legacy payload without role_name allows write and denies read", () => {
+	const allowed = runGate({
+		payload: JSON.stringify({ permission: "write" }),
+	});
+	assert.equal(allowed.status, 0, allowed.stderr);
+	assert.equal(lastOutput(allowed.githubOutput, "allowed"), "true");
+
+	const denied = runGate({
+		payload: JSON.stringify({ permission: "read" }),
+	});
+	assert.notEqual(denied.status, 0);
+	assert.notEqual(lastOutput(denied.githubOutput, "allowed"), "true");
+});
+
+test("API lookup failure is denied fail-closed", () => {
+	const result = runGate({
+		payload: payloadFor("admin"),
+		apiFailure: true,
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.notEqual(lastOutput(result.githubOutput, "allowed"), "true");
+	assert.match(result.stderr, /Failed to look up repository permission/);
+});
+
+test("malformed permission payload is denied fail-closed", () => {
+	const result = runGate({ payload: "not-json" });
+
+	assert.notEqual(result.status, 0);
+	assert.notEqual(lastOutput(result.githubOutput, "allowed"), "true");
+	assert.match(result.stderr, /Invalid permission payload/);
+});


### PR DESCRIPTION
Closes #51.

## Problem

`commands.yml` line 1 documents the workflow as **"(maintainers only)"**. Its gate authorized far more than that:

```yaml
contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
```

`author_association` does not encode repository permission:
- **`COLLABORATOR`** covers anyone invited to the repo — including **read** and **triage** collaborators.
- **`MEMBER`** covers any member of the owning org, regardless of access to *this* repository.

Those users could dispatch `review.yml` and trigger the **self-hosted** `explain` job — model spend and code execution on the production review runner.

## Change

Replace the association test with a lookup of **effective repository permission**:

```
GET /repos/{owner}/{repo}/collaborators/{username}/permission
```

Allowed: `admin`, `maintain`, `write`. Everything else denies.

**Both `.role_name` and `.permission` are checked**, because each alone misjudges a real case:
- `.role_name` is the only field that actually names `maintain` / `triage`.
- `.permission` is always present, and a **custom write role** surfaces as `.permission: write` with a non-standard `.role_name` — checking only `.role_name` against the three standard names would deny it.

**Fail-closed throughout.** The step writes `allowed=false` to `GITHUB_OUTPUT` *before* the lookup and `allowed=true` only after an explicit allow, so an API error, malformed payload, or unknown role denies. The lookup is the **first** step, on `ubuntu-latest`, before the eyes reaction, the `workflow_dispatch`, and any self-hosted work. `explain` is reachable only through `needs: parse`, which a failed gate skips.

Command parsing (the strict `@needlefish recheck` / `@needlefish explain ` prefix match) is untouched, and `permissions:` was **not** widened.

## Verification

`scripts/commands-workflow-auth.test.mjs` extracts the live gate script from the YAML and stubs `gh` with realistic payloads:

| role | `.permission` | result |
|---|---|---|
| `admin` | `admin` | ✅ allow |
| `maintain` | `write` | ✅ allow |
| `write` | `write` | ✅ allow |
| `triage` | `read` | ✅ **deny** |
| `read` | `read` | ✅ **deny** |
| `none` | `none` | ✅ **deny** |
| API failure (`gh` exits 1) | — | ✅ **deny** |
| malformed JSON | — | ✅ **deny** |
| legacy payload, `.permission: write` only | | ✅ allow |
| legacy payload, `.permission: read` only | | ✅ deny |

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 15 / fail 0` |
| allow `read`/`triage` | `pass 12 / fail 3` ✅ |
| API failure defaults to allow | `pass 14 / fail 1` ✅ |
| drop the gate on `Dispatch recheck` | `pass 14 / fail 1` ✅ |
| restored | `pass 15 / fail 0` |

YAML parses ✅ · `pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **549 pass / 0 fail** (exit 0).

> **Correction to an earlier version of this description.** The first full-suite run on this branch was **548 pass / 1 fail**, not clean, and this body originally claimed otherwise. The failure was `process SIGTERM stops and kills the runner group without deleting its live tree` (`src/shared/temp-lifecycle.test.ts:414`, `Missing expected exception (isMissingProcess)`) — a **pre-existing, load-sensitive flake**, not something this diff can cause: the change touches only `.github/workflows/commands.yml` and a new `scripts/*.test.mjs`, no TypeScript. Characterized afterwards: 3/3 clean runs of that file on this branch, 3/3 clean on `main`, and a clean full-suite rerun at 549/0 exit 0. The same flake appeared twice more during this batch of work. Recording it rather than burying it.

## Trade-off, stated explicitly

`author_association` is now **gone from the job `if:`**, so any PR comment starting with `@needlefish ` starts a hosted job that makes one API call. That is a small widening of who can *start* a free hosted job, traded for a single source of authorization truth rather than two overlapping concepts. The self-hosted runner remains unreachable without write access.

If you would rather keep the association check as a cheap prefilter *in addition to* the permission lookup, that is a one-line change — say the word.

## Risk / not verified

- **Not exercised against the live API.** If `GITHUB_TOKEN` turns out to lack the scope for the collaborators/permission endpoint in production, the gate will **deny everyone including maintainers** — fail-closed, visible immediately, not a silent widen. The endpoint is documented as *Metadata: read*, which `GITHUB_TOKEN` receives whenever any repository permission is granted, and this workflow already has `contents: read`. If a 403 does occur, read the `X-Accepted-GitHub-Permissions` header before adding any scope.
- Tests run the extracted script under local bash with a stubbed `gh`, which matches how Actions runs it but is not the same environment.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, mutation testing, job-gating trace)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)