### PR TITLE
fix(ci): stop persisting checkout credentials before model runs

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           fetch-depth: 0
           path: target
+          persist-credentials: false
       - name: Needlefish explain
         working-directory: target
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,4 +13,6 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: scripts/deploy-ubuntu.sh

--- a/.github/workflows/hosted-review.yml
+++ b/.github/workflows/hosted-review.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: frankekn/needlefish@v0
         with:
           pr_number: ${{ inputs.pr }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Persist credentials (checkout default): "Roll floating major tag" runs
+      # `git push -f origin "$major"` and needs the stored https extraheader.
+      # GH_TOKEN is passed only to the later `gh release create` step.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -248,6 +248,7 @@ jobs:
           ref: ${{ steps.refs.outputs.head }}
           fetch-depth: 0
           path: target
+          persist-credentials: false
 
       - name: Needlefish review
         if: steps.refs.outputs.skip != 'true'

--- a/.github/workflows/weekly-eval.yml
+++ b/.github/workflows/weekly-eval.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run full eval
         env:
           # pi routes through the local CLIProxyAPI (ccp) on ubuntu-needlefish.
@@ -75,7 +76,15 @@ jobs:
           git config user.email "actions@github.com"
           git add eval/results/weekly
           git commit -m "chore(eval): weekly regression report $(date -u +%Y-%m-%d)" || exit 0
-          git pull --rebase origin main && git push origin HEAD:main
+          # Checkout did not persist credentials, so the model eval cannot read
+          # the job token from .git/config. Authenticate via a credential helper
+          # that reads GH_TOKEN from the environment (never argv).
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
+              pull --rebase origin main && \
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
+              push origin HEAD:main
       - name: Dispatch deploy workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "eslint": "^10.6.0",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
-    "typescript-eslint": "^8.63.0"
+    "typescript-eslint": "^8.63.0",
+    "yaml": "2.9.0"
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       typescript-eslint:
         specifier: ^8.63.0
         version: 8.63.0(eslint@10.6.0)(typescript@5.9.3)
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -589,6 +592,11 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1102,5 +1110,7 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -12,10 +13,12 @@ import test from "node:test";
 //
 // What it guards: workflowFiles() decides which files get scanned at all, and
 // assertEveryMentionRecognized() can only speak about files that are in that set.
-// If a workflow is renamed to an unscanned extension, or checkouts migrate into a
-// composite action under .github/actions/*/action.yml (a path this scanner does not
-// read), no mention is left to flag and the scan goes quiet. The count falling
-// below the floor is the only signal of that coverage loss.
+// If checkouts leave that set — a workflow renamed to a non-YAML extension, or moved
+// to a path outside .github/ — no mention is left to flag and the scan goes quiet.
+// The count falling below the floor is the only signal of that coverage loss.
+// (Note this floor does NOT catch a checkout *added* somewhere unscanned: the six
+// here stay intact and the floor stays green. Only widening workflowFiles() fixes
+// that, which is why it recurses rather than listing directories.)
 //
 // Why not equality: a checkout being *added* is already fully policed — it must be
 // recognized (assertEveryMentionRecognized) and must set persist-credentials: false
@@ -178,15 +181,30 @@ function assertCheckoutPolicy(checkouts, allowlist) {
 	);
 }
 
-function workflowFiles() {
-	const dir = ".github/workflows";
-	return [
-		...readdirSync(dir)
-			.filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
-			.map((name) => join(dir, name))
-			.sort(),
-		"action.yml",
-	];
+function yamlFilesUnder(dir) {
+	const files = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+		a.name.localeCompare(b.name),
+	)) {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...yamlFilesUnder(path));
+		} else if (entry.isFile() && /\.ya?ml$/.test(entry.name)) {
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+// All YAML under .github/, not just .github/workflows/. A composite action at
+// .github/actions/<name>/action.yml runs its own steps, including its own
+// actions/checkout, and a file the scanner never opens is a file it cannot police —
+// the same fail-open as unrecognized syntax, one directory over. Recursing on the
+// whole .github tree rather than allowlisting action.yml means a new location does
+// not need this list updated to be covered. Plus the repo-root action.yml, the
+// published action surface, which lives outside .github/.
+function workflowFiles(root = ".") {
+	return [...yamlFilesUnder(join(root, ".github")), join(root, "action.yml")];
 }
 
 test("every actions/checkout sets persist-credentials: false or is allowlisted", () => {
@@ -314,6 +332,51 @@ test("a commented-out checkout is not treated as an unrecognized step", () => {
 	const checkouts = collectCheckouts(yaml, "example.yml");
 	assert.equal(checkouts.length, 1);
 	assert.equal(checkouts[0].line, 5);
+});
+
+test("a composite action's checkout is scanned, not just .github/workflows", () => {
+	// The floor cannot see this one: adding an unprotected checkout under
+	// .github/actions leaves the workflow checkouts intact, so the count stays green.
+	// Only the scan set widening catches it.
+	const root = mkdtempSync(join(tmpdir(), "needlefish-checkout-scan-"));
+	try {
+		mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+		mkdirSync(join(root, ".github", "actions", "setup"), { recursive: true });
+		writeFileSync(join(root, "action.yml"), "name: root\n");
+		writeFileSync(
+			join(root, ".github", "workflows", "review.yml"),
+			[
+				"jobs:",
+				"  review:",
+				"    steps:",
+				"      - uses: actions/checkout@v4",
+				"        with:",
+				"          persist-credentials: false",
+			].join("\n"),
+		);
+		writeFileSync(
+			join(root, ".github", "actions", "setup", "action.yml"),
+			["runs:", "  using: composite", "  steps:", "    - uses: actions/checkout@v4"].join(
+				"\n",
+			),
+		);
+
+		const files = workflowFiles(root);
+		assert.ok(
+			files.includes(join(root, ".github", "actions", "setup", "action.yml")),
+			`composite action metadata must be in the scan set: ${files.join(", ")}`,
+		);
+
+		const checkouts = files.flatMap((file) =>
+			collectCheckouts(readFileSync(file, "utf8"), file),
+		);
+		assert.throws(
+			() => assertCheckoutPolicy(checkouts, []),
+			/actions[/\\]setup[/\\]action\.yml:4 .*must set persist-credentials: false or be allowlisted/,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("weekly-eval git push authenticates with GH_TOKEN instead of persisted checkout credentials", () => {

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -66,9 +66,22 @@ const PERSISTED_CREDENTIAL_ALLOWLIST = [
 ];
 
 const CHECKOUT_ACTION = /^actions\/checkout(?:@|$)/;
-// `uses: ./path` runs a composite action whose metadata lives at path/action.yml,
-// resolved from the repository root. Such an action can run its own checkout.
+
+// The three reference forms GitHub documents for `uses:`. A resolved value that is
+// none of them fails the scan.
+//
+// This is a CLASSIFICATION guard, and it is not the spelling guard that parsing
+// replaced. Parsing settles how a value is *written*; it says nothing about what the
+// resulting string *means*. Dropping the old regex guard in the parser rewrite lost
+// the second half by accident: an unclassifiable `uses:` fell through both branches
+// and vanished, so a composite action referenced by an invalid form was never
+// followed and its checkout was never policed. Found by driving `uses: $/tools/prepare`
+// (a form that does not exist in Actions) through the scanner: six protected
+// checkouts plus one unprotected checkout behind the bad reference, and the policy
+// passed. Unknown must mean stop, not skip.
 const LOCAL_ACTION = /^\.{1,2}\//;
+const EXTERNAL_ACTION = /^[\w.-]+\/[\w./-]+@[\w./-]+$/;
+const DOCKER_ACTION = /^docker:\/\/\S+$/;
 
 function parseWorkflow(content, file) {
 	const lineCounter = new LineCounter();
@@ -89,6 +102,7 @@ function scanWorkflow(content, file) {
 	const { doc, lineCounter } = parseWorkflow(content, file);
 	const checkouts = [];
 	const localActions = [];
+	const unresolvable = [];
 	// Anchors may be referenced repeatedly and may even recurse. Visiting each
 	// resolved node once terminates; the effect on the count is fail-closed, since a
 	// step reused through N aliases is counted once and can only push the total down
@@ -148,13 +162,14 @@ function scanWorkflow(content, file) {
 		const usesPair = pairsNamed(resolved, "uses")[0];
 		if (usesPair) {
 			const uses = scalarValue(usesPair.value);
-			if (typeof uses === "string") {
-				const ref = uses.trim();
-				if (CHECKOUT_ACTION.test(ref)) {
-					checkouts.push(describe(resolved, usesPair, attached));
-				} else if (LOCAL_ACTION.test(ref)) {
-					localActions.push({ ref, line: lineOf(usesPair.key ?? resolved, lineCounter) });
-				}
+			const ref = typeof uses === "string" ? uses.trim() : "";
+			const line = lineOf(usesPair.key ?? resolved, lineCounter);
+			if (LOCAL_ACTION.test(ref)) {
+				localActions.push({ ref, line });
+			} else if (CHECKOUT_ACTION.test(ref)) {
+				checkouts.push(describe(resolved, usesPair, attached));
+			} else if (!EXTERNAL_ACTION.test(ref) && !DOCKER_ACTION.test(ref)) {
+				unresolvable.push(`${file}:${line}: uses: ${ref === "" ? JSON.stringify(uses) : ref}`);
 			}
 		}
 
@@ -164,6 +179,13 @@ function scanWorkflow(content, file) {
 	};
 
 	visit(doc.contents, "");
+
+	assert.deepEqual(
+		unresolvable,
+		[],
+		`uses: values that are not a documented action reference (owner/repo@ref, ./path, or docker://…), so the scanner cannot tell whether they run a checkout: ${unresolvable.join(" | ")}`,
+	);
+
 	return { checkouts, localActions };
 }
 
@@ -597,6 +619,46 @@ test("local action references are followed transitively", () => {
 		assert.throws(
 			() => assertCheckoutPolicy(checkouts, []),
 			/tools[/\\]inner[/\\]action\.yml:4 /,
+		);
+	});
+});
+
+test("a uses: value that is not a documented reference form fails the scan", () => {
+	// Two separate facts, both worth pinning.
+	//
+	// 1. `$/path` is NOT a GitHub Actions reference form. The documented forms are
+	//    {owner}/{repo}@{ref}, ./path/to/dir, and docker://{image}:{tag}; a bare
+	//    path/to/dir is read as {owner}/{repo} and fails to resolve. So a workflow
+	//    written this way would not run the action at all.
+	// 2. It does not matter. The scan fails on any reference it cannot classify, so
+	//    no bypass of this shape exists whether or not the form is real. That is the
+	//    property under test — unknown means stop, not skip.
+	//
+	// The fixture is the bypass as it was claimed: six compliant checkouts, plus an
+	// unprotected one hidden behind the unclassifiable reference. Before the
+	// classification guard this passed, with tools/prepare never opened.
+	withFixtureRepo((root, write) => {
+		const steps = [];
+		for (let i = 0; i < MINIMUM_CHECKOUT_COUNT; i++) {
+			steps.push(
+				"      - uses: actions/checkout@v4",
+				"        with:",
+				"          persist-credentials: false",
+			);
+		}
+		steps.push("      - uses: $/tools/prepare");
+		write(".github/workflows/review.yml", ["jobs:", "  review:", "    steps:", ...steps]);
+		write("tools/prepare/action.yml", [
+			"runs:",
+			"  using: composite",
+			"  steps:",
+			"    - uses: actions/checkout@v4",
+		]);
+
+		assert.throws(
+			() => scanRepository(root),
+			/review\.yml:22: uses: \$\/tools\/prepare/,
+			"an unclassifiable reference must fail the scan, not be skipped",
 		);
 	});
 });

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -8,10 +8,22 @@ import test from "node:test";
 // step must set persist-credentials: false, or be on the allowlist below
 // with a YAML comment documenting why persisted git auth is required.
 
-// A new actions/checkout is a new place the job token can land on disk. The
-// coverage guard keeps a checkout from vanishing from the scan; this keeps one
-// from appearing without anyone deciding it should.
-const EXPECTED_CHECKOUT_COUNT = 6;
+// A FLOOR, deliberately not an equality — do not "tighten" this to assert.equal.
+//
+// What it guards: workflowFiles() decides which files get scanned at all, and
+// assertEveryMentionRecognized() can only speak about files that are in that set.
+// If a workflow is renamed to an unscanned extension, or checkouts migrate into a
+// composite action under .github/actions/*/action.yml (a path this scanner does not
+// read), no mention is left to flag and the scan goes quiet. The count falling
+// below the floor is the only signal of that coverage loss.
+//
+// Why not equality: a checkout being *added* is already fully policed — it must be
+// recognized (assertEveryMentionRecognized) and must set persist-credentials: false
+// or be allowlisted. Equality adds no security signal over the floor, and it breaks
+// on merge: any concurrently-open PR that legitimately adds a workflow checkout
+// passes its own CI, merges cleanly (different files), and lands a main that fails
+// an equality this branch could not have known to bump.
+const MINIMUM_CHECKOUT_COUNT = 6;
 
 const PERSISTED_CREDENTIAL_ALLOWLIST = [
 	{
@@ -181,10 +193,9 @@ test("every actions/checkout sets persist-credentials: false or is allowlisted",
 	const checkouts = workflowFiles().flatMap((file) =>
 		collectCheckouts(readFileSync(file, "utf8"), file),
 	);
-	assert.equal(
-		checkouts.length,
-		EXPECTED_CHECKOUT_COUNT,
-		`expected exactly ${EXPECTED_CHECKOUT_COUNT} actions/checkout steps, found ${checkouts.length}; bump EXPECTED_CHECKOUT_COUNT deliberately when adding or removing one`,
+	assert.ok(
+		checkouts.length >= MINIMUM_CHECKOUT_COUNT,
+		`expected at least ${MINIMUM_CHECKOUT_COUNT} actions/checkout steps, found ${checkouts.length}; checkouts left the scanned file set, so raise the floor only if they are genuinely gone`,
 	);
 	assertCheckoutPolicy(checkouts, PERSISTED_CREDENTIAL_ALLOWLIST);
 });

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -51,6 +51,75 @@ const CHECKOUT_USES =
 const CHECKOUT_MENTION = /actions\/checkout/g;
 const COMMENT_LINE = /^\s*#/;
 
+// The inverted guard. CHECKOUT_MENTION matches one literal spelling, so every round
+// of review found another way to write the same reference without it:
+// `"actions\/checkout@v4"` (YAML 1.2 solidus escape), `"actions\u002Fcheckout@v4"`,
+// and a double-quoted line continuation splitting the literal across two lines. That
+// tail has no end — \x6f, single quotes, block scalars — so stop enumerating
+// spellings and invert the question. Instead of "does this line name a checkout?",
+// ask "is this `uses:` value one this scanner can read at all?" and reject the file
+// if it is not, checkout or otherwise. Exotic spellings then fail closed without
+// anyone having to predict them.
+//
+// Fail closed on unparseable, NOT on unfamiliar: every form the repo actually uses
+// is accepted. Today that is only `owner/repo@ref`, but local (`./path`) and
+// `docker://` refs are accepted too so adding one does not break the build.
+// A quoted value is fine when it is a plain scalar — closing quote on the same line,
+// no backslash, so nothing can be hiding in an escape.
+//
+// Known false positive: a `uses:` written inside a `run: |` shell block would be
+// read as a step. No such line exists here (all 11 `uses:` lines are real steps or
+// inside `#` comments); if one appears, quote it differently or extend this.
+const USES_LINE = /^(\s*)(?:- )?uses:\s*(.*)$/;
+const PLAIN_ACTION_REF = /^[\w.-]+\/[\w./-]+@[\w./-]+$/;
+const LOCAL_ACTION_REF = /^\.{1,2}\/[\w./-]+$/;
+const DOCKER_ACTION_REF = /^docker:\/\/[\w.:/@-]+$/;
+
+function inspectableUsesValue(raw) {
+	// Strip a trailing YAML comment, but only when it is separated by whitespace —
+	// `#` inside a ref (a docker digest) is not a comment.
+	const value = raw.replace(/\s+#.*$/, "").trim();
+	if (value === "") return null;
+
+	let scalar = value;
+	if (scalar.startsWith('"')) {
+		// The `\\` in this class is deliberately redundant: a backslash is not in any
+		// of the three ref charsets below, so an escaped value is already rejected
+		// there (removing it from here fails no test — checked). It stays as the
+		// explicit statement of intent, so that widening a ref charset later cannot
+		// quietly re-admit \/, \u002F and friends. The closing-quote requirement is
+		// NOT redundant: it is what rejects an end-of-line continuation, whose quote
+		// lands on the next line.
+		if (!/^"[^"\\]*"$/.test(scalar)) return null;
+		scalar = scalar.slice(1, -1);
+	} else if (scalar.startsWith("'")) {
+		if (!/^'[^']*'$/.test(scalar)) return null;
+		scalar = scalar.slice(1, -1);
+	}
+
+	if (PLAIN_ACTION_REF.test(scalar)) return scalar;
+	if (LOCAL_ACTION_REF.test(scalar)) return scalar;
+	if (DOCKER_ACTION_REF.test(scalar)) return scalar;
+	return null;
+}
+
+function assertEveryUsesIsInspectable(lines, file) {
+	const uninspectable = [];
+	lines.forEach((line, index) => {
+		if (COMMENT_LINE.test(line)) return;
+		const match = line.match(USES_LINE);
+		if (!match) return;
+		if (inspectableUsesValue(match[2]) !== null) return;
+		uninspectable.push(`${file}:${index + 1}: ${line.trim()}`);
+	});
+
+	assert.deepEqual(
+		uninspectable,
+		[],
+		`uses: values this scanner cannot resolve, so it cannot prove they are not a checkout (write them as a plain owner/repo@ref): ${uninspectable.join(" | ")}`,
+	);
+}
+
 function indentOf(line) {
 	const match = line.match(/^(\s*)/);
 	return match ? match[1].length : 0;
@@ -139,6 +208,7 @@ function collectCheckouts(content, file) {
 		});
 	}
 	assertEveryMentionRecognized(lines, checkouts, file);
+	assertEveryUsesIsInspectable(lines, file);
 	return checkouts;
 }
 
@@ -332,6 +402,60 @@ test("a commented-out checkout is not treated as an unrecognized step", () => {
 	const checkouts = collectCheckouts(yaml, "example.yml");
 	assert.equal(checkouts.length, 1);
 	assert.equal(checkouts[0].line, 5);
+});
+
+test("a checkout spelled around the literal fails closed", () => {
+	// The three spellings that defeated CHECKOUT_MENTION. All resolve to
+	// actions/checkout@v4 under YAML 1.2; none contains the literal on one line.
+	const spellings = {
+		"solidus escape": '      - uses: "actions\\/checkout@v4"',
+		"unicode escape": '      - uses: "actions\\u002Fcheckout@v4"',
+	};
+	for (const [label, step] of Object.entries(spellings)) {
+		const yaml = ["jobs:", "  a:", "    steps:", step].join("\n");
+		assert.throws(
+			() => collectCheckouts(yaml, "sneaky.yml"),
+			/sneaky\.yml:4: .*cannot resolve|cannot resolve.*sneaky\.yml:4/s,
+			`${label} must be rejected`,
+		);
+	}
+
+	// Line continuation: the closing quote is on the next line, so the value is not a
+	// plain scalar and the reference is split across two lines.
+	const continued = [
+		"jobs:",
+		"  a:",
+		"    steps:",
+		'      - uses: "actions/check\\',
+		'          out@v4"',
+	].join("\n");
+	assert.throws(() => collectCheckouts(continued, "sneaky.yml"), /cannot resolve/);
+});
+
+test("every uses: form the repo relies on stays inspectable", () => {
+	// Guards the other direction: fail closed on unparseable, not on unfamiliar.
+	const yaml = [
+		"jobs:",
+		"  a:",
+		"    steps:",
+		"      - uses: actions/checkout@v4",
+		"        with:",
+		"          persist-credentials: false",
+		"      - uses: actions/setup-node@v4",
+		"      - uses: frankekn/needlefish@v0",
+		"      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
+		"        with:",
+		"          persist-credentials: false",
+		'      - uses: "actions/setup-node@v4"',
+		"      - uses: 'actions/setup-node@v4'",
+		"      - uses: ./.github/actions/setup",
+		"      - uses: owner/repo/sub/dir@main",
+		"      - uses: docker://alpine:3.19",
+		"      # - uses: whatever/nonsense@\\/weird",
+	].join("\n");
+	const checkouts = collectCheckouts(yaml, "legit.yml");
+	assert.equal(checkouts.length, 2, "both plain checkouts stay recognized");
+	assertCheckoutPolicy(checkouts, []);
 });
 
 test("a YAML alias cannot smuggle a checkout past the scanner", () => {

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -6,6 +6,7 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
+	statSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -65,7 +66,12 @@ const PERSISTED_CREDENTIAL_ALLOWLIST = [
 	},
 ];
 
-const CHECKOUT_ACTION = /^actions\/checkout(?:@|$)/;
+// Case-insensitive: GitHub resolves owner/repo without regard to case, so
+// `uses: Actions/Checkout@v4` runs this very action — `git ls-remote` for
+// Actions/Checkout and actions/checkout return the same SHA for v4. A case-sensitive
+// matcher classified the mixed-case spelling as an ordinary third-party action and
+// skipped it, leaving a real checkout unpoliced.
+const CHECKOUT_ACTION = /^actions\/checkout(?:@|$)/i;
 
 // The three reference forms GitHub documents for `uses:`. A resolved value that is
 // none of them fails the scan.
@@ -92,6 +98,12 @@ function parseWorkflow(content, file) {
 		assert.fail(`${file}:${line}: workflow YAML does not parse cleanly: ${problem.message}`);
 	}
 	return { doc, lineCounter };
+}
+
+// Returns the path when it is a regular file, otherwise undefined, so callers can
+// chain candidates with ?? and never confuse a directory for a file.
+function isFile(path) {
+	return existsSync(path) && statSync(path).isFile() ? path : undefined;
 }
 
 function lineOf(node, lineCounter) {
@@ -301,22 +313,18 @@ function scanRepository(root = ".") {
 			// Two different things share the `uses: ./…` spelling. A step-level
 			// reference names a DIRECTORY holding action.yml; a job-level reusable
 			// workflow call names the workflow FILE itself
-			// (`uses: ./.github/workflows/build.yml`). Demanding action.yml under the
-			// latter would fail the scan on a legitimate workflow — failing on
-			// unfamiliar, which this scanner must not do. Distinguish by extension:
-			// GitHub requires a reusable workflow to be a .yml/.yaml file, and an
-			// action directory cannot be named that way and still be resolvable.
-			const isReusableWorkflow = /\.ya?ml$/.test(ref);
-			const resolved = isReusableWorkflow
-				? [target].find((path) => existsSync(path))
-				: [join(target, "action.yml"), join(target, "action.yaml")].find((path) =>
-						existsSync(path),
-					);
+			// (`uses: ./.github/workflows/build.yml`). Decide by what is actually on
+			// disk, never by the name: a directory may legally be called `thing.yml`,
+			// and inferring "workflow" from the suffix would queue that directory and
+			// then read it as a file. Demanding action.yml under a reusable workflow
+			// call is equally wrong — that fails the scan on a legitimate workflow.
+			const resolved =
+				isFile(target) ??
+				isFile(join(target, "action.yml")) ??
+				isFile(join(target, "action.yaml"));
 			assert.ok(
 				resolved,
-				isReusableWorkflow
-					? `${file}:${line}: uses: ${ref} but that workflow file does not exist, so its steps cannot be inspected`
-					: `${file}:${line}: uses: ${ref} but no action.yml or action.yaml exists there, so its steps cannot be inspected`,
+				`${file}:${line}: uses: ${ref} resolves to neither a workflow file nor a directory containing action.yml or action.yaml, so its steps cannot be inspected`,
 			);
 			queue.push(resolved);
 		}
@@ -691,6 +699,51 @@ test("a uses: value that is not a documented reference form fails the scan", () 
 	});
 });
 
+test("a mixed-case checkout reference is still a checkout", () => {
+	// GitHub resolves owner/repo case-insensitively: `git ls-remote` for
+	// Actions/Checkout and actions/checkout both give v4 = 11d5960a…, the same repo.
+	// So this runs the real checkout action and must be policed like any other.
+	for (const ref of ["Actions/Checkout@v4", "ACTIONS/CHECKOUT@v4", "actions/Checkout@v4"]) {
+		const yaml = ["jobs:", "  a:", "    steps:", `      - uses: ${ref}`].join("\n");
+		const checkouts = collectCheckouts(yaml, "case.yml");
+		assert.equal(checkouts.length, 1, `${ref} must be recognized as a checkout`);
+		assert.throws(
+			() => assertCheckoutPolicy(checkouts, []),
+			/must set persist-credentials: false or be allowlisted/,
+			`${ref} must fail the policy`,
+		);
+	}
+});
+
+test("a local action in a directory named like a workflow is resolved by what is on disk", () => {
+	// A directory may legally be called `thing.yml`. Inferring "reusable workflow"
+	// from the suffix would queue the directory and then read it as a file.
+	withFixtureRepo((root, write) => {
+		write(".github/workflows/review.yml", [
+			"jobs:",
+			"  review:",
+			"    steps:",
+			"      - uses: ./tools/thing.yml",
+		]);
+		write("tools/thing.yml/action.yml", [
+			"runs:",
+			"  using: composite",
+			"  steps:",
+			"    - uses: actions/checkout@v4",
+		]);
+
+		const { checkouts, scanned } = scanRepository(root);
+		assert.ok(
+			scanned.includes(join(root, "tools", "thing.yml", "action.yml")),
+			`the action.yml inside the .yml-named directory must be scanned: ${scanned.join(", ")}`,
+		);
+		assert.throws(
+			() => assertCheckoutPolicy(checkouts, []),
+			/thing\.yml[/\\]action\.yml:4 .*must set persist-credentials: false or be allowlisted/,
+		);
+	});
+});
+
 test("persist-credentials must be a literal true or false", () => {
 	// `yes` is the string "yes" under YAML 1.2 but a boolean under YAML 1.1, and
 	// GitHub's parser is the 1.1-flavoured one. Reading "not true, so safe" here would
@@ -762,7 +815,7 @@ test("a reusable workflow call pointing at a missing file fails the scan", () =>
 		]);
 		assert.throws(
 			() => scanRepository(root),
-			/caller\.yml:3: uses: \.\/\.github\/workflows\/absent\.yml but that workflow file does not exist/,
+			/caller\.yml:3: uses: \.\/\.github\/workflows\/absent\.yml resolves to neither a workflow file nor a directory containing action\.yml/,
 		);
 	});
 });
@@ -777,7 +830,7 @@ test("a local action reference with no metadata file fails the scan", () => {
 		]);
 		assert.throws(
 			() => scanRepository(root),
-			/review\.yml:4: uses: \.\/tools\/missing but no action\.yml or action\.yaml exists there/,
+			/review\.yml:4: uses: \.\/tools\/missing resolves to neither a workflow file nor a directory containing action\.yml/,
 		);
 	});
 });

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -3,29 +3,49 @@ import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { isAlias, isMap, isScalar, isSeq, LineCounter, parseDocument } from "yaml";
 
-// Line/regex scanner, not a YAML parser: Node has no YAML built-in and this
-// repo's workflow tests stay dependency-free. Each `uses: actions/checkout`
-// step must set persist-credentials: false, or be on the allowlist below
-// with a YAML comment documenting why persisted git auth is required.
+// Parses the workflow YAML; it does not pattern-match the source text. Each
+// actions/checkout step must set persist-credentials: false, or be on the allowlist
+// below with a YAML comment documenting why persisted git auth is required.
+//
+// This was a line/regex scanner through five rounds of review, and each round found
+// another way to spell the same reference past it: a flow mapping (`- { uses: ... }`),
+// "actions\/checkout@v4" (YAML 1.2 solidus escape), "actions/checkout@v4", a
+// double-quoted line continuation splitting the literal across two lines, anchors and
+// aliases, and finally a quoted key combined with an escaped value, which evaded the
+// key match and the value match at once. Every fix closed one syntactic axis and
+// exposed the next, because a regex over YAML has an unbounded number of them.
+//
+// Parsing ends that: the parser resolves quoting, escapes, flow vs block style,
+// anchors and block scalars before this file sees a single value, so an obfuscated
+// reference arrives as the same string as a plain one and is policed identically.
+// What matters is what the step RESOLVES to, which is also exactly what Actions runs.
+//
+// Why this scanner exists at all: persist-credentials: true writes the job token into
+// the workspace's .git/config. That is a filesystem channel, and the runner env
+// allowlist (buildRunnerEnv in src/shared/codex.ts, which builds from {} and never
+// copies GITHUB_TOKEN/GH_TOKEN) does not cover it. Model CLIs run against these trees
+// without a filesystem sandbox (AGENTS.md). This guards a different door from the env
+// allowlist, not the same one twice.
 
 // A FLOOR, deliberately not an equality — do not "tighten" this to assert.equal.
 //
-// What it guards: workflowFiles() decides which files get scanned at all, and
-// assertEveryMentionRecognized() can only speak about files that are in that set.
-// If checkouts leave that set — a workflow renamed to a non-YAML extension, or moved
-// to a path outside .github/ — no mention is left to flag and the scan goes quiet.
-// The count falling below the floor is the only signal of that coverage loss.
-// (Note this floor does NOT catch a checkout *added* somewhere unscanned: the six
-// here stay intact and the floor stays green. Only widening workflowFiles() fixes
-// that, which is why it recurses rather than listing directories.)
+// What it guards: workflowFiles() decides which files get scanned at all, and the
+// parse-based scan can only speak about files that are in that set. If checkouts
+// leave that set — a workflow renamed to a non-YAML extension, or moved to a path
+// outside .github/ — nothing remains to parse and the scan goes quiet. The count
+// falling below the floor is the only signal of that coverage loss. (It does NOT
+// catch a checkout *added* somewhere unscanned: the six here stay intact and the
+// floor stays green. Only widening workflowFiles() fixes that, which is why it
+// recurses rather than listing directories.)
 //
-// Why not equality: a checkout being *added* is already fully policed — it must be
-// recognized (assertEveryMentionRecognized) and must set persist-credentials: false
-// or be allowlisted. Equality adds no security signal over the floor, and it breaks
-// on merge: any concurrently-open PR that legitimately adds a workflow checkout
-// passes its own CI, merges cleanly (different files), and lands a main that fails
-// an equality this branch could not have known to bump.
+// Why not equality: a checkout being *added* is already fully policed — it is
+// resolved by the parser and must set persist-credentials: false or be allowlisted.
+// Equality adds no security signal over the floor, and it breaks on merge: any
+// concurrently-open PR that legitimately adds a workflow checkout passes its own CI,
+// merges cleanly (different files), and lands a main that fails an equality this
+// branch could not have known to bump.
 const MINIMUM_CHECKOUT_COUNT = 6;
 
 const PERSISTED_CREDENTIAL_ALLOWLIST = [
@@ -36,179 +56,96 @@ const PERSISTED_CREDENTIAL_ALLOWLIST = [
 	},
 ];
 
-const CHECKOUT_USES =
-	/^(\s*)(?:- )?uses:\s*['"]?actions\/checkout@\S+/;
+const CHECKOUT_ACTION = /^actions\/checkout(?:@|$)/;
 
-// CHECKOUT_USES only understands block-style steps. `- { uses: actions/checkout@v4 }`
-// is valid YAML that Actions runs happily, but it never matches — so without the
-// coverage guard below the step would drop out of collectCheckouts() and the policy
-// assertions would never see it. This scanner exists because model CLIs write
-// .github/workflows/*.yml with no filesystem sandbox (AGENTS.md), which makes a
-// silent pass on unrecognized syntax the exact failure it was written to prevent.
-// Fail closed instead: anything naming actions/checkout that the recognizer cannot
-// inspect fails the test with its file:line. Comment-only lines are excluded — a
-// commented-out step does not run.
-const CHECKOUT_MENTION = /actions\/checkout/g;
-const COMMENT_LINE = /^\s*#/;
-
-// The inverted guard. CHECKOUT_MENTION matches one literal spelling, so every round
-// of review found another way to write the same reference without it:
-// `"actions\/checkout@v4"` (YAML 1.2 solidus escape), `"actions\u002Fcheckout@v4"`,
-// and a double-quoted line continuation splitting the literal across two lines. That
-// tail has no end — \x6f, single quotes, block scalars — so stop enumerating
-// spellings and invert the question. Instead of "does this line name a checkout?",
-// ask "is this `uses:` value one this scanner can read at all?" and reject the file
-// if it is not, checkout or otherwise. Exotic spellings then fail closed without
-// anyone having to predict them.
-//
-// Fail closed on unparseable, NOT on unfamiliar: every form the repo actually uses
-// is accepted. Today that is only `owner/repo@ref`, but local (`./path`) and
-// `docker://` refs are accepted too so adding one does not break the build.
-// A quoted value is fine when it is a plain scalar — closing quote on the same line,
-// no backslash, so nothing can be hiding in an escape.
-//
-// Known false positive: a `uses:` written inside a `run: |` shell block would be
-// read as a step. No such line exists here (all 11 `uses:` lines are real steps or
-// inside `#` comments); if one appears, quote it differently or extend this.
-const USES_LINE = /^(\s*)(?:- )?uses:\s*(.*)$/;
-const PLAIN_ACTION_REF = /^[\w.-]+\/[\w./-]+@[\w./-]+$/;
-const LOCAL_ACTION_REF = /^\.{1,2}\/[\w./-]+$/;
-const DOCKER_ACTION_REF = /^docker:\/\/[\w.:/@-]+$/;
-
-function inspectableUsesValue(raw) {
-	// Strip a trailing YAML comment, but only when it is separated by whitespace —
-	// `#` inside a ref (a docker digest) is not a comment.
-	const value = raw.replace(/\s+#.*$/, "").trim();
-	if (value === "") return null;
-
-	let scalar = value;
-	if (scalar.startsWith('"')) {
-		// The `\\` in this class is deliberately redundant: a backslash is not in any
-		// of the three ref charsets below, so an escaped value is already rejected
-		// there (removing it from here fails no test — checked). It stays as the
-		// explicit statement of intent, so that widening a ref charset later cannot
-		// quietly re-admit \/, \u002F and friends. The closing-quote requirement is
-		// NOT redundant: it is what rejects an end-of-line continuation, whose quote
-		// lands on the next line.
-		if (!/^"[^"\\]*"$/.test(scalar)) return null;
-		scalar = scalar.slice(1, -1);
-	} else if (scalar.startsWith("'")) {
-		if (!/^'[^']*'$/.test(scalar)) return null;
-		scalar = scalar.slice(1, -1);
+function parseWorkflow(content, file) {
+	const lineCounter = new LineCounter();
+	const doc = parseDocument(content, { lineCounter });
+	const problem = doc.errors[0] ?? doc.warnings[0];
+	if (problem) {
+		const line = problem.pos ? lineCounter.linePos(problem.pos[0]).line : 0;
+		assert.fail(`${file}:${line}: workflow YAML does not parse cleanly: ${problem.message}`);
 	}
-
-	if (PLAIN_ACTION_REF.test(scalar)) return scalar;
-	if (LOCAL_ACTION_REF.test(scalar)) return scalar;
-	if (DOCKER_ACTION_REF.test(scalar)) return scalar;
-	return null;
+	return { doc, lineCounter };
 }
 
-function assertEveryUsesIsInspectable(lines, file) {
-	const uninspectable = [];
-	lines.forEach((line, index) => {
-		if (COMMENT_LINE.test(line)) return;
-		const match = line.match(USES_LINE);
-		if (!match) return;
-		if (inspectableUsesValue(match[2]) !== null) return;
-		uninspectable.push(`${file}:${index + 1}: ${line.trim()}`);
-	});
-
-	assert.deepEqual(
-		uninspectable,
-		[],
-		`uses: values this scanner cannot resolve, so it cannot prove they are not a checkout (write them as a plain owner/repo@ref): ${uninspectable.join(" | ")}`,
-	);
-}
-
-function indentOf(line) {
-	const match = line.match(/^(\s*)/);
-	return match ? match[1].length : 0;
-}
-
-function countByLine(entries) {
-	const counts = new Map();
-	for (const line of entries) counts.set(line, (counts.get(line) ?? 0) + 1);
-	return counts;
-}
-
-function assertEveryMentionRecognized(lines, checkouts, file) {
-	const mentioned = countByLine(
-		lines.flatMap((line, index) =>
-			COMMENT_LINE.test(line)
-				? []
-				: Array.from(line.match(CHECKOUT_MENTION) ?? [], () => index + 1),
-		),
-	);
-	const recognized = countByLine(checkouts.map((checkout) => checkout.line));
-
-	const unrecognized = [];
-	for (const [line, count] of [...mentioned].sort((a, b) => a[0] - b[0])) {
-		if ((recognized.get(line) ?? 0) >= count) continue;
-		unrecognized.push(`${file}:${line}: ${lines[line - 1].trim()}`);
-	}
-
-	assert.deepEqual(
-		unrecognized,
-		[],
-		`checkout syntax the scanner cannot inspect (rewrite as a block-style step, or teach CHECKOUT_USES to match it): ${unrecognized.join(" | ")}`,
-	);
+function lineOf(node, lineCounter) {
+	return node?.range ? lineCounter.linePos(node.range[0]).line : 0;
 }
 
 function collectCheckouts(content, file) {
-	const lines = content.split(/\r?\n/);
+	const { doc, lineCounter } = parseWorkflow(content, file);
 	const checkouts = [];
-	for (let usesIndex = 0; usesIndex < lines.length; usesIndex++) {
-		if (!CHECKOUT_USES.test(lines[usesIndex])) continue;
+	// Anchors may be referenced repeatedly and may even recurse. Visiting each
+	// resolved node once terminates; the effect on the count is fail-closed, since a
+	// step reused through N aliases is counted once and can only push the total down
+	// toward the floor, never hide a policy violation.
+	const seen = new Set();
 
-		const usesIndent = indentOf(lines[usesIndex]);
-		let start = usesIndex;
-		for (let i = usesIndex; i >= 0; i--) {
-			const dash = lines[i].match(/^(\s*)- /);
-			if (dash && dash[1].length <= usesIndent) {
-				start = i;
-				break;
-			}
-		}
+	const deref = (node) => (isAlias(node) ? node.resolve(doc) : node);
 
-		const stepIndent = indentOf(lines[start]);
-		let end = start;
-		for (let i = start + 1; i < lines.length; i++) {
-			const line = lines[i];
-			if (line.trim() === "") continue;
-			if (/^\s*#/.test(line)) {
-				end = i;
-				continue;
-			}
-			if (indentOf(line) <= stepIndent) break;
-			end = i;
-		}
+	const scalarValue = (node) => {
+		const resolved = deref(node);
+		return isScalar(resolved) ? resolved.value : undefined;
+	};
 
-		let commentStart = start;
-		for (let i = start - 1; i >= 0; i--) {
-			const line = lines[i];
-			if (line.trim() === "" || /^\s*#/.test(line)) {
-				commentStart = i;
-				continue;
-			}
-			break;
-		}
-		while (commentStart < start && lines[commentStart].trim() === "") {
-			commentStart++;
-		}
+	const pairsNamed = (map, key) =>
+		map.items.filter((pair) => scalarValue(pair.key) === key);
 
-		const block = lines.slice(commentStart, end + 1).join("\n");
-		const nameMatch = block.match(/^\s+- name:\s*(.+)$/m) ?? block.match(/^\s+name:\s*(.+)$/m);
-		const persistMatch = block.match(/^\s+persist-credentials:\s*['"]?(true|false)['"]?\s*(?:#.*)?$/m);
-		checkouts.push({
+	const describe = (map, usesPair, comment) => {
+		const withPair = pairsNamed(map, "with")[0];
+		const withMap = withPair ? deref(withPair.value) : undefined;
+		const persistPair = isMap(withMap) ? pairsNamed(withMap, "persist-credentials")[0] : undefined;
+		const persistRaw = persistPair ? scalarValue(persistPair.value) : undefined;
+		// Actions treats inputs as strings, so `false` and "false" mean the same thing.
+		const persistCredentials =
+			persistRaw === undefined || persistRaw === null ? null : String(persistRaw) === "true";
+
+		return {
 			file,
-			name: nameMatch ? nameMatch[1].trim() : "",
-			persistCredentials: persistMatch ? persistMatch[1] === "true" : null,
-			block,
-			line: usesIndex + 1,
-		});
-	}
-	assertEveryMentionRecognized(lines, checkouts, file);
-	assertEveryUsesIsInspectable(lines, file);
+			name: String(scalarValue(pairsNamed(map, "name")[0]?.value) ?? "").trim(),
+			persistCredentials,
+			comment: comment ?? "",
+			// For a step reached through an alias this is the anchor's definition site,
+			// which is where an author would have to make the fix.
+			line: lineOf(usesPair.key ?? map, lineCounter),
+		};
+	};
+
+	const visit = (node, comment) => {
+		const resolved = deref(node);
+		if (!resolved || seen.has(resolved)) return;
+		if (!isMap(resolved) && !isSeq(resolved)) return;
+		seen.add(resolved);
+
+		const attached = resolved.commentBefore ?? comment ?? "";
+
+		if (isSeq(resolved)) {
+			resolved.items.forEach((item, index) => {
+				// A comment before the FIRST item is hoisted onto the sequence itself,
+				// so item 0 inherits it; later items carry their own commentBefore.
+				visit(item, index === 0 ? attached : (deref(item)?.commentBefore ?? ""));
+			});
+			return;
+		}
+
+		// No duplicate-`uses:` guard here on purpose: the parser's uniqueKeys check
+		// rejects a repeated key as a parse error before this code runs, so such a
+		// guard would be unreachable. The test below pins that it is the parser's job.
+		const usesPair = pairsNamed(resolved, "uses")[0];
+		if (usesPair) {
+			const uses = scalarValue(usesPair.value);
+			if (typeof uses === "string" && CHECKOUT_ACTION.test(uses.trim())) {
+				checkouts.push(describe(resolved, usesPair, attached));
+			}
+		}
+
+		for (const pair of resolved.items) {
+			visit(pair.value, deref(pair.value)?.commentBefore ?? "");
+		}
+	};
+
+	visit(doc.contents, "");
 	return checkouts;
 }
 
@@ -224,7 +161,7 @@ function assertCheckoutPolicy(checkouts, allowlist) {
 		const allowed = remaining.get(key);
 		if (allowed) {
 			assert.match(
-				checkout.block,
+				checkout.comment,
 				allowed.commentMustMatch,
 				`${checkout.file}:${checkout.line} is allowlisted but has no YAML comment matching ${allowed.commentMustMatch}`,
 			);
@@ -268,11 +205,10 @@ function yamlFilesUnder(dir) {
 
 // All YAML under .github/, not just .github/workflows/. A composite action at
 // .github/actions/<name>/action.yml runs its own steps, including its own
-// actions/checkout, and a file the scanner never opens is a file it cannot police —
-// the same fail-open as unrecognized syntax, one directory over. Recursing on the
-// whole .github tree rather than allowlisting action.yml means a new location does
-// not need this list updated to be covered. Plus the repo-root action.yml, the
-// published action surface, which lives outside .github/.
+// actions/checkout, and a file the scanner never opens is a file it cannot police.
+// Recursing the whole .github tree rather than allowlisting known directories means a
+// new location does not need this list updated to be covered. Plus the repo-root
+// action.yml, the published action surface, which lives outside .github/.
 function workflowFiles(root = ".") {
 	return [...yamlFilesUnder(join(root, ".github")), join(root, "action.yml")];
 }
@@ -283,7 +219,7 @@ test("every actions/checkout sets persist-credentials: false or is allowlisted",
 	);
 	assert.ok(
 		checkouts.length >= MINIMUM_CHECKOUT_COUNT,
-		`expected at least ${MINIMUM_CHECKOUT_COUNT} actions/checkout steps, found ${checkouts.length}; checkouts left the scanned file set, so raise the floor only if they are genuinely gone`,
+		`expected at least ${MINIMUM_CHECKOUT_COUNT} actions/checkout steps, found ${checkouts.length}; checkouts left the scanned file set, so lower the floor only if they are genuinely gone`,
 	);
 	assertCheckoutPolicy(checkouts, PERSISTED_CREDENTIAL_ALLOWLIST);
 });
@@ -297,8 +233,8 @@ test("allowlisted checkouts document why persisted git credentials are required"
 			1,
 			`${entry.file} name=${JSON.stringify(entry.name)} must identify exactly one checkout`,
 		);
-		assert.match(matches[0].block, entry.commentMustMatch);
-		assert.match(matches[0].block, /#/);
+		assert.match(matches[0].comment, entry.commentMustMatch);
+		assert.notEqual(matches[0].comment, "", "an allowlisted checkout must carry a YAML comment");
 	}
 });
 
@@ -342,134 +278,53 @@ test("scanner accepts persist-credentials: false and rejects a stale allowlist e
 	);
 });
 
-test("scanner rejects a flow-mapping checkout instead of silently skipping it", () => {
-	// Valid YAML, runs on Actions, never matches CHECKOUT_USES. Before the coverage
-	// guard this yielded zero checkouts and assertCheckoutPolicy passed on nothing.
-	const yaml = [
-		"jobs:",
-		"  review:",
-		"    steps:",
-		"      - { uses: actions/checkout@v4 }",
-	].join("\n");
-	assert.throws(
-		() => collectCheckouts(yaml, "example.yml"),
-		/example\.yml:4: - \{ uses: actions\/checkout@v4 \}/,
-	);
-});
+// The obfuscations that defeated the five regex generations. Each must now be
+// RESOLVED and policed like any other checkout, not merely rejected as unreadable.
+const OBFUSCATIONS = {
+	"flow mapping": ["      - { uses: actions/checkout@v4 }"],
+	"solidus escape": ['      - uses: "actions\\/checkout@v4"'],
+	"unicode escape": ['      - uses: "actions\\u002Fcheckout@v4"'],
+	"line continuation": ['      - uses: "actions/check\\', '          out@v4"'],
+	"quoted key": ['      - "uses": actions/checkout@v4'],
+	"quoted key and escaped value": ['      - "uses": "actions\\/checkout@v4"'],
+	"unicode-escaped key and value": ['      - "\\u0075ses": "actions\\u002Fcheckout@v4"'],
+	"folded block scalar": ["      - uses: >-", "          actions/checkout@v4"],
+	"literal block scalar": ["      - uses: |-", "          actions/checkout@v4"],
+	"single-quoted": ["      - uses: 'actions/checkout@v4'"],
+};
 
-test("scanner rejects unrecognized checkout syntax even when it sets persist-credentials: false", () => {
-	// Inspectability, not policy: the scanner may not conclude "compliant" from
-	// syntax whose step boundaries it cannot resolve.
-	const yaml = [
-		"jobs:",
-		"  review:",
-		"    steps:",
-		"      - {uses: actions/checkout@v4, with: {persist-credentials: false}}",
-	].join("\n");
-	assert.throws(() => collectCheckouts(yaml, "example.yml"), /example\.yml:4/);
-});
-
-test("one unrecognized checkout fails the scan even when the other steps are compliant", () => {
-	const yaml = [
-		"jobs:",
-		"  review:",
-		"    steps:",
-		"      - uses: actions/checkout@v4",
-		"        with:",
-		"          persist-credentials: false",
-		"      - { uses: actions/checkout@v4 }",
-	].join("\n");
-	assert.throws(
-		() => collectCheckouts(yaml, "example.yml"),
-		(error) => {
-			assert.match(error.message, /example\.yml:7/);
-			assert.doesNotMatch(error.message, /example\.yml:4/);
-			return true;
-		},
-	);
-});
-
-test("a commented-out checkout is not treated as an unrecognized step", () => {
-	const yaml = [
-		"jobs:",
-		"  review:",
-		"    steps:",
-		"      # - uses: actions/checkout@v4  (dropped; the job clones its own copy)",
-		"      - uses: actions/checkout@v4",
-		"        with:",
-		"          persist-credentials: false",
-	].join("\n");
-	const checkouts = collectCheckouts(yaml, "example.yml");
-	assert.equal(checkouts.length, 1);
-	assert.equal(checkouts[0].line, 5);
-});
-
-test("a checkout spelled around the literal fails closed", () => {
-	// The three spellings that defeated CHECKOUT_MENTION. All resolve to
-	// actions/checkout@v4 under YAML 1.2; none contains the literal on one line.
-	const spellings = {
-		"solidus escape": '      - uses: "actions\\/checkout@v4"',
-		"unicode escape": '      - uses: "actions\\u002Fcheckout@v4"',
-	};
-	for (const [label, step] of Object.entries(spellings)) {
-		const yaml = ["jobs:", "  a:", "    steps:", step].join("\n");
+test("every known obfuscation resolves to a policed checkout", () => {
+	for (const [label, step] of Object.entries(OBFUSCATIONS)) {
+		const yaml = ["jobs:", "  a:", "    steps:", ...step].join("\n");
+		const checkouts = collectCheckouts(yaml, "sneaky.yml");
+		assert.equal(checkouts.length, 1, `${label}: must resolve to exactly one checkout`);
+		assert.equal(checkouts[0].persistCredentials, null, `${label}: persistence is on by default`);
 		assert.throws(
-			() => collectCheckouts(yaml, "sneaky.yml"),
-			/sneaky\.yml:4: .*cannot resolve|cannot resolve.*sneaky\.yml:4/s,
-			`${label} must be rejected`,
+			() => assertCheckoutPolicy(checkouts, []),
+			/persist-credentials: false or be allowlisted/,
+			`${label}: must fail the policy`,
 		);
 	}
-
-	// Line continuation: the closing quote is on the next line, so the value is not a
-	// plain scalar and the reference is split across two lines.
-	const continued = [
-		"jobs:",
-		"  a:",
-		"    steps:",
-		'      - uses: "actions/check\\',
-		'          out@v4"',
-	].join("\n");
-	assert.throws(() => collectCheckouts(continued, "sneaky.yml"), /cannot resolve/);
 });
 
-test("every uses: form the repo relies on stays inspectable", () => {
-	// Guards the other direction: fail closed on unparseable, not on unfamiliar.
+test("an obfuscated checkout that does disable persistence is accepted", () => {
+	// The mirror of the test above: the scanner reads the real value, so a compliant
+	// step written in an unusual style passes rather than being rejected for its style.
 	const yaml = [
 		"jobs:",
 		"  a:",
 		"    steps:",
-		"      - uses: actions/checkout@v4",
-		"        with:",
-		"          persist-credentials: false",
-		"      - uses: actions/setup-node@v4",
-		"      - uses: frankekn/needlefish@v0",
-		"      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
-		"        with:",
-		"          persist-credentials: false",
-		'      - uses: "actions/setup-node@v4"',
-		"      - uses: 'actions/setup-node@v4'",
-		"      - uses: ./.github/actions/setup",
-		"      - uses: owner/repo/sub/dir@main",
-		"      - uses: docker://alpine:3.19",
-		"      # - uses: whatever/nonsense@\\/weird",
+		'      - { "uses": "actions\\/checkout@v4", with: { persist-credentials: false } }',
 	].join("\n");
-	const checkouts = collectCheckouts(yaml, "legit.yml");
-	assert.equal(checkouts.length, 2, "both plain checkouts stay recognized");
+	const checkouts = collectCheckouts(yaml, "sneaky.yml");
+	assert.equal(checkouts.length, 1);
+	assert.equal(checkouts[0].persistCredentials, false);
 	assertCheckoutPolicy(checkouts, []);
 });
 
-test("a YAML alias cannot smuggle a checkout past the scanner", () => {
-	// Actions has resolved anchors/aliases since 2025-09, so `uses: *checkout` runs.
-	// It is still not a bypass, and the reason is worth pinning: aliases are
-	// file-scoped, so an alias needs an `&anchor` in the SAME file, and YAML has no
-	// concatenation — the anchor's value must spell out `actions/checkout`. That
-	// definition line is never a plain `uses: actions/checkout@...`, so CHECKOUT_USES
-	// misses it, CHECKOUT_MENTION sees it, and the coverage guard rejects the file.
-	//
-	// Do NOT "fix" this by teaching the mention scan to skip anchor definitions or by
-	// resolving aliases: skipping the definition line is what would open the hole.
+test("YAML anchors and aliases resolve to policed checkouts", () => {
 	const variants = {
-		"anchor on a uses: line": [
+		"anchor on a uses: value": [
 			"jobs:",
 			"  a:",
 			"    steps:",
@@ -478,7 +333,7 @@ test("a YAML alias cannot smuggle a checkout past the scanner", () => {
 			"    steps:",
 			"      - uses: *checkout",
 		],
-		"anchor on a non-uses key": [
+		"anchor on an unrelated key": [
 			"x-defs:",
 			"  checkout: &checkout actions/checkout@v4",
 			"jobs:",
@@ -497,12 +352,73 @@ test("a YAML alias cannot smuggle a checkout past the scanner", () => {
 	};
 
 	for (const [label, lines] of Object.entries(variants)) {
+		const checkouts = collectCheckouts(lines.join("\n"), "alias.yml");
+		assert.ok(checkouts.length >= 1, `${label}: the aliased checkout must be found`);
 		assert.throws(
-			() => collectCheckouts(lines.join("\n"), "alias.yml"),
-			/cannot inspect/,
-			`${label}: the anchor definition must fail the coverage guard`,
+			() => assertCheckoutPolicy(checkouts, []),
+			/persist-credentials: false or be allowlisted/,
+			`${label}: must fail the policy`,
 		);
 	}
+});
+
+test("a commented-out checkout is not a step", () => {
+	const yaml = [
+		"jobs:",
+		"  review:",
+		"    steps:",
+		"      # - uses: actions/checkout@v4  (dropped; the job clones its own copy)",
+		"      - uses: actions/checkout@v4",
+		"        with:",
+		"          persist-credentials: false",
+	].join("\n");
+	const checkouts = collectCheckouts(yaml, "example.yml");
+	assert.equal(checkouts.length, 1);
+	assert.equal(checkouts[0].line, 5);
+});
+
+test("a step declaring uses: twice is rejected by the parser, not silently last-wins", () => {
+	// Ambiguity is a bypass shape: if the scanner read the first `uses:` and Actions
+	// ran the second, a checkout could hide behind a benign-looking step.
+	const yaml = [
+		"jobs:",
+		"  a:",
+		"    steps:",
+		"      - uses: actions/setup-node@v4",
+		"        uses: actions/checkout@v4",
+	].join("\n");
+	assert.throws(
+		() => collectCheckouts(yaml, "dup.yml"),
+		/dup\.yml:\d+: workflow YAML does not parse cleanly: Map keys must be unique/,
+	);
+});
+
+test("a workflow that does not parse fails with its file and line", () => {
+	const yaml = ["jobs:", "  a:", "    steps:", "      - uses: [unterminated"].join("\n");
+	assert.throws(() => collectCheckouts(yaml, "broken.yml"), /broken\.yml:\d+: workflow YAML does not parse/);
+});
+
+test("every uses: form the repo relies on stays acceptable", () => {
+	// Fail closed on obfuscation, not on legitimate variety.
+	const yaml = [
+		"jobs:",
+		"  a:",
+		"    steps:",
+		"      - uses: actions/checkout@v4",
+		"        with:",
+		"          persist-credentials: false",
+		"      - uses: actions/setup-node@v4",
+		"      - uses: frankekn/needlefish@v0",
+		"      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
+		"        with:",
+		"          persist-credentials: false",
+		"      - uses: ./.github/actions/setup",
+		"      - uses: owner/repo/sub/dir@main",
+		"      - uses: docker://alpine:3.19",
+	].join("\n");
+	const checkouts = collectCheckouts(yaml, "legit.yml");
+	assert.equal(checkouts.length, 2, "both checkouts recognized, the other four forms ignored");
+	assertCheckoutPolicy(checkouts, []);
 });
 
 test("a composite action's checkout is scanned, not just .github/workflows", () => {
@@ -527,9 +443,7 @@ test("a composite action's checkout is scanned, not just .github/workflows", () 
 		);
 		writeFileSync(
 			join(root, ".github", "actions", "setup", "action.yml"),
-			["runs:", "  using: composite", "  steps:", "    - uses: actions/checkout@v4"].join(
-				"\n",
-			),
+			["runs:", "  using: composite", "  steps:", "    - uses: actions/checkout@v4"].join("\n"),
 		);
 
 		const files = workflowFiles(root);
@@ -538,9 +452,7 @@ test("a composite action's checkout is scanned, not just .github/workflows", () 
 			`composite action metadata must be in the scan set: ${files.join(", ")}`,
 		);
 
-		const checkouts = files.flatMap((file) =>
-			collectCheckouts(readFileSync(file, "utf8"), file),
-		);
+		const checkouts = files.flatMap((file) => collectCheckouts(readFileSync(file, "utf8"), file));
 		assert.throws(
 			() => assertCheckoutPolicy(checkouts, []),
 			/actions[/\\]setup[/\\]action\.yml:4 .*must set persist-credentials: false or be allowlisted/,

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -334,6 +334,53 @@ test("a commented-out checkout is not treated as an unrecognized step", () => {
 	assert.equal(checkouts[0].line, 5);
 });
 
+test("a YAML alias cannot smuggle a checkout past the scanner", () => {
+	// Actions has resolved anchors/aliases since 2025-09, so `uses: *checkout` runs.
+	// It is still not a bypass, and the reason is worth pinning: aliases are
+	// file-scoped, so an alias needs an `&anchor` in the SAME file, and YAML has no
+	// concatenation — the anchor's value must spell out `actions/checkout`. That
+	// definition line is never a plain `uses: actions/checkout@...`, so CHECKOUT_USES
+	// misses it, CHECKOUT_MENTION sees it, and the coverage guard rejects the file.
+	//
+	// Do NOT "fix" this by teaching the mention scan to skip anchor definitions or by
+	// resolving aliases: skipping the definition line is what would open the hole.
+	const variants = {
+		"anchor on a uses: line": [
+			"jobs:",
+			"  a:",
+			"    steps:",
+			"      - uses: &checkout actions/checkout@v4",
+			"  b:",
+			"    steps:",
+			"      - uses: *checkout",
+		],
+		"anchor on a non-uses key": [
+			"x-defs:",
+			"  checkout: &checkout actions/checkout@v4",
+			"jobs:",
+			"  a:",
+			"    steps:",
+			"      - uses: *checkout",
+		],
+		"anchor on a whole step mapping": [
+			"x-defs:",
+			"  step: &checkout { uses: actions/checkout@v4 }",
+			"jobs:",
+			"  a:",
+			"    steps:",
+			"      - *checkout",
+		],
+	};
+
+	for (const [label, lines] of Object.entries(variants)) {
+		assert.throws(
+			() => collectCheckouts(lines.join("\n"), "alias.yml"),
+			/cannot inspect/,
+			`${label}: the anchor definition must fail the coverage guard`,
+		);
+	}
+});
+
 test("a composite action's checkout is scanned, not just .github/workflows", () => {
 	// The floor cannot see this one: adding an unprotected checkout under
 	// .github/actions leaves the workflow checkouts intact, so the count stays green.

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -37,8 +45,9 @@ import { isAlias, isMap, isScalar, isSeq, LineCounter, parseDocument } from "yam
 // outside .github/ — nothing remains to parse and the scan goes quiet. The count
 // falling below the floor is the only signal of that coverage loss. (It does NOT
 // catch a checkout *added* somewhere unscanned: the six here stay intact and the
-// floor stays green. Only widening workflowFiles() fixes that, which is why it
-// recurses rather than listing directories.)
+// floor stays green. Only the scan set itself fixes that — hence the .github
+// recursion, and hence scanRepository() following local `uses: ./…` references to
+// wherever their action.yml actually lives.)
 //
 // Why not equality: a checkout being *added* is already fully policed — it is
 // resolved by the parser and must set persist-credentials: false or be allowlisted.
@@ -57,6 +66,9 @@ const PERSISTED_CREDENTIAL_ALLOWLIST = [
 ];
 
 const CHECKOUT_ACTION = /^actions\/checkout(?:@|$)/;
+// `uses: ./path` runs a composite action whose metadata lives at path/action.yml,
+// resolved from the repository root. Such an action can run its own checkout.
+const LOCAL_ACTION = /^\.{1,2}\//;
 
 function parseWorkflow(content, file) {
 	const lineCounter = new LineCounter();
@@ -73,9 +85,10 @@ function lineOf(node, lineCounter) {
 	return node?.range ? lineCounter.linePos(node.range[0]).line : 0;
 }
 
-function collectCheckouts(content, file) {
+function scanWorkflow(content, file) {
 	const { doc, lineCounter } = parseWorkflow(content, file);
 	const checkouts = [];
+	const localActions = [];
 	// Anchors may be referenced repeatedly and may even recurse. Visiting each
 	// resolved node once terminates; the effect on the count is fail-closed, since a
 	// step reused through N aliases is counted once and can only push the total down
@@ -135,8 +148,13 @@ function collectCheckouts(content, file) {
 		const usesPair = pairsNamed(resolved, "uses")[0];
 		if (usesPair) {
 			const uses = scalarValue(usesPair.value);
-			if (typeof uses === "string" && CHECKOUT_ACTION.test(uses.trim())) {
-				checkouts.push(describe(resolved, usesPair, attached));
+			if (typeof uses === "string") {
+				const ref = uses.trim();
+				if (CHECKOUT_ACTION.test(ref)) {
+					checkouts.push(describe(resolved, usesPair, attached));
+				} else if (LOCAL_ACTION.test(ref)) {
+					localActions.push({ ref, line: lineOf(usesPair.key ?? resolved, lineCounter) });
+				}
 			}
 		}
 
@@ -146,7 +164,11 @@ function collectCheckouts(content, file) {
 	};
 
 	visit(doc.contents, "");
-	return checkouts;
+	return { checkouts, localActions };
+}
+
+function collectCheckouts(content, file) {
+	return scanWorkflow(content, file).checkouts;
 }
 
 function allowlistKey(entry) {
@@ -213,10 +235,48 @@ function workflowFiles(root = ".") {
 	return [...yamlFilesUnder(join(root, ".github")), join(root, "action.yml")];
 }
 
+// Directory listing alone cannot find every composite action: `uses: ./tools/thing`
+// puts action.yml anywhere in the repo, and enumerating candidate directories is the
+// same losing game as enumerating spellings was. So follow the references instead.
+// Start from the files that run by virtue of their location (workflows, root
+// action.yml) and walk every local `uses: ./…` to its metadata, transitively. That
+// set is closed under reachability: an action nothing references never runs, and one
+// that does is scanned wherever it lives.
+//
+// A reference with no metadata file fails the scan rather than being skipped — the
+// workflow would break at runtime anyway, and "the target is missing" must not be a
+// way to leave a checkout uninspected.
+function scanRepository(root = ".") {
+	const queue = [...workflowFiles(root)];
+	const scanned = new Set();
+	const checkouts = [];
+
+	while (queue.length > 0) {
+		const file = queue.shift();
+		if (scanned.has(file)) continue;
+		scanned.add(file);
+
+		const scan = scanWorkflow(readFileSync(file, "utf8"), file);
+		checkouts.push(...scan.checkouts);
+
+		for (const { ref, line } of scan.localActions) {
+			const dir = join(root, ref);
+			const metadata = [join(dir, "action.yml"), join(dir, "action.yaml")].find((path) =>
+				existsSync(path),
+			);
+			assert.ok(
+				metadata,
+				`${file}:${line}: uses: ${ref} but no action.yml or action.yaml exists there, so its steps cannot be inspected`,
+			);
+			queue.push(metadata);
+		}
+	}
+
+	return { checkouts, scanned: [...scanned] };
+}
+
 test("every actions/checkout sets persist-credentials: false or is allowlisted", () => {
-	const checkouts = workflowFiles().flatMap((file) =>
-		collectCheckouts(readFileSync(file, "utf8"), file),
-	);
+	const { checkouts } = scanRepository();
 	assert.ok(
 		checkouts.length >= MINIMUM_CHECKOUT_COUNT,
 		`expected at least ${MINIMUM_CHECKOUT_COUNT} actions/checkout steps, found ${checkouts.length}; checkouts left the scanned file set, so lower the floor only if they are genuinely gone`,
@@ -460,6 +520,100 @@ test("a composite action's checkout is scanned, not just .github/workflows", () 
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+function withFixtureRepo(build) {
+	const root = mkdtempSync(join(tmpdir(), "needlefish-checkout-scan-"));
+	try {
+		mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+		writeFileSync(join(root, "action.yml"), "name: root\n");
+		build(root, (relative, lines) => {
+			const path = join(root, relative);
+			mkdirSync(join(path, ".."), { recursive: true });
+			writeFileSync(path, lines.join("\n"));
+		});
+		return build.result;
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+test("a local composite action outside .github is followed and scanned", () => {
+	// The directory recursion cannot reach this one and the floor cannot see it: the
+	// workflow checkouts stay intact. Only following the `uses: ./…` reference finds it.
+	withFixtureRepo((root, write) => {
+		write(".github/workflows/review.yml", [
+			"jobs:",
+			"  review:",
+			"    steps:",
+			"      - uses: actions/checkout@v4",
+			"        with:",
+			"          persist-credentials: false",
+			"      - uses: ./tools/prepare",
+		]);
+		write("tools/prepare/action.yml", [
+			"runs:",
+			"  using: composite",
+			"  steps:",
+			"    - uses: actions/checkout@v4",
+		]);
+
+		const { checkouts, scanned } = scanRepository(root);
+		assert.ok(
+			scanned.includes(join(root, "tools", "prepare", "action.yml")),
+			`referenced composite action must be scanned: ${scanned.join(", ")}`,
+		);
+		assert.throws(
+			() => assertCheckoutPolicy(checkouts, []),
+			/tools[/\\]prepare[/\\]action\.yml:4 .*must set persist-credentials: false or be allowlisted/,
+		);
+	});
+});
+
+test("local action references are followed transitively", () => {
+	withFixtureRepo((root, write) => {
+		write(".github/workflows/review.yml", [
+			"jobs:",
+			"  review:",
+			"    steps:",
+			"      - uses: ./tools/outer",
+		]);
+		write("tools/outer/action.yml", [
+			"runs:",
+			"  using: composite",
+			"  steps:",
+			"    - uses: ./tools/inner",
+		]);
+		write("tools/inner/action.yml", [
+			"runs:",
+			"  using: composite",
+			"  steps:",
+			"    - uses: actions/checkout@v4",
+		]);
+
+		const { checkouts, scanned } = scanRepository(root);
+		assert.ok(scanned.includes(join(root, "tools", "inner", "action.yml")));
+		assert.equal(checkouts.length, 1);
+		assert.throws(
+			() => assertCheckoutPolicy(checkouts, []),
+			/tools[/\\]inner[/\\]action\.yml:4 /,
+		);
+	});
+});
+
+test("a local action reference with no metadata file fails the scan", () => {
+	withFixtureRepo((root, write) => {
+		write(".github/workflows/review.yml", [
+			"jobs:",
+			"  review:",
+			"    steps:",
+			"      - uses: ./tools/missing",
+		]);
+		assert.throws(
+			() => scanRepository(root),
+			/review\.yml:4: uses: \.\/tools\/missing but no action\.yml or action\.yaml exists there/,
+		);
+	});
 });
 
 test("weekly-eval git push authenticates with GH_TOKEN instead of persisted checkout credentials", () => {

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+// Line/regex scanner, not a YAML parser: Node has no YAML built-in and this
+// repo's workflow tests stay dependency-free. Each `uses: actions/checkout`
+// step must set persist-credentials: false, or be on the allowlist below
+// with a YAML comment documenting why persisted git auth is required.
+
+const PERSISTED_CREDENTIAL_ALLOWLIST = [
+	{
+		file: ".github/workflows/release.yml",
+		name: "",
+		commentMustMatch: /git push/,
+	},
+];
+
+const CHECKOUT_USES =
+	/^(\s*)(?:- )?uses:\s*['"]?actions\/checkout@\S+/;
+
+function indentOf(line) {
+	const match = line.match(/^(\s*)/);
+	return match ? match[1].length : 0;
+}
+
+function collectCheckouts(content, file) {
+	const lines = content.split(/\r?\n/);
+	const checkouts = [];
+	for (let usesIndex = 0; usesIndex < lines.length; usesIndex++) {
+		if (!CHECKOUT_USES.test(lines[usesIndex])) continue;
+
+		const usesIndent = indentOf(lines[usesIndex]);
+		let start = usesIndex;
+		for (let i = usesIndex; i >= 0; i--) {
+			const dash = lines[i].match(/^(\s*)- /);
+			if (dash && dash[1].length <= usesIndent) {
+				start = i;
+				break;
+			}
+		}
+
+		const stepIndent = indentOf(lines[start]);
+		let end = start;
+		for (let i = start + 1; i < lines.length; i++) {
+			const line = lines[i];
+			if (line.trim() === "") continue;
+			if (/^\s*#/.test(line)) {
+				end = i;
+				continue;
+			}
+			if (indentOf(line) <= stepIndent) break;
+			end = i;
+		}
+
+		let commentStart = start;
+		for (let i = start - 1; i >= 0; i--) {
+			const line = lines[i];
+			if (line.trim() === "" || /^\s*#/.test(line)) {
+				commentStart = i;
+				continue;
+			}
+			break;
+		}
+		while (commentStart < start && lines[commentStart].trim() === "") {
+			commentStart++;
+		}
+
+		const block = lines.slice(commentStart, end + 1).join("\n");
+		const nameMatch = block.match(/^\s+- name:\s*(.+)$/m) ?? block.match(/^\s+name:\s*(.+)$/m);
+		const persistMatch = block.match(/^\s+persist-credentials:\s*['"]?(true|false)['"]?\s*(?:#.*)?$/m);
+		checkouts.push({
+			file,
+			name: nameMatch ? nameMatch[1].trim() : "",
+			persistCredentials: persistMatch ? persistMatch[1] === "true" : null,
+			block,
+			line: usesIndex + 1,
+		});
+	}
+	return checkouts;
+}
+
+function allowlistKey(entry) {
+	return `${entry.file}::${entry.name}`;
+}
+
+function assertCheckoutPolicy(checkouts, allowlist) {
+	const remaining = new Map(allowlist.map((entry) => [allowlistKey(entry), entry]));
+
+	for (const checkout of checkouts) {
+		const key = allowlistKey(checkout);
+		const allowed = remaining.get(key);
+		if (allowed) {
+			assert.match(
+				checkout.block,
+				allowed.commentMustMatch,
+				`${checkout.file}:${checkout.line} is allowlisted but has no YAML comment matching ${allowed.commentMustMatch}`,
+			);
+			assert.notEqual(
+				checkout.persistCredentials,
+				false,
+				`${checkout.file}:${checkout.line} is allowlisted for persisted auth but sets persist-credentials: false`,
+			);
+			remaining.delete(key);
+			continue;
+		}
+
+		assert.equal(
+			checkout.persistCredentials,
+			false,
+			`${checkout.file}:${checkout.line} (${checkout.name || "unnamed"}) must set persist-credentials: false or be allowlisted`,
+		);
+	}
+
+	assert.equal(
+		remaining.size,
+		0,
+		`allowlist entries did not match exactly one checkout each: ${[...remaining.keys()].join(", ")}`,
+	);
+}
+
+function workflowFiles() {
+	const dir = ".github/workflows";
+	return [
+		...readdirSync(dir)
+			.filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+			.map((name) => join(dir, name))
+			.sort(),
+		"action.yml",
+	];
+}
+
+test("every actions/checkout sets persist-credentials: false or is allowlisted", () => {
+	const checkouts = workflowFiles().flatMap((file) =>
+		collectCheckouts(readFileSync(file, "utf8"), file),
+	);
+	assert.ok(checkouts.length >= 6, `expected to find checkouts, found ${checkouts.length}`);
+	assertCheckoutPolicy(checkouts, PERSISTED_CREDENTIAL_ALLOWLIST);
+});
+
+test("allowlisted checkouts document why persisted git credentials are required", () => {
+	for (const entry of PERSISTED_CREDENTIAL_ALLOWLIST) {
+		const checkouts = collectCheckouts(readFileSync(entry.file, "utf8"), entry.file);
+		const matches = checkouts.filter((checkout) => checkout.name === entry.name);
+		assert.equal(
+			matches.length,
+			1,
+			`${entry.file} name=${JSON.stringify(entry.name)} must identify exactly one checkout`,
+		);
+		assert.match(matches[0].block, entry.commentMustMatch);
+		assert.match(matches[0].block, /#/);
+	}
+});
+
+test("scanner fails closed on a checkout that neither disables persistence nor is allowlisted", () => {
+	const yaml = [
+		"jobs:",
+		"  review:",
+		"    steps:",
+		"      - name: Checkout review target",
+		"        uses: actions/checkout@v4",
+		"        with:",
+		"          fetch-depth: 0",
+	].join("\n");
+	const checkouts = collectCheckouts(yaml, "example.yml");
+	assert.equal(checkouts.length, 1);
+	assert.equal(checkouts[0].persistCredentials, null);
+	assert.throws(
+		() => assertCheckoutPolicy(checkouts, []),
+		/persist-credentials: false or be allowlisted/,
+	);
+});
+
+test("scanner accepts persist-credentials: false and rejects a stale allowlist entry", () => {
+	const yaml = [
+		"jobs:",
+		"  review:",
+		"    steps:",
+		"      - uses: actions/checkout@v4",
+		"        with:",
+		"          persist-credentials: false",
+	].join("\n");
+	const checkouts = collectCheckouts(yaml, "example.yml");
+	assert.equal(checkouts[0].persistCredentials, false);
+	assertCheckoutPolicy(checkouts, []);
+	assert.throws(
+		() =>
+			assertCheckoutPolicy(checkouts, [
+				{ file: "missing.yml", name: "", commentMustMatch: /git push/ },
+			]),
+		/did not match exactly one checkout/,
+	);
+});
+
+test("weekly-eval git push authenticates with GH_TOKEN instead of persisted checkout credentials", () => {
+	const weekly = readFileSync(".github/workflows/weekly-eval.yml", "utf8");
+	assert.match(weekly, /persist-credentials:\s*false/);
+
+	const compare = weekly.match(
+		/      - name: Compare with previous week and commit report\n([\s\S]*?)(?=\n      - name:|$)/,
+	);
+	assert.ok(compare, "Compare with previous week and commit report step must exist");
+	const script = compare[1];
+	assert.match(
+		script,
+		/credential\.helper='!f\(\) \{ echo username=x-access-token; echo "password=\$GH_TOKEN"; \}; f'/,
+		"compare step must use a credential helper that reads GH_TOKEN from the environment",
+	);
+	assert.match(script, /git -c credential\.helper= \\/);
+	assert.match(script, /push origin HEAD:main/);
+	assert.doesNotMatch(script, /extraheader/);
+	assert.doesNotMatch(script, /base64/);
+	assert.doesNotMatch(
+		script,
+		/credential\.helper="/,
+		"helper must be single-quoted so bash does not expand GH_TOKEN into git argv",
+	);
+});

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -102,7 +102,8 @@ function scanWorkflow(content, file) {
 	const { doc, lineCounter } = parseWorkflow(content, file);
 	const checkouts = [];
 	const localActions = [];
-	const unresolvable = [];
+	// Anything the scanner cannot read well enough to prove the policy holds.
+	const problems = [];
 	// Anchors may be referenced repeatedly and may even recurse. Visiting each
 	// resolved node once terminates; the effect on the count is fail-closed, since a
 	// step reused through N aliases is counted once and can only push the total down
@@ -123,10 +124,22 @@ function scanWorkflow(content, file) {
 		const withPair = pairsNamed(map, "with")[0];
 		const withMap = withPair ? deref(withPair.value) : undefined;
 		const persistPair = isMap(withMap) ? pairsNamed(withMap, "persist-credentials")[0] : undefined;
-		const persistRaw = persistPair ? scalarValue(persistPair.value) : undefined;
-		// Actions treats inputs as strings, so `false` and "false" mean the same thing.
-		const persistCredentials =
-			persistRaw === undefined || persistRaw === null ? null : String(persistRaw) === "true";
+		// Only a literal false counts as disabling persistence. Anything else that is
+		// not a literal true fails the scan rather than being read as "not true, so
+		// safe": this file parses YAML 1.2, where `yes` is the string "yes", while
+		// GitHub's workflow parser is YAML-1.1-flavoured and may hand actions/checkout
+		// the string "true" for it. Guessing which side is right is how a
+		// persist-credentials: yes ends up recorded as compliant. Unknown means stop.
+		let persistCredentials = null;
+		if (persistPair) {
+			const persistText = String(scalarValue(persistPair.value));
+			if (persistText !== "true" && persistText !== "false") {
+				problems.push(
+					`${file}:${lineOf(persistPair.key ?? persistPair.value, lineCounter)}: persist-credentials: ${persistText} is neither true nor false`,
+				);
+			}
+			persistCredentials = persistText !== "false";
+		}
 
 		return {
 			file,
@@ -169,7 +182,9 @@ function scanWorkflow(content, file) {
 			} else if (CHECKOUT_ACTION.test(ref)) {
 				checkouts.push(describe(resolved, usesPair, attached));
 			} else if (!EXTERNAL_ACTION.test(ref) && !DOCKER_ACTION.test(ref)) {
-				unresolvable.push(`${file}:${line}: uses: ${ref === "" ? JSON.stringify(uses) : ref}`);
+				problems.push(
+					`${file}:${line}: uses: ${ref === "" ? JSON.stringify(uses) : ref} is not a documented reference form (owner/repo@ref, ./path, or docker://…)`,
+				);
 			}
 		}
 
@@ -181,9 +196,9 @@ function scanWorkflow(content, file) {
 	visit(doc.contents, "");
 
 	assert.deepEqual(
-		unresolvable,
+		problems,
 		[],
-		`uses: values that are not a documented action reference (owner/repo@ref, ./path, or docker://…), so the scanner cannot tell whether they run a checkout: ${unresolvable.join(" | ")}`,
+		`the scanner cannot read these well enough to prove no checkout persists credentials: ${problems.join(" | ")}`,
 	);
 
 	return { checkouts, localActions };
@@ -282,15 +297,28 @@ function scanRepository(root = ".") {
 		checkouts.push(...scan.checkouts);
 
 		for (const { ref, line } of scan.localActions) {
-			const dir = join(root, ref);
-			const metadata = [join(dir, "action.yml"), join(dir, "action.yaml")].find((path) =>
-				existsSync(path),
-			);
+			const target = join(root, ref);
+			// Two different things share the `uses: ./…` spelling. A step-level
+			// reference names a DIRECTORY holding action.yml; a job-level reusable
+			// workflow call names the workflow FILE itself
+			// (`uses: ./.github/workflows/build.yml`). Demanding action.yml under the
+			// latter would fail the scan on a legitimate workflow — failing on
+			// unfamiliar, which this scanner must not do. Distinguish by extension:
+			// GitHub requires a reusable workflow to be a .yml/.yaml file, and an
+			// action directory cannot be named that way and still be resolvable.
+			const isReusableWorkflow = /\.ya?ml$/.test(ref);
+			const resolved = isReusableWorkflow
+				? [target].find((path) => existsSync(path))
+				: [join(target, "action.yml"), join(target, "action.yaml")].find((path) =>
+						existsSync(path),
+					);
 			assert.ok(
-				metadata,
-				`${file}:${line}: uses: ${ref} but no action.yml or action.yaml exists there, so its steps cannot be inspected`,
+				resolved,
+				isReusableWorkflow
+					? `${file}:${line}: uses: ${ref} but that workflow file does not exist, so its steps cannot be inspected`
+					: `${file}:${line}: uses: ${ref} but no action.yml or action.yaml exists there, so its steps cannot be inspected`,
 			);
-			queue.push(metadata);
+			queue.push(resolved);
 		}
 	}
 
@@ -659,6 +687,82 @@ test("a uses: value that is not a documented reference form fails the scan", () 
 			() => scanRepository(root),
 			/review\.yml:22: uses: \$\/tools\/prepare/,
 			"an unclassifiable reference must fail the scan, not be skipped",
+		);
+	});
+});
+
+test("persist-credentials must be a literal true or false", () => {
+	// `yes` is the string "yes" under YAML 1.2 but a boolean under YAML 1.1, and
+	// GitHub's parser is the 1.1-flavoured one. Reading "not true, so safe" here would
+	// record a step as compliant that actions/checkout may well see as "true".
+	for (const value of ["yes", "no", "1", "0", "'FALSE'", "~"]) {
+		const yaml = [
+			"jobs:",
+			"  a:",
+			"    steps:",
+			"      - uses: actions/checkout@v4",
+			"        with:",
+			`          persist-credentials: ${value}`,
+		].join("\n");
+		assert.throws(
+			() => collectCheckouts(yaml, "vague.yml"),
+			/vague\.yml:6: persist-credentials: .* is neither true nor false/,
+			`persist-credentials: ${value} must not be read as compliant`,
+		);
+	}
+
+	// Both literal spellings of the compliant value keep working.
+	for (const value of ["false", '"false"']) {
+		const yaml = [
+			"jobs:",
+			"  a:",
+			"    steps:",
+			"      - uses: actions/checkout@v4",
+			"        with:",
+			`          persist-credentials: ${value}`,
+		].join("\n");
+		const checkouts = collectCheckouts(yaml, "ok.yml");
+		assert.equal(checkouts[0].persistCredentials, false, `persist-credentials: ${value}`);
+		assertCheckoutPolicy(checkouts, []);
+	}
+});
+
+test("a local reusable workflow call is scanned as a workflow, not as an action directory", () => {
+	// `uses: ./.github/workflows/build.yml` at job level names the file itself. Looking
+	// for action.yml underneath it would fail the scan on a legitimate workflow.
+	withFixtureRepo((root, write) => {
+		write(".github/workflows/caller.yml", [
+			"jobs:",
+			"  build:",
+			"    uses: ./.github/workflows/build.yml",
+		]);
+		write(".github/workflows/build.yml", [
+			"jobs:",
+			"  build:",
+			"    steps:",
+			"      - uses: actions/checkout@v4",
+		]);
+
+		const { checkouts, scanned } = scanRepository(root);
+		assert.ok(scanned.includes(join(root, ".github", "workflows", "build.yml")));
+		// The called workflow's unprotected checkout is still policed.
+		assert.throws(
+			() => assertCheckoutPolicy(checkouts, []),
+			/build\.yml:4 .*must set persist-credentials: false or be allowlisted/,
+		);
+	});
+});
+
+test("a reusable workflow call pointing at a missing file fails the scan", () => {
+	withFixtureRepo((root, write) => {
+		write(".github/workflows/caller.yml", [
+			"jobs:",
+			"  build:",
+			"    uses: ./.github/workflows/absent.yml",
+		]);
+		assert.throws(
+			() => scanRepository(root),
+			/caller\.yml:3: uses: \.\/\.github\/workflows\/absent\.yml but that workflow file does not exist/,
 		);
 	});
 });

--- a/scripts/workflow-checkout-credentials.test.mjs
+++ b/scripts/workflow-checkout-credentials.test.mjs
@@ -8,6 +8,11 @@ import test from "node:test";
 // step must set persist-credentials: false, or be on the allowlist below
 // with a YAML comment documenting why persisted git auth is required.
 
+// A new actions/checkout is a new place the job token can land on disk. The
+// coverage guard keeps a checkout from vanishing from the scan; this keeps one
+// from appearing without anyone deciding it should.
+const EXPECTED_CHECKOUT_COUNT = 6;
+
 const PERSISTED_CREDENTIAL_ALLOWLIST = [
 	{
 		file: ".github/workflows/release.yml",
@@ -19,9 +24,50 @@ const PERSISTED_CREDENTIAL_ALLOWLIST = [
 const CHECKOUT_USES =
 	/^(\s*)(?:- )?uses:\s*['"]?actions\/checkout@\S+/;
 
+// CHECKOUT_USES only understands block-style steps. `- { uses: actions/checkout@v4 }`
+// is valid YAML that Actions runs happily, but it never matches — so without the
+// coverage guard below the step would drop out of collectCheckouts() and the policy
+// assertions would never see it. This scanner exists because model CLIs write
+// .github/workflows/*.yml with no filesystem sandbox (AGENTS.md), which makes a
+// silent pass on unrecognized syntax the exact failure it was written to prevent.
+// Fail closed instead: anything naming actions/checkout that the recognizer cannot
+// inspect fails the test with its file:line. Comment-only lines are excluded — a
+// commented-out step does not run.
+const CHECKOUT_MENTION = /actions\/checkout/g;
+const COMMENT_LINE = /^\s*#/;
+
 function indentOf(line) {
 	const match = line.match(/^(\s*)/);
 	return match ? match[1].length : 0;
+}
+
+function countByLine(entries) {
+	const counts = new Map();
+	for (const line of entries) counts.set(line, (counts.get(line) ?? 0) + 1);
+	return counts;
+}
+
+function assertEveryMentionRecognized(lines, checkouts, file) {
+	const mentioned = countByLine(
+		lines.flatMap((line, index) =>
+			COMMENT_LINE.test(line)
+				? []
+				: Array.from(line.match(CHECKOUT_MENTION) ?? [], () => index + 1),
+		),
+	);
+	const recognized = countByLine(checkouts.map((checkout) => checkout.line));
+
+	const unrecognized = [];
+	for (const [line, count] of [...mentioned].sort((a, b) => a[0] - b[0])) {
+		if ((recognized.get(line) ?? 0) >= count) continue;
+		unrecognized.push(`${file}:${line}: ${lines[line - 1].trim()}`);
+	}
+
+	assert.deepEqual(
+		unrecognized,
+		[],
+		`checkout syntax the scanner cannot inspect (rewrite as a block-style step, or teach CHECKOUT_USES to match it): ${unrecognized.join(" | ")}`,
+	);
 }
 
 function collectCheckouts(content, file) {
@@ -77,6 +123,7 @@ function collectCheckouts(content, file) {
 			line: usesIndex + 1,
 		});
 	}
+	assertEveryMentionRecognized(lines, checkouts, file);
 	return checkouts;
 }
 
@@ -134,7 +181,11 @@ test("every actions/checkout sets persist-credentials: false or is allowlisted",
 	const checkouts = workflowFiles().flatMap((file) =>
 		collectCheckouts(readFileSync(file, "utf8"), file),
 	);
-	assert.ok(checkouts.length >= 6, `expected to find checkouts, found ${checkouts.length}`);
+	assert.equal(
+		checkouts.length,
+		EXPECTED_CHECKOUT_COUNT,
+		`expected exactly ${EXPECTED_CHECKOUT_COUNT} actions/checkout steps, found ${checkouts.length}; bump EXPECTED_CHECKOUT_COUNT deliberately when adding or removing one`,
+	);
 	assertCheckoutPolicy(checkouts, PERSISTED_CREDENTIAL_ALLOWLIST);
 });
 
@@ -190,6 +241,68 @@ test("scanner accepts persist-credentials: false and rejects a stale allowlist e
 			]),
 		/did not match exactly one checkout/,
 	);
+});
+
+test("scanner rejects a flow-mapping checkout instead of silently skipping it", () => {
+	// Valid YAML, runs on Actions, never matches CHECKOUT_USES. Before the coverage
+	// guard this yielded zero checkouts and assertCheckoutPolicy passed on nothing.
+	const yaml = [
+		"jobs:",
+		"  review:",
+		"    steps:",
+		"      - { uses: actions/checkout@v4 }",
+	].join("\n");
+	assert.throws(
+		() => collectCheckouts(yaml, "example.yml"),
+		/example\.yml:4: - \{ uses: actions\/checkout@v4 \}/,
+	);
+});
+
+test("scanner rejects unrecognized checkout syntax even when it sets persist-credentials: false", () => {
+	// Inspectability, not policy: the scanner may not conclude "compliant" from
+	// syntax whose step boundaries it cannot resolve.
+	const yaml = [
+		"jobs:",
+		"  review:",
+		"    steps:",
+		"      - {uses: actions/checkout@v4, with: {persist-credentials: false}}",
+	].join("\n");
+	assert.throws(() => collectCheckouts(yaml, "example.yml"), /example\.yml:4/);
+});
+
+test("one unrecognized checkout fails the scan even when the other steps are compliant", () => {
+	const yaml = [
+		"jobs:",
+		"  review:",
+		"    steps:",
+		"      - uses: actions/checkout@v4",
+		"        with:",
+		"          persist-credentials: false",
+		"      - { uses: actions/checkout@v4 }",
+	].join("\n");
+	assert.throws(
+		() => collectCheckouts(yaml, "example.yml"),
+		(error) => {
+			assert.match(error.message, /example\.yml:7/);
+			assert.doesNotMatch(error.message, /example\.yml:4/);
+			return true;
+		},
+	);
+});
+
+test("a commented-out checkout is not treated as an unrecognized step", () => {
+	const yaml = [
+		"jobs:",
+		"  review:",
+		"    steps:",
+		"      # - uses: actions/checkout@v4  (dropped; the job clones its own copy)",
+		"      - uses: actions/checkout@v4",
+		"        with:",
+		"          persist-credentials: false",
+	].join("\n");
+	const checkouts = collectCheckouts(yaml, "example.yml");
+	assert.equal(checkouts.length, 1);
+	assert.equal(checkouts[0].line, 5);
 });
 
 test("weekly-eval git push authenticates with GH_TOKEN instead of persisted checkout credentials", () => {


### PR DESCRIPTION
Closes #49.

## Problem

`actions/checkout` writes the job token into the checkout's **local git config** (an `http.<host>/.extraheader` basic-auth value) until post-job cleanup. No checkout in this repo set `persist-credentials: false` — grep confirmed zero occurrences.

Needlefish strips GitHub credentials from the model runner's **child environment** (`src/shared/codex.ts` env allowlist), but `AGENTS.md` records that model CLIs *intentionally* run without a process or filesystem sandbox on trusted self-hosted runners. A runner can therefore walk to the checkout directory and read the token straight out of `.git/config` — bypassing the env boundary entirely.

## Change

| Workflow / step | Change | Justification |
|---|---|---|
| `review.yml` — Checkout review target (PR head) → `path: target` | **`persist-credentials: false`** | The tree the model runner works in. Highest priority. |
| `commands.yml` — Checkout PR head → `path: target` | **`persist-credentials: false`** | Feeds the self-hosted `explain` job. |
| `hosted-review.yml` | **`persist-credentials: false`** | Hosted dogfood; model runs against this workspace. |
| `weekly-eval.yml` | **`persist-credentials: false`** + explicit push auth | Runs `eval/run.ts --runner codex`, so the token must not sit on disk during it. |
| `deploy.yml` | **`persist-credentials: false`** | `scripts/deploy-ubuntu.sh:4` defaults `NEEDLEFISH_REPO_URL` to the public clone URL and does its own `git init`/`remote add`/`fetch` in a temp dir — verified, it never uses the workspace checkout's header. |
| `release.yml` | **unchanged**, comment added | Runs `git push -f origin "$major"` for the floating major tag; genuinely needs authenticated git. No model runner in that job. |

`action.yml` has no checkout step.

**`gh` does not need the persisted header** — verified rather than assumed: `GH_TOKEN` authenticates *API requests*; git HTTP auth is a separate path (`gh auth setup-git` exists precisely because of that). Needlefish's posting goes through `ghText` → `runText("gh", …)`, which inherits the parent step's env.

### weekly-eval's push

That path *did* rely on the persisted header. It now authenticates through a credential helper that reads `GH_TOKEN` from the **environment at helper-execution time**:

```bash
git -c credential.helper= \
    -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
    push origin HEAD:main
```

**Proven with real git**, not argued:

```
$ git -c credential.helper='!f() { … "password=$GH_TOKEN"; }; f' credential fill
username=x-access-token
password=<TOKEN-PRESENT>          ← resolved at runtime
```
…while the constructed command line contains **no token** (single-quoted, so bash never expands it).

An earlier revision of this PR used `-c "http.https://github.com/.extraheader=AUTHORIZATION: basic $b64"`. That works, but expands the credential into git's **argv**, readable via `/proc/<pid>/cmdline` — and `weekly-eval` runs on a long-lived shared `self-hosted` machine, so that is a real exposure. `::add-mask::` only redacts log output, not argv. Replaced. As a bonus it drops the GNU-specific `base64 -w0`.

## Verification

`scripts/workflow-checkout-credentials.test.mjs` scans every workflow plus `action.yml` and fails on any `actions/checkout` that neither sets `persist-credentials: false` nor is on a one-entry allowlist whose YAML block documents why (`release.yml`, comment matching `/git push/`).

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 5 / fail 0` |
| drop `persist-credentials: false` from **review.yml** | `pass 4 / fail 1` ✅ |
| drop it from **commands.yml** | `pass 4 / fail 1` ✅ |
| revert weekly-eval to extraheader-in-argv | `pass 4 / fail 1` ✅ |
| restored | `pass 5 / fail 0` |

All YAML parses ✅ · `pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **539 pass / 0 fail** (exit 0).

## Risk / not verified

- **weekly-eval's actual push against GitHub was not live-exercised.** If the credential helper misbehaves on the runner's git version, the weekly report commit fails — visible, recoverable, and it does not affect reviews.
- `commands.yml` `explain`'s git fetch was not tested on a private repo; this repo is public, so unauthenticated fetch works there.
- The token is still present in the parent job env (`GH_TOKEN`) by design. This fix removes it from **disk**, which is the bypass of the runner env allowlist — it does not and must not re-sandbox the runner (`AGENTS.md` forbids that).
- Action versions are deliberately left at `@v4`; SHA pinning is #52's separate PR.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, per-checkout justification review, argv-exposure catch, mutation testing)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI, one corrective round)