### PR TITLE
chore(supply-chain): pin actions to SHAs and runner CLIs to versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           path: target

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,5 +12,5 @@ jobs:
   deploy:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - run: scripts/deploy-ubuntu.sh

--- a/.github/workflows/hosted-review.yml
+++ b/.github/workflows/hosted-review.yml
@@ -1,7 +1,8 @@
 # Dogfood the composite action on a GitHub-hosted runner.
 # Manual trigger only — pull_request reviews stay on the self-hosted runner
 # (review.yml); this exists to live-test the `uses: frankekn/needlefish@v0`
-# path without double-reviewing every PR.
+# path without double-reviewing every PR. The first-party v0 tag is
+# deliberately floating; do not SHA-pin it.
 name: hosted-review
 on:
   workflow_dispatch:
@@ -17,7 +18,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - uses: frankekn/needlefish@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
       - name: Verify

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Checkout review target (PR head)
         if: steps.refs.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ steps.refs.outputs.head }}
           fetch-depth: 0

--- a/.github/workflows/weekly-eval.yml
+++ b/.github/workflows/weekly-eval.yml
@@ -19,7 +19,7 @@ jobs:
   eval:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Run full eval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- GitHub: pin third-party Actions to commit SHAs and pin hosted-action runner
+  CLI defaults per runner, with `runner_version` as an explicit override.
 - GitHub: execute the exact immutable release selected by
   `needlefish_release_sha`, so a newer deployment cannot invalidate or replace a
   caller-pinned review runtime.

--- a/README.md
+++ b/README.md
@@ -427,8 +427,15 @@ other providers' keys need `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR` (see
 
 Inputs (all optional): `pr_number` (defaults to the event PR), `runner`
 (default `codex`), `model`, `timeout_ms`, `codex_reasoning_effort`,
-`runner_version` (npm version of the runner CLI), `repo_path` (defaults to the
-workspace checkout), `github_token` (defaults to the workflow token).
+`runner_version`, `repo_path` (defaults to the workspace checkout),
+`github_token` (defaults to the workflow token).
+
+`runner_version` overrides the npm version of the selected runner CLI. When
+omitted, the action installs the per-runner pin from `action.yml` (currently
+Codex `0.149.0`, Claude `2.1.239`, OpenCode `1.18.21`, pi `0.70.6`). Pass an
+explicit version — or `latest` — only when you intentionally want something
+other than the pin. A single default cannot be correct for four packages, so
+the pin is chosen from the selected `runner`.
 
 Cost and behavior notes:
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -355,6 +355,12 @@ jobs:
 Hosted action 只會安裝 `action.yml` 列出的 runner；Grok CLI 不在其中。要
 使用 Grok 4.5，請使用上方的 self-hosted reusable workflow。
 
+`runner_version` 可覆寫所選 runner CLI 的 npm 版本。未設定時，action 會安裝
+`action.yml` 裡的 per-runner pin（目前 Codex `0.149.0`、Claude `2.1.239`、
+OpenCode `1.18.21`、pi `0.70.6`）。只有在你刻意要偏離 pin 時才傳入明確版本
+（或 `latest`）。四個套件無法共用一個正確的預設值，所以 pin 依 `runner`
+選擇。
+
 runner 認證方式：
 
 | runner | secret／認證 |

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,10 @@ inputs:
     description: "Codex reasoning effort: medium, high, or xhigh"
     required: false
   runner_version:
-    description: npm version of the model runner CLI to install
+    description: >-
+      npm version of the selected runner CLI. Omit to install the per-runner
+      pin in the install step; set to override (including an intentional latest).
     required: false
-    default: latest
   repo_path:
     description: Path to the target repo checkout to review
     required: false
@@ -37,7 +38,7 @@ branding:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 20
     - name: Install needlefish dependencies
@@ -54,13 +55,14 @@ runs:
         NF_RUNNER_VERSION: ${{ inputs.runner_version }}
       run: |
         case "$NF_RUNNER" in
-          codex) pkg="@openai/codex" ;;
-          claude) pkg="@anthropic-ai/claude-code" ;;
-          opencode) pkg="opencode-ai" ;;
-          pi) pkg="@mariozechner/pi" ;;
+          codex) pkg="@openai/codex"; pinned="0.149.0" ;;
+          claude) pkg="@anthropic-ai/claude-code"; pinned="2.1.239" ;;
+          opencode) pkg="opencode-ai"; pinned="1.18.21" ;;
+          pi) pkg="@mariozechner/pi"; pinned="0.70.6" ;;
           *) echo "unknown runner: $NF_RUNNER" >&2; exit 1 ;;
         esac
-        npm install -g "${pkg}@${NF_RUNNER_VERSION}"
+        ver="${NF_RUNNER_VERSION:-$pinned}"
+        npm install -g "${pkg}@${ver}"
     - name: Authenticate model runner
       shell: bash
       env:

--- a/scripts/action-pins.test.mjs
+++ b/scripts/action-pins.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const SHA = /^[0-9a-f]{40}$/;
+const VERSION_COMMENT = /^v\d+\.\d+\.\d+$/;
+const FIRST_PARTY_FLOATING = /^frankekn\/needlefish@v\d+$/;
+const PINNED_RUNNER = /^(\d+)\.(\d+)\.(\d+)$/;
+
+function workflowFiles() {
+  return [
+    "action.yml",
+    ...readdirSync(".github/workflows")
+      .filter((name) => name.endsWith(".yml"))
+      .map((name) => join(".github/workflows", name)),
+  ];
+}
+
+function usesLines(text) {
+  const found = [];
+  for (const [index, line] of text.split("\n").entries()) {
+    const match = line.match(/^\s+(?:-\s+)?uses:\s+(\S+)(?:\s+#\s+(\S+))?\s*$/);
+    if (!match) continue;
+    found.push({
+      line: index + 1,
+      action: match[1],
+      comment: match[2] ?? "",
+      raw: line.trim(),
+    });
+  }
+  return found;
+}
+
+test("third-party actions are SHA-pinned with a version comment", () => {
+  let thirdParty = 0;
+  let firstParty = 0;
+  for (const file of workflowFiles()) {
+    for (const use of usesLines(readFileSync(file, "utf8"))) {
+      if (FIRST_PARTY_FLOATING.test(use.action)) {
+        firstParty += 1;
+        continue;
+      }
+      const at = use.action.lastIndexOf("@");
+      assert.notEqual(at, -1, `${file}:${use.line} missing @ref: ${use.raw}`);
+      const ref = use.action.slice(at + 1);
+      assert.match(
+        ref,
+        SHA,
+        `${file}:${use.line} third-party action must be a 40-hex SHA: ${use.raw}`,
+      );
+      assert.match(
+        use.comment,
+        VERSION_COMMENT,
+        `${file}:${use.line} SHA pin must have a # vX.Y.Z comment: ${use.raw}`,
+      );
+      thirdParty += 1;
+    }
+  }
+  assert.ok(thirdParty > 0, "expected at least one third-party action pin");
+  assert.ok(firstParty > 0, "expected the hosted live-test first-party floating ref");
+});
+
+test("hosted action pins a version per runner and lets runner_version override", () => {
+  const action = readFileSync("action.yml", "utf8");
+  assert.doesNotMatch(action, /^\s+default:\s*latest\s*$/m);
+  assert.match(
+    action,
+    /ver="\$\{NF_RUNNER_VERSION:-\$pinned\}"/,
+    "install step must prefer runner_version when set",
+  );
+  assert.match(action, /npm install -g "\$\{pkg\}@\$\{ver\}"/);
+
+  const pins = {};
+  for (const match of action.matchAll(
+    /^\s+(codex|claude|opencode|pi)\) pkg="([^"]+)"; pinned="([^"]+)" ;;$/gm,
+  )) {
+    pins[match[1]] = { pkg: match[2], pinned: match[3] };
+  }
+  assert.deepEqual(
+    Object.keys(pins).sort(),
+    ["claude", "codex", "opencode", "pi"],
+    "every hosted runner must have its own pin",
+  );
+  assert.equal(pins.codex.pkg, "@openai/codex");
+  assert.equal(pins.claude.pkg, "@anthropic-ai/claude-code");
+  assert.equal(pins.opencode.pkg, "opencode-ai");
+  assert.equal(pins.pi.pkg, "@mariozechner/pi");
+  for (const [runner, { pinned }] of Object.entries(pins)) {
+    assert.notEqual(pinned, "latest", `${runner} must not pin latest`);
+    assert.match(pinned, PINNED_RUNNER, `${runner} pin must be x.y.z: ${pinned}`);
+  }
+});

--- a/scripts/action-pins.test.mjs
+++ b/scripts/action-pins.test.mjs
@@ -6,6 +6,11 @@ import test from "node:test";
 const SHA = /^[0-9a-f]{40}$/;
 const VERSION_COMMENT = /^v\d+\.\d+\.\d+$/;
 const FIRST_PARTY_FLOATING = /^frankekn\/needlefish@v\d+$/;
+// Only hosted-review.yml is allowed to carry a floating frankekn/needlefish@vN ref:
+// it deliberately live-tests the published major tag (see the file's header comment).
+// Any other workflow (deploy.yml, release.yml, etc.) must SHA-pin like every other
+// action, or a floating first-party tag could silently ship in a privileged workflow.
+const FIRST_PARTY_FLOATING_EXEMPT_FILE = join(".github/workflows", "hosted-review.yml");
 const PINNED_RUNNER = /^(\d+)\.(\d+)\.(\d+)$/;
 
 function workflowFiles() {
@@ -32,33 +37,60 @@ function usesLines(text) {
   return found;
 }
 
+// Checks one `uses:` line against the pinning invariant. Returns `{ exempt: true }`
+// for the hosted-review.yml floating first-party tag; otherwise asserts SHA+version
+// comment and returns `{ exempt: false }`. Exported behavior only via return value so
+// both the aggregate sweep test and the file-scoping unit tests exercise the same logic.
+function assertPinned(file, use) {
+  if (file === FIRST_PARTY_FLOATING_EXEMPT_FILE && FIRST_PARTY_FLOATING.test(use.action)) {
+    return { exempt: true };
+  }
+  const at = use.action.lastIndexOf("@");
+  assert.notEqual(at, -1, `${file}:${use.line} missing @ref: ${use.raw}`);
+  const ref = use.action.slice(at + 1);
+  assert.match(
+    ref,
+    SHA,
+    `${file}:${use.line} third-party action must be a 40-hex SHA: ${use.raw}`,
+  );
+  assert.match(
+    use.comment,
+    VERSION_COMMENT,
+    `${file}:${use.line} SHA pin must have a # vX.Y.Z comment: ${use.raw}`,
+  );
+  return { exempt: false };
+}
+
 test("third-party actions are SHA-pinned with a version comment", () => {
   let thirdParty = 0;
   let firstParty = 0;
   for (const file of workflowFiles()) {
     for (const use of usesLines(readFileSync(file, "utf8"))) {
-      if (FIRST_PARTY_FLOATING.test(use.action)) {
+      const { exempt } = assertPinned(file, use);
+      if (exempt) {
         firstParty += 1;
-        continue;
+      } else {
+        thirdParty += 1;
       }
-      const at = use.action.lastIndexOf("@");
-      assert.notEqual(at, -1, `${file}:${use.line} missing @ref: ${use.raw}`);
-      const ref = use.action.slice(at + 1);
-      assert.match(
-        ref,
-        SHA,
-        `${file}:${use.line} third-party action must be a 40-hex SHA: ${use.raw}`,
-      );
-      assert.match(
-        use.comment,
-        VERSION_COMMENT,
-        `${file}:${use.line} SHA pin must have a # vX.Y.Z comment: ${use.raw}`,
-      );
-      thirdParty += 1;
     }
   }
   assert.ok(thirdParty > 0, "expected at least one third-party action pin");
   assert.ok(firstParty > 0, "expected the hosted live-test first-party floating ref");
+});
+
+test("floating first-party tag is exempt in hosted-review.yml", () => {
+  const use = { line: 1, action: "frankekn/needlefish@v0", comment: "", raw: "uses: frankekn/needlefish@v0" };
+  const result = assertPinned(FIRST_PARTY_FLOATING_EXEMPT_FILE, use);
+  assert.deepEqual(result, { exempt: true });
+});
+
+test("floating first-party tag fails the invariant outside hosted-review.yml", () => {
+  const use = { line: 1, action: "frankekn/needlefish@v1", comment: "", raw: "uses: frankekn/needlefish@v1" };
+  assert.throws(
+    () => assertPinned(join(".github/workflows", "deploy.yml"), use),
+    /must be a 40-hex SHA/,
+    "a floating first-party tag must not be silently exempted in a privileged workflow",
+  );
 });
 
 test("hosted action pins a version per runner and lets runner_version override", () => {

--- a/scripts/action-pins.test.mjs
+++ b/scripts/action-pins.test.mjs
@@ -5,11 +5,13 @@ import test from "node:test";
 
 const SHA = /^[0-9a-f]{40}$/;
 const VERSION_COMMENT = /^v\d+\.\d+\.\d+$/;
-const FIRST_PARTY_FLOATING = /^frankekn\/needlefish@v\d+$/;
-// Only hosted-review.yml is allowed to carry a floating frankekn/needlefish@vN ref:
-// it deliberately live-tests the published major tag (see the file's header comment).
-// Any other workflow (deploy.yml, release.yml, etc.) must SHA-pin like every other
-// action, or a floating first-party tag could silently ship in a privileged workflow.
+// Only hosted-review.yml is allowed to carry a floating first-party ref, and only the
+// exact major tag its header comment documents as the deliberate live-test target
+// (currently v0 — see .github/workflows/hosted-review.yml:1-5). Matching any `vN` here
+// would silently follow a future major bump (or a typo) without anyone updating this
+// test, defeating the point of an intentional, reviewed exemption. Bumping the major
+// tag in hosted-review.yml must come with a matching bump here in the same PR.
+const FIRST_PARTY_FLOATING = /^frankekn\/needlefish@v0$/;
 const FIRST_PARTY_FLOATING_EXEMPT_FILE = join(".github/workflows", "hosted-review.yml");
 const PINNED_RUNNER = /^(\d+)\.(\d+)\.(\d+)$/;
 
@@ -90,6 +92,15 @@ test("floating first-party tag fails the invariant outside hosted-review.yml", (
     () => assertPinned(join(".github/workflows", "deploy.yml"), use),
     /must be a 40-hex SHA/,
     "a floating first-party tag must not be silently exempted in a privileged workflow",
+  );
+});
+
+test("a different floating major tag in hosted-review.yml is not silently exempted", () => {
+  const use = { line: 1, action: "frankekn/needlefish@v1", comment: "", raw: "uses: frankekn/needlefish@v1" };
+  assert.throws(
+    () => assertPinned(FIRST_PARTY_FLOATING_EXEMPT_FILE, use),
+    /must be a 40-hex SHA/,
+    "only the documented v0 tag is exempt in hosted-review.yml; a major bump must update this test deliberately",
   );
 });
 


### PR DESCRIPTION
Closes #52.

## Problem

Six workflows plus `action.yml` used mutable tags (`actions/checkout@v4`, `actions/setup-node@v4`), and `action.yml` defaulted `runner_version` to `latest`:

```bash
npm install -g "${pkg}@${NF_RUNNER_VERSION}"     # NF_RUNNER_VERSION = latest
```

So the **same needlefish revision installed different executable code over time**. These runners execute inside *target* repos, which makes a silent version change a change to what runs on other people's code.

## Action pins — independently verified

Both SHAs re-resolved from GitHub during review, not taken from the implementor's report:

| Action | SHA | Tag | Verification |
|---|---|---|---|
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 | ✅ tag ref matches; commit exists (2026-07-16) |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 | ✅ tag ref matches; commit exists (2025-04-02) |

Neither tag is annotated, so no `git/tags` dereference was needed. Pins stay on the **latest v4.x** — deliberately not a major-version bump, even though v5+ exist.

`frankekn/needlefish@v0` in `hosted-review.yml` **stays floating on purpose**: that workflow exists to live-test the published major tag. Documented in its header and encoded in the invariant test, which distinguishes third-party pins from the first-party floating tag.

## Runner-version pins

A single `runner_version` default cannot be correct for four different packages, so the input loses its default and the install step carries a per-runner map. All four confirmed published:

| runner | package | pin | `npm view` |
|---|---|---|---|
| codex | `@openai/codex` | `0.149.0` | ✅ exists |
| claude | `@anthropic-ai/claude-code` | `2.1.239` | ✅ exists |
| opencode | `opencode-ai` | `1.18.21` | ✅ exists |
| pi | `@mariozechner/pi` | `0.70.6` | ✅ exists |

`runner_version` still overrides when set — including an intentional `latest` — so callers testing another version are unaffected. Default and override behavior are documented in both READMEs and in the input description.

Refreshes come from a new `.github/dependabot.yml` (`github-actions`, weekly), not a custom updater.

## Verification

`scripts/action-pins.test.mjs` asserts the invariant: every third-party `uses:` is SHA-pinned with a version comment, and the runner map contains no `latest`.

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 2 / fail 0` |
| unpin `checkout` in `deploy.yml` | `pass 1 / fail 1` ✅ |
| runner pin back to `latest` | `pass 1 / fail 1` ✅ |
| unpin `setup-node` in `action.yml` | `pass 1 / fail 1` ✅ |
| restored | `pass 2 / fail 0` |

All YAML parses (workflows + `action.yml` + `dependabot.yml`) ✅ · `pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **536 pass / 0 fail** (exit 0).

## Risk / not verified

- **The pinned SHAs were not audited line by line** — they are verified to *be* the v4.4.0 releases of the official `actions/*` repos, which is what "reviewed commit SHA" means here in practice.
- `@anthropic-ai/claude-code` also publishes a `stable` dist-tag at `2.1.231`. The pin follows `npm view … version` (i.e. `latest`, `2.1.239`). If you would rather track `stable` for the claude runner, that is a one-line change.
- Pinned runner versions will go stale; Dependabot covers actions but **not** the npm pins inside `action.yml`'s shell map — those need manual bumps. Called out rather than left implicit.
- No workflow triggers, permissions, `runs-on`, or logic changed; `persist-credentials` is #49's separate PR.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, independent SHA and npm-version re-verification, mutation testing)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)