### PR TITLE
fix(github): parse C-quoted diff paths before inline anchoring

### DIFF
--- a/src/adapters/github-diff-path.test.ts
+++ b/src/adapters/github-diff-path.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { commitAll, initRepo } from "../shared/codex-runner-test-fixtures";
+import { anchorableIn, headLinesInPatch, unquoteGitCStyle } from "./github";
+
+test("unquoteGitCStyle decodes named escapes and leaves trailing junk after the close quote", () => {
+  assert.equal(unquoteGitCStyle('"plain"'), "plain");
+  assert.equal(unquoteGitCStyle('"a\\\\b"'), "a\\b");
+  assert.equal(unquoteGitCStyle('"a\\"b"'), 'a"b');
+  assert.equal(unquoteGitCStyle('"a\\nb"'), "a\nb");
+  assert.equal(unquoteGitCStyle('"a\\tb"'), "a\tb");
+  assert.equal(unquoteGitCStyle('"a\\rb"'), "a\rb");
+  assert.equal(unquoteGitCStyle('"a\\bb"'), "a\bb");
+  assert.equal(unquoteGitCStyle('"a\\fb"'), "a\fb");
+  assert.equal(unquoteGitCStyle('"a\\vb"'), "a\vb");
+  assert.equal(unquoteGitCStyle('"a\\ab"'), "a\x07b");
+  assert.equal(unquoteGitCStyle('"b/foo"\tSat Jan 1 00:00:00 2024 +0000'), "b/foo");
+});
+
+test("unquoteGitCStyle decodes octal escapes as UTF-8 bytes, not code points", () => {
+  // 測 U+6E2C = e6 b8 ac; 試 U+8A66 = e8 a9 a6. Independent-code-point
+  // decoding of \346\270\254 would be mojibake, not 測.
+  assert.equal(unquoteGitCStyle('"b/src/\\346\\270\\254\\350\\251\\246.ts"'), "b/src/測試.ts");
+  assert.notEqual(unquoteGitCStyle('"\\346\\270\\254"'), "\u0146\u00b8\u00ac");
+});
+
+test("unquoteGitCStyle rejects malformed quoting", () => {
+  assert.equal(unquoteGitCStyle("plain"), null);
+  assert.equal(unquoteGitCStyle('"unterminated'), null);
+  assert.equal(unquoteGitCStyle('"\\x"'), null);
+  assert.equal(unquoteGitCStyle('"\\400"'), null);
+  assert.equal(unquoteGitCStyle('"\\34"'), null);
+  assert.equal(unquoteGitCStyle(""), null);
+});
+
+test("headLinesInPatch strips a trailing tab from an unquoted +++ path", () => {
+  const patch = [
+    "diff --git a/src/has space.ts b/src/has space.ts",
+    "--- a/src/has space.ts",
+    "+++ b/src/has space.ts\t",
+    "@@ -0,0 +1 @@",
+    "+x",
+    "diff --git a/ordinary.ts b/ordinary.ts",
+    "--- a/ordinary.ts",
+    "+++ b/ordinary.ts\t2024-01-01 00:00:00.000000000 +0000",
+    "@@ -0,0 +1 @@",
+    "+y",
+  ].join("\n");
+  const ranges = headLinesInPatch(patch);
+  assert.deepEqual(ranges.get("src/has space.ts"), [[1, 1]]);
+  assert.equal(ranges.has("src/has space.ts\t"), false);
+  assert.equal(anchorableIn(ranges, "src/has space.ts", 1), true);
+  assert.deepEqual(ranges.get("ordinary.ts"), [[1, 1]]);
+  assert.equal(anchorableIn(ranges, "ordinary.ts", 1), true);
+});
+
+test("headLinesInPatch anchors a handwritten C-quoted CJK +++ header", () => {
+  const patch = [
+    'diff --git "a/src/\\346\\270\\254\\350\\251\\246.ts" "b/src/\\346\\270\\254\\350\\251\\246.ts"',
+    "new file mode 100644",
+    "--- /dev/null",
+    '+++ "b/src/\\346\\270\\254\\350\\251\\246.ts"',
+    "@@ -0,0 +1 @@",
+    "+x",
+  ].join("\n");
+  const ranges = headLinesInPatch(patch);
+  assert.deepEqual(ranges.get("src/測試.ts"), [[1, 1]]);
+  assert.equal(anchorableIn(ranges, "src/測試.ts", 1), true);
+});
+
+function runGit(repo: string, args: readonly string[]): Buffer {
+  const result = spawnSync("git", [...args], { cwd: repo, encoding: "buffer" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${(result.stderr ?? Buffer.alloc(0)).toString("utf8")}`,
+    );
+  }
+  return result.stdout ?? Buffer.alloc(0);
+}
+
+function plusPlusPlusHeaders(diff: Buffer): Buffer[] {
+  const headers: Buffer[] = [];
+  let start = 0;
+  for (let i = 0; i <= diff.length; i++) {
+    if (i !== diff.length && diff[i] !== 0x0a) continue;
+    const line = diff.subarray(start, i);
+    if (line.length >= 4 && line.subarray(0, 4).equals(Buffer.from("+++ "))) {
+      headers.push(Buffer.from(line));
+    }
+    start = i + 1;
+  }
+  return headers;
+}
+
+test("headLinesInPatch parses real git-generated headers for hostile names", (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-diff-path-"));
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+  const repo = initRepo(tmp);
+  mkdirSync(path.join(repo, "src"));
+
+  const files: ReadonlyArray<{ name: string; body: string }> = [
+    { name: "src/has space.ts", body: "space-a\nspace-b\n" },
+    { name: "src/has\ttab.ts", body: "tab-a\ntab-b\n" },
+    { name: 'src/has"quote.ts', body: "quote-a\nquote-b\n" },
+    { name: "src/has\\slash.ts", body: "slash-a\nslash-b\n" },
+    { name: "src/測試.ts", body: "cjk-a\ncjk-b\ncjk-c\n" },
+    { name: "src/測 space.ts", body: "mix-a\nmix-b\n" },
+  ];
+  for (const file of files) {
+    writeFileSync(path.join(repo, file.name), file.body);
+  }
+  commitAll(repo, "hostile names");
+
+  const diff = runGit(repo, ["diff", "HEAD~1", "HEAD"]);
+  const patch = diff.toString("utf8");
+  const ranges = headLinesInPatch(patch);
+
+  assert.deepEqual(ranges.get("src/has space.ts"), [[1, 2]]);
+  assert.deepEqual(ranges.get("src/has\ttab.ts"), [[1, 2]]);
+  assert.deepEqual(ranges.get('src/has"quote.ts'), [[1, 2]]);
+  assert.deepEqual(ranges.get("src/has\\slash.ts"), [[1, 2]]);
+  assert.deepEqual(ranges.get("src/測試.ts"), [[1, 3]]);
+  assert.deepEqual(ranges.get("src/測 space.ts"), [[1, 2]]);
+
+  for (const file of files) {
+    assert.equal(anchorableIn(ranges, file.name, 1), true);
+  }
+  for (const key of ranges.keys()) {
+    assert.equal(key.startsWith('"'), false, `leftover quotes in ${key}`);
+    assert.doesNotMatch(key, /\\[0-7]{3}/, `leftover octal escape in ${key}`);
+  }
+
+  const headers = plusPlusPlusHeaders(diff);
+  const cjkHeader = headers.find((line) => {
+    const text = line.toString("utf8");
+    return text.includes("\\346\\270\\254\\350\\251\\246") || /b\/src\/測試\.ts/.test(text);
+  });
+  assert.ok(cjkHeader, "expected a +++ header for the CJK file");
+  // Default core.quotepath quotes non-ASCII as octal; either form is git's.
+  assert.match(
+    cjkHeader.toString("utf8"),
+    /\+\+\+ "b\/src\/\\346\\270\\254\\350\\251\\246\.ts"|\+\+\+ b\/src\/測試\.ts/,
+  );
+});
+
+test("headLinesInPatch skips a real git deleted-file header", (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-diff-path-del-"));
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+  const repo = initRepo(tmp);
+  writeFileSync(path.join(repo, "gone.txt"), "bye\n");
+  commitAll(repo, "add gone");
+  runGit(repo, ["rm", "-q", "gone.txt"]);
+  commitAll(repo, "delete gone");
+
+  const patch = runGit(repo, ["diff", "HEAD~1", "HEAD"]).toString("utf8");
+  assert.match(patch, /^\+\+\+ \/dev\/null$/m);
+  const ranges = headLinesInPatch(patch);
+  assert.equal(ranges.has("gone.txt"), false);
+  assert.equal(anchorableIn(ranges, "gone.txt", 1), false);
+});
+
+test("headLinesInPatch uses the head-side path from a real git rename", (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-diff-path-mv-"));
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+  const repo = initRepo(tmp);
+  writeFileSync(path.join(repo, "old.txt"), "old\n");
+  commitAll(repo, "add old");
+  runGit(repo, ["mv", "old.txt", "new.txt"]);
+  writeFileSync(path.join(repo, "new.txt"), "old\nnew\n");
+  commitAll(repo, "rename and edit");
+
+  const patch = runGit(repo, ["diff", "HEAD~1", "HEAD"]).toString("utf8");
+  assert.match(patch, /^rename from old\.txt$/m);
+  assert.match(patch, /^rename to new\.txt$/m);
+  const ranges = headLinesInPatch(patch);
+  assert.deepEqual(ranges.get("new.txt"), [[1, 2]]);
+  assert.equal(ranges.has("old.txt"), false);
+  assert.equal(anchorableIn(ranges, "new.txt", 2), true);
+});

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -118,9 +118,88 @@ export function applyVerdictLabel(
 	return Promise.resolve();
 }
 
+// Git C-quoting (quote.c unquote_c_style): surrounding double quotes,
+// named escapes \a \b \f \n \r \t \v \\ \", and 3-digit octal \NNN.
+// Octal values are bytes of the UTF-8 path, not independent code points.
+export function unquoteGitCStyle(quoted: string): string | null {
+	const src = Buffer.from(quoted, "utf8");
+	if (src.length < 2 || src[0] !== 0x22) return null;
+	const out: number[] = [];
+	let i = 1;
+	while (i < src.length) {
+		const b = src[i++];
+		if (b === 0x22) return Buffer.from(out).toString("utf8");
+		if (b !== 0x5c) {
+			out.push(b);
+			continue;
+		}
+		if (i >= src.length) return null;
+		const esc = src[i++];
+		switch (esc) {
+			case 0x61:
+				out.push(0x07);
+				break;
+			case 0x62:
+				out.push(0x08);
+				break;
+			case 0x66:
+				out.push(0x0c);
+				break;
+			case 0x6e:
+				out.push(0x0a);
+				break;
+			case 0x72:
+				out.push(0x0d);
+				break;
+			case 0x74:
+				out.push(0x09);
+				break;
+			case 0x76:
+				out.push(0x0b);
+				break;
+			case 0x5c:
+			case 0x22:
+				out.push(esc);
+				break;
+			case 0x30:
+			case 0x31:
+			case 0x32:
+			case 0x33: {
+				if (i + 1 >= src.length) return null;
+				const d2 = src[i];
+				const d3 = src[i + 1];
+				if (d2 < 0x30 || d2 > 0x37 || d3 < 0x30 || d3 > 0x37) return null;
+				i += 2;
+				out.push(((esc - 0x30) << 6) | ((d2 - 0x30) << 3) | (d3 - 0x30));
+				break;
+			}
+			default:
+				return null;
+		}
+	}
+	return null;
+}
+
+function pathFromDiffHeaderRest(rest: string): string | null {
+	if (rest.startsWith('"')) return unquoteGitCStyle(rest);
+	const tab = rest.indexOf("\t");
+	return tab === -1 ? rest : rest.slice(0, tab);
+}
+
+function headPathFromPlusPlusPlus(line: string): string | null {
+	const decoded = pathFromDiffHeaderRest(line.slice(4));
+	if (decoded === null || decoded === "/dev/null") return null;
+	if (!decoded.startsWith("b/")) return null;
+	const file = decoded.slice(2);
+	return file === "" ? null : file;
+}
+
 // Parse a unified diff into head-side (new) line ranges per file path.
-// For each `+++ b/<path>`, hunk headers `@@ -a,b +c,d @@` yield [c, c+d-1];
-// d defaults to 1 when omitted. Deleted files (`+++ /dev/null`) are skipped.
+// `+++` paths follow git quoting: unquoted `b/<path>`, or C-quoted
+// `"b/<path>"` (the `b/` prefix sits inside the quotes). A tab after the
+// name is a GNU-patch terminator / timestamp separator, not part of the path.
+// Hunk headers `@@ -a,b +c,d @@` yield [c, c+d-1]; d defaults to 1 when
+// omitted. Deleted files (`+++ /dev/null`) are skipped.
 export function headLinesInPatch(
 	patch: string,
 ): Map<string, Array<[number, number]>> {
@@ -128,8 +207,7 @@ export function headLinesInPatch(
 	let file: string | null = null;
 	for (const raw of patch.split("\n")) {
 		if (raw.startsWith("+++ ")) {
-			const m = /^\+\+\+ b\/(.+)$/.exec(raw);
-			file = m ? m[1] : null;
+			file = headPathFromPlusPlusPlus(raw);
 			if (file && !ranges.has(file)) ranges.set(file, []);
 			continue;
 		}


### PR DESCRIPTION
Closes #57.

## Problem

`headLinesInPatch` recognized only unquoted headers:

```ts
const m = /^\+\+\+ b\/(.+)$/.exec(raw);
```

Real `git diff` output breaks that two ways. Both confirmed by generating an actual patch (shown with `cat -A`, `^I` = tab):

```
+++ b/src/has space.ts^I
+++ "b/src/has\"quote.ts"
+++ "b/src/has\\slash.ts"
+++ "b/src/\346\270\254\350\251\246.ts"
```

Running the **old** parser over those exact headers:

```
"src/has space.ts\t" -> [[1,1]]        ← trailing tab swallowed into the name
(quoted headers produced no key at all)
```

So `anchorableIn` never matched, and every finding in such a file silently lost inline anchoring — visible only in the summary body. **The verdict is unaffected**; this is posting completeness, not verdict integrity, and is scoped accordingly.

## Change

Replaces the regex with a decoder for git's own quoting rules (`unquote_c_style`): `\\` `\"` `\n` `\t` `\r` `\b` `\f` `\v` `\a`, and 3-digit octal.

**Octal escapes are collected as bytes and then decoded as UTF-8.** Decoding each `\NNN` as its own code point turns `測` into mojibake, so a test pins that specific mistake. Unknown or truncated escapes fail closed (no anchors for that file rather than a wrong key).

`b/` is stripped inside the quotes for quoted headers and outside for unquoted ones; unquoted names are cut at the first tab; `+++ /dev/null` is still skipped; renames still use the head-side path.

## Verification

**Against real git output**, not hand-written fixtures — a temp repo with hostile filenames, `git diff` piped into the real function:

| input header (real git) | decoded key |
|---|---|
| `+++ b/src/has space.ts` + tab | `src/has space.ts` ✅ |
| `+++ "b/src/has\"quote.ts"` | `src/has"quote.ts` ✅ |
| `+++ "b/src/has\\slash.ts"` | `src/has\slash.ts` ✅ |
| `+++ "b/src/\346\270\254\350\251\246.ts"` | `src/測試.ts` ✅ |

Also covered with real git: a quoted CJK name *with* a trailing tab after the close quote, a deleted file (`/dev/null`, excluded), and a rename+edit (head-side path used).

**Mutation-verified:** restoring the old regex parser turns **3** tests red (`pass 15 / fail 0` → `pass 12 / fail 3`); restoring the fix returns them to green. The pre-existing `github-anchor.test.ts` cases pass unchanged throughout.

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **542 pass / 0 fail** (exit 0).

## Risk / not verified

- **No live GitHub PR post.** The bug lives in the local `git diff` → `headLinesInPatch` key, which is exactly the seam the real-git tests exercise. This would change if GitHub ever fed the function a non-git patch dialect.
- Names containing a literal newline, CR, bell, backspace, vertical tab, or form feed are covered by **handwritten decoder cases only** — creating them in a real repo is awkward even where the filesystem allows it. Stated rather than implied.
- The `>20 anchorable findings` selection rule and finding-side path production are untouched.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, real-git byte-level comparison of old vs new parser, mutation testing)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)