### PR TITLE
fix(github): authenticate needlefish-state markers before same-head dedupe

### DIFF
--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -36,6 +36,7 @@ type Fixture = {
 	readonly repo: string;
 	readonly reviewOutput: string;
 	readonly reviewsState: string;
+	readonly issueCommentsState: string;
 	readonly runnerLog: string;
 	readonly headSha: string;
 };
@@ -199,6 +200,12 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"const fs = require('node:fs');",
 			"const args = process.argv.slice(2);",
 			"if (args[0] !== 'api') process.exit(2);",
+			// Mirror the live API: every user object carries `type`, and GitHub
+			// only ever pairs a `[bot]` login with type "Bot". Verified against
+			// `gh api repos/frankekn/needlefish/pulls/71/reviews`, which returns
+			// {login: "github-actions[bot]", type: "Bot"}.
+			`const AUTHOR_LOGIN = ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")};`,
+			"const AUTHOR_TYPE = AUTHOR_LOGIN.endsWith('[bot]') ? 'Bot' : 'User';",
 			"if (args.includes('--input')) {",
 			"  const payload = fs.readFileSync(0, 'utf8');",
 			`  fs.appendFileSync(${JSON.stringify(postLog)}, JSON.stringify({ args, payload }) + '\\n');`,
@@ -210,7 +217,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  const apiPath = methodIdx >= 0 ? args[methodIdx + 2] : args[1];",
 			"  if (apiPath === reviewsEndpoint && method === 'POST') {",
 			"    const parsed = JSON.parse(payload);",
-			`    reviews.push({ id: reviews.length + 1, body: parsed.body || '', user: { login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} } });`,
+			"    reviews.push({ id: reviews.length + 1, body: parsed.body || '', user: { login: AUTHOR_LOGIN, type: AUTHOR_TYPE } });",
 			"    fs.writeFileSync(reviewsPath, JSON.stringify(reviews));",
 			"  }",
 			"  if (apiPath && apiPath.startsWith(reviewsEndpoint + '/') && method === 'PUT') {",
@@ -228,7 +235,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"    const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
 			"    const parsed = JSON.parse(payload);",
 			"    const nextId = issueComments.length + 1;",
-			`    issueComments.push({ id: nextId, node_id: 'IC_node_' + nextId, body: parsed.body || '', user: { login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} } });`,
+			"    issueComments.push({ id: nextId, node_id: 'IC_node_' + nextId, body: parsed.body || '', user: { login: AUTHOR_LOGIN, type: AUTHOR_TYPE } });",
 			"    fs.writeFileSync(issueCommentsPath, JSON.stringify(issueComments));",
 			"  }",
 			"  process.stdout.write('{}');",
@@ -270,7 +277,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  process.stdout.write(JSON.stringify(issueComments));",
 			"  process.exit(0);",
 			"}",
-			`if (args[1] === 'user') { if (${JSON.stringify(opts.failUserApi === true)} === true) { process.stderr.write('simulated user lookup failure'); process.exit(1); } process.stdout.write(JSON.stringify({ login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} })); process.exit(0); }`,
+			`if (args[1] === 'user') { if (${JSON.stringify(opts.failUserApi === true)} === true) { process.stderr.write('simulated user lookup failure'); process.exit(1); } process.stdout.write(JSON.stringify({ login: AUTHOR_LOGIN, type: AUTHOR_TYPE })); process.exit(0); }`,
 			"if (args[1] === 'graphql') {",
 			`  fs.appendFileSync(${JSON.stringify(postLog)}, JSON.stringify({ args, payload: '' }) + '\\n');`,
 			"  process.stdout.write('{}');",
@@ -305,6 +312,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 		repo,
 		reviewOutput: reviewOutputFile,
 		reviewsState,
+		issueCommentsState,
 		runnerLog,
 		headSha: targetHeadSha,
 	};
@@ -1017,7 +1025,10 @@ test("runGithub finds a state-bearing review on the second paginated page", asyn
 
 // --- State-marker author trust (same-head dedupe must not trust strangers) ---
 
-test("runGithub still skips same-head review when the marker is from a trusted bot author", async (t) => {
+// The production identity: under GITHUB_TOKEN, Needlefish's reviews come back
+// from the API as {login: "github-actions[bot]", type: "Bot"} (verified live
+// on frankekn/needlefish#71). This is the identity the dedupe must still trust.
+test("runGithub still skips same-head review when the marker is from the real github-actions[bot] identity", async (t) => {
 	const fixture = setupFixture(t, {
 		prNumber: 50,
 		rawReview: defaultRawReview(),
@@ -1026,7 +1037,7 @@ test("runGithub still skips same-head review when the marker is from a trusted b
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "github-actions" },
+			user: { login: "github-actions[bot]", type: "Bot" },
 		},
 	]);
 
@@ -1036,7 +1047,7 @@ test("runGithub still skips same-head review when the marker is from a trusted b
 	assert.deepEqual(readPosts(fixture.postLog), [], "dedupe must post nothing");
 });
 
-test("runGithub still skips same-head review when the marker is from a [bot] suffix author", async (t) => {
+test("runGithub still skips same-head review when the marker is from a GitHub App bot identity", async (t) => {
 	const fixture = setupFixture(t, {
 		prNumber: 51,
 		rawReview: defaultRawReview(),
@@ -1045,7 +1056,7 @@ test("runGithub still skips same-head review when the marker is from a [bot] suf
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "needlefish[bot]" },
+			user: { login: "needlefish[bot]", type: "Bot" },
 		},
 	]);
 
@@ -1065,7 +1076,7 @@ test("runGithub still skips same-head review when the marker is from the authent
 		{
 			id: 7,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "frank-pat" },
+			user: { login: "frank-pat", type: "User" },
 		},
 	]);
 
@@ -1079,6 +1090,106 @@ test("runGithub still skips same-head review when the marker is from the authent
 	assert.deepEqual(readPosts(fixture.postLog), []);
 });
 
+// THE BYPASS THIS PR EXISTS TO CLOSE. `z-github-actions-z` is a registrable
+// GitHub username (alphanumerics + single hyphens) that contains
+// "github-actions" as a substring. Any user can open a review on a public PR,
+// so if the marker author is authorized by substring the attacker mints a
+// same-head marker and the dedupe silently skips the model run, the review
+// post and the check run.
+test("runGithub does not trust a same-head marker whose author merely contains github-actions as a substring", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 63,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "z-github-actions-z", type: "User" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 63, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"a substring-lookalike login must not suppress the model runner",
+	);
+	assert.ok(
+		postedReview(readPosts(fixture.postLog), 63),
+		"a substring-lookalike login must not suppress posting a review",
+	);
+});
+
+// Defence in depth: GitHub never issues a human account a login containing
+// brackets, but the trust decision must rest on the type GitHub asserts, not
+// on the login's shape, so a User-typed "[bot]" login stays untrusted.
+test("runGithub does not trust a same-head marker from a [bot]-shaped login that GitHub types as User", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 64,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "needlefish[bot]", type: "User" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 64, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"user-typed [bot] login must not suppress the model runner",
+	);
+	assert.ok(postedReview(readPosts(fixture.postLog), 64));
+});
+
+// The cosmetic cleanup path keeps the loose, substring-based predicate on
+// purpose (see isLooselyBotShaped). This pins that the security tightening
+// above did not leak into it: a round comment from a loosely bot-shaped login
+// that is neither the real bot identity nor the authenticated login is still
+// minimized, exactly as before.
+test("minimizePreviousRoundComments still sweeps a loosely bot-shaped author", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 65,
+		rawReview: defaultRawReview(),
+	});
+	// Trusted marker for a DIFFERENT head: prev exists, so the re-review branch
+	// (the one that minimizes) runs instead of the same-head dedupe.
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 10,
+			body: stateReviewBody("c".repeat(40)),
+			user: { login: "github-actions[bot]", type: "Bot" },
+		},
+	]);
+	writeFileSync(
+		fixture.issueCommentsState,
+		JSON.stringify([
+			{
+				id: 99,
+				node_id: "IC_seeded_loose",
+				body: "**Needlefish re-review** @ deadbee\n<!-- needlefish-round -->",
+				user: { login: "github-actions", type: "User" },
+			},
+		]),
+	);
+
+	await runGithub(fixture.repo, 65, { timeoutMs: 1000 });
+
+	const minimized = readPosts(fixture.postLog).some(
+		(p) =>
+			p.args.some((a) => a.includes("minimizeComment")) &&
+			p.args.some((a) => a.includes("IC_seeded_loose")),
+	);
+	assert.ok(
+		minimized,
+		"cosmetic cleanup must keep its loose author test unchanged",
+	);
+});
+
 test("runGithub does not skip same-head review when the only state marker is from an untrusted user", async (t) => {
 	const fixture = setupFixture(t, {
 		prNumber: 53,
@@ -1088,7 +1199,7 @@ test("runGithub does not skip same-head review when the only state marker is fro
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "unrelated-attacker" },
+			user: { login: "unrelated-attacker", type: "User" },
 		},
 	]);
 
@@ -1114,7 +1225,7 @@ test("runGithub ignores an untrusted review that quotes a trusted state marker",
 		{
 			id: 1,
 			body: quoted,
-			user: { login: "unrelated-attacker" },
+			user: { login: "unrelated-attacker", type: "User" },
 		},
 	]);
 
@@ -1136,15 +1247,15 @@ test("runGithub skips malformed review objects without throwing and does not tre
 	seedReviews(fixture.reviewsState, [
 		"not an object",
 		null,
-		{ body, id: "1", user: { login: "github-actions[bot]" } },
-		{ body, id: 2, user: { login: 123 } },
+		{ body, id: "1", user: { login: "github-actions[bot]", type: "Bot" } },
+		{ body, id: 2, user: { login: 123, type: "Bot" } },
 		{ body, id: 3, user: "github-actions[bot]" },
 		{ body, id: 4 },
-		{ body, user: { login: "github-actions[bot]" } },
+		{ body, user: { login: "github-actions[bot]", type: "Bot" } },
 		{
 			id: 100,
 			body,
-			user: { login: "unrelated-attacker" },
+			user: { login: "unrelated-attacker", type: "User" },
 		},
 	]);
 
@@ -1167,12 +1278,12 @@ test("runGithub skips an untrusted newest marker and still uses an older trusted
 		{
 			id: 10,
 			body: stateReviewBody(otherHead),
-			user: { login: "github-actions[bot]" },
+			user: { login: "github-actions[bot]", type: "Bot" },
 		},
 		{
 			id: 20,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "unrelated-attacker" },
+			user: { login: "unrelated-attacker", type: "User" },
 		},
 	]);
 
@@ -1203,12 +1314,12 @@ test("runGithub skips same-head review when an untrusted newest marker is follow
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "github-actions[bot]" },
+			user: { login: "github-actions[bot]", type: "Bot" },
 		},
 		{
 			id: 2,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "unrelated-attacker" },
+			user: { login: "unrelated-attacker", type: "User" },
 		},
 	]);
 
@@ -1229,12 +1340,12 @@ test("runGithub still finds a trusted marker when an untrusted one is newest acr
 		{
 			id: 10,
 			body: stateReviewBody(otherHead),
-			user: { login: "github-actions[bot]" },
+			user: { login: "github-actions[bot]", type: "Bot" },
 		},
 		{
 			id: 20,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "unrelated-attacker" },
+			user: { login: "unrelated-attacker", type: "User" },
 		},
 	]);
 
@@ -1253,7 +1364,7 @@ test("runGithub re-reviews a trusted same-head marker when recheck is true", asy
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "github-actions[bot]" },
+			user: { login: "github-actions[bot]", type: "Bot" },
 		},
 	]);
 
@@ -1276,7 +1387,7 @@ test("runGithub still skips a bot-authored same-head marker when gh api user fai
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "github-actions[bot]" },
+			user: { login: "github-actions[bot]", type: "Bot" },
 		},
 	]);
 
@@ -1296,7 +1407,7 @@ test("runGithub does not skip an untrusted same-head marker when gh api user fai
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "unrelated-attacker" },
+			user: { login: "unrelated-attacker", type: "User" },
 		},
 	]);
 
@@ -1320,7 +1431,7 @@ test("runGithub does not skip a PAT-authored marker when gh api user fails", asy
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "frank-pat" },
+			user: { login: "frank-pat", type: "User" },
 		},
 	]);
 

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -1047,7 +1047,10 @@ test("runGithub still skips same-head review when the marker is from the real gi
 	assert.deepEqual(readPosts(fixture.postLog), [], "dedupe must post nothing");
 });
 
-test("runGithub still skips same-head review when the marker is from a GitHub App bot identity", async (t) => {
+// A different GitHub App installed on the repo is a genuine Bot identity but
+// it is not us. Trusting it would let it suppress our review, so bot-ness is
+// not sufficient: the login must be the identity this run posts as.
+test("runGithub does not trust a same-head marker from an unrelated GitHub App bot", async (t) => {
 	const fixture = setupFixture(t, {
 		prNumber: 51,
 		rawReview: defaultRawReview(),
@@ -1056,14 +1059,20 @@ test("runGithub still skips same-head review when the marker is from a GitHub Ap
 		{
 			id: 1,
 			body: stateReviewBody(fixture.headSha),
-			user: { login: "needlefish[bot]", type: "Bot" },
+			user: { login: "unrelated-reviewer[bot]", type: "Bot" },
 		},
 	]);
 
 	await runGithub(fixture.repo, 51, { timeoutMs: 1000 });
 
-	assert.equal(runnerInvocationCount(fixture), 0);
-	assert.deepEqual(readPosts(fixture.postLog), []);
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"an unrelated Bot-typed [bot] account must not suppress the model runner",
+	);
+	assert.ok(
+		postedReview(readPosts(fixture.postLog), 51),
+		"an unrelated Bot-typed [bot] account must not suppress posting a review",
+	);
 });
 
 test("runGithub still skips same-head review when the marker is from the authenticated PAT identity", async (t) => {

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -36,6 +36,8 @@ type Fixture = {
 	readonly repo: string;
 	readonly reviewOutput: string;
 	readonly reviewsState: string;
+	readonly runnerLog: string;
+	readonly headSha: string;
 };
 
 type FixtureOptions = {
@@ -43,6 +45,9 @@ type FixtureOptions = {
 	readonly rawReview: string;
 	readonly staleHeadAfterReview?: boolean;
 	readonly paginatePreviousReviewOnSecondPage?: boolean;
+	// Each review becomes its own slurp page, last page newest. Used to prove
+	// an untrusted marker on a later page cannot hide an earlier trusted one.
+	readonly paginateEachReviewAsOwnPage?: boolean;
 	// Make POSTs to the issue-comments endpoint exit 1 (after logging the
 	// attempt) to exercise the fail-soft paths around cosmetic comments.
 	readonly failIssueCommentPosts?: boolean;
@@ -53,6 +58,8 @@ type FixtureOptions = {
 	// comments — set to a plain user login to simulate a PAT-authenticated
 	// runner. Defaults to a bot-shaped login.
 	readonly authorLogin?: string;
+	// Simulate `gh api user` failing. authenticatedLogin() fail-softs to "".
+	readonly failUserApi?: boolean;
 };
 
 function isPost(raw: unknown): raw is Post {
@@ -139,6 +146,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 	const postLog = path.join(tmp, "posts.jsonl");
 	const reviewsState = path.join(tmp, "reviews-state.json");
 	const issueCommentsState = path.join(tmp, "issue-comments-state.json");
+	const runnerLog = path.join(tmp, "runner.log");
 	const previous = {
 		path: process.env.PATH,
 		repository: process.env.GITHUB_REPOSITORY,
@@ -202,7 +210,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  const apiPath = methodIdx >= 0 ? args[methodIdx + 2] : args[1];",
 			"  if (apiPath === reviewsEndpoint && method === 'POST') {",
 			"    const parsed = JSON.parse(payload);",
-			"    reviews.push({ id: reviews.length + 1, body: parsed.body || '', user: { login: 'github-actions' } });",
+			`    reviews.push({ id: reviews.length + 1, body: parsed.body || '', user: { login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} } });`,
 			"    fs.writeFileSync(reviewsPath, JSON.stringify(reviews));",
 			"  }",
 			"  if (apiPath && apiPath.startsWith(reviewsEndpoint + '/') && method === 'PUT') {",
@@ -243,7 +251,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			`if (args[1] === '--paginate' && args[2] === '--slurp' && args[3] === ${JSON.stringify(`repos/frankekn/needlefish/pulls/${opts.prNumber}/reviews`)}) {`,
 			`  const reviewsPath = ${JSON.stringify(reviewsState)};`,
 			"  const reviews = fs.existsSync(reviewsPath) ? JSON.parse(fs.readFileSync(reviewsPath, 'utf8')) : [];",
-			`  const pages = ${JSON.stringify(opts.paginatePreviousReviewOnSecondPage === true)} ? [[], reviews] : [reviews];`,
+			`  const pages = ${JSON.stringify(opts.paginateEachReviewAsOwnPage === true)} ? reviews.map((r) => [r]) : ${JSON.stringify(opts.paginatePreviousReviewOnSecondPage === true)} ? [[], reviews] : [reviews];`,
 			"  process.stdout.write(JSON.stringify(pages));",
 			"  process.exit(0);",
 			"}",
@@ -262,7 +270,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  process.stdout.write(JSON.stringify(issueComments));",
 			"  process.exit(0);",
 			"}",
-			`if (args[1] === 'user') { process.stdout.write(JSON.stringify({ login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} })); process.exit(0); }`,
+			`if (args[1] === 'user') { if (${JSON.stringify(opts.failUserApi === true)} === true) { process.stderr.write('simulated user lookup failure'); process.exit(1); } process.stdout.write(JSON.stringify({ login: ${JSON.stringify(opts.authorLogin ?? "github-actions[bot]")} })); process.exit(0); }`,
 			"if (args[1] === 'graphql') {",
 			`  fs.appendFileSync(${JSON.stringify(postLog)}, JSON.stringify({ args, payload: '' }) + '\\n');`,
 			"  process.stdout.write('{}');",
@@ -280,6 +288,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 		[
 			"#!/usr/bin/env node",
 			"const fs = require('node:fs');",
+			`fs.appendFileSync(${JSON.stringify(runnerLog)}, 'run\\n');`,
 			`process.stdout.write(fs.readFileSync(${JSON.stringify(reviewOutputFile)}, 'utf8'));`,
 		].join("\n"),
 	);
@@ -291,7 +300,56 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 	process.env.NEEDLEFISH_RUNNER = "claude";
 	process.env.CLAUDE_BIN = claude;
 	process.env.NEEDLEFISH_NO_FAST_PATH = "1";
-	return { postLog, repo, reviewOutput: reviewOutputFile, reviewsState };
+	return {
+		postLog,
+		repo,
+		reviewOutput: reviewOutputFile,
+		reviewsState,
+		runnerLog,
+		headSha: targetHeadSha,
+	};
+}
+
+function runnerInvocationCount(fixture: Fixture): number {
+	if (!existsSync(fixture.runnerLog)) return 0;
+	return readFileSync(fixture.runnerLog, "utf8")
+		.split("\n")
+		.filter(Boolean).length;
+}
+
+function stateReviewBody(headSha: string): string {
+	return `# Needlefish review\n\n${renderState(headSha, [mkFinding({ title: "bug", lineStart: 1 })])}\n`;
+}
+
+function seedReviews(reviewsState: string, reviews: readonly unknown[]): void {
+	writeFileSync(reviewsState, JSON.stringify(reviews));
+}
+
+function defaultRawReview(): string {
+	return JSON.stringify({
+		summary: "review",
+		findings: [mkFinding({ title: "bug", lineStart: 1 })],
+		checked: ["checked"],
+		residual_risks: [],
+	});
+}
+
+function postedReview(posts: readonly Post[], prNumber: number): Post | undefined {
+	return posts.find(
+		(p) =>
+			p.args.includes("POST") &&
+			p.args.includes(`repos/frankekn/needlefish/pulls/${prNumber}/reviews`),
+	);
+}
+
+function putReview(posts: readonly Post[], prNumber: number, id: number): Post | undefined {
+	return posts.find(
+		(p) =>
+			p.args.includes("PUT") &&
+			p.args.includes(
+				`repos/frankekn/needlefish/pulls/${prNumber}/reviews/${id}`,
+			),
+	);
 }
 
 test("runGithub posts blocking findings as non-sticky review comments", async (t) => {
@@ -955,6 +1013,324 @@ test("runGithub finds a state-bearing review on the second paginated page", asyn
 		round2Posts.some((post) => post.args.includes("PUT")),
 		"a state-bearing review on page 2 must be found for the update",
 	);
+});
+
+// --- State-marker author trust (same-head dedupe must not trust strangers) ---
+
+test("runGithub still skips same-head review when the marker is from a trusted bot author", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 50,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "github-actions" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 50, { timeoutMs: 1000 });
+
+	assert.equal(runnerInvocationCount(fixture), 0, "bot marker must enable dedupe");
+	assert.deepEqual(readPosts(fixture.postLog), [], "dedupe must post nothing");
+});
+
+test("runGithub still skips same-head review when the marker is from a [bot] suffix author", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 51,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "needlefish[bot]" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 51, { timeoutMs: 1000 });
+
+	assert.equal(runnerInvocationCount(fixture), 0);
+	assert.deepEqual(readPosts(fixture.postLog), []);
+});
+
+test("runGithub still skips same-head review when the marker is from the authenticated PAT identity", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 52,
+		authorLogin: "frank-pat",
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 7,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "frank-pat" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 52, { timeoutMs: 1000 });
+
+	assert.equal(
+		runnerInvocationCount(fixture),
+		0,
+		"PAT-authored marker must enable same-head dedupe",
+	);
+	assert.deepEqual(readPosts(fixture.postLog), []);
+});
+
+test("runGithub does not skip same-head review when the only state marker is from an untrusted user", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 53,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "unrelated-attacker" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 53, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"untrusted marker must not suppress the model runner",
+	);
+	assert.ok(
+		postedReview(readPosts(fixture.postLog), 53),
+		"untrusted marker must not suppress posting a review",
+	);
+});
+
+test("runGithub ignores an untrusted review that quotes a trusted state marker", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 54,
+		rawReview: defaultRawReview(),
+	});
+	const quoted = `Looks correct.\n\n> ${renderState(fixture.headSha, [mkFinding({ title: "bug", lineStart: 1 })])}\n`;
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: quoted,
+			user: { login: "unrelated-attacker" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 54, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"quoted marker from an untrusted author must not skip the runner",
+	);
+	assert.ok(postedReview(readPosts(fixture.postLog), 54));
+});
+
+test("runGithub skips malformed review objects without throwing and does not treat them as trusted", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 55,
+		rawReview: defaultRawReview(),
+	});
+	const body = stateReviewBody(fixture.headSha);
+	seedReviews(fixture.reviewsState, [
+		"not an object",
+		null,
+		{ body, id: "1", user: { login: "github-actions[bot]" } },
+		{ body, id: 2, user: { login: 123 } },
+		{ body, id: 3, user: "github-actions[bot]" },
+		{ body, id: 4 },
+		{ body, user: { login: "github-actions[bot]" } },
+		{
+			id: 100,
+			body,
+			user: { login: "unrelated-attacker" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 55, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"malformed entries must be skipped without throwing; review must proceed",
+	);
+	assert.ok(postedReview(readPosts(fixture.postLog), 55));
+});
+
+test("runGithub skips an untrusted newest marker and still uses an older trusted review", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 56,
+		rawReview: defaultRawReview(),
+	});
+	const otherHead = "a".repeat(40);
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 10,
+			body: stateReviewBody(otherHead),
+			user: { login: "github-actions[bot]" },
+		},
+		{
+			id: 20,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "unrelated-attacker" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 56, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"untrusted newest same-head marker must not suppress review",
+	);
+	const posts = readPosts(fixture.postLog);
+	assert.ok(
+		putReview(posts, 56, 10),
+		"older trusted review id must still be found for the PUT update",
+	);
+	assert.equal(
+		postedReview(posts, 56),
+		undefined,
+		"must not POST a new review when a trusted previous review exists",
+	);
+});
+
+test("runGithub skips same-head review when an untrusted newest marker is followed by an older trusted same-head marker", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 57,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "github-actions[bot]" },
+		},
+		{
+			id: 2,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "unrelated-attacker" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 57, { timeoutMs: 1000 });
+
+	assert.equal(runnerInvocationCount(fixture), 0);
+	assert.deepEqual(readPosts(fixture.postLog), []);
+});
+
+test("runGithub still finds a trusted marker when an untrusted one is newest across paginated pages", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 58,
+		paginateEachReviewAsOwnPage: true,
+		rawReview: defaultRawReview(),
+	});
+	const otherHead = "b".repeat(40);
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 10,
+			body: stateReviewBody(otherHead),
+			user: { login: "github-actions[bot]" },
+		},
+		{
+			id: 20,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "unrelated-attacker" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 58, { timeoutMs: 1000 });
+
+	assert.ok(runnerInvocationCount(fixture) >= 1);
+	assert.ok(putReview(readPosts(fixture.postLog), 58, 10));
+});
+
+test("runGithub re-reviews a trusted same-head marker when recheck is true", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 59,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "github-actions[bot]" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 59, { timeoutMs: 1000 }, true);
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"--recheck must bypass same-head dedupe",
+	);
+	assert.ok(putReview(readPosts(fixture.postLog), 59, 1));
+});
+
+test("runGithub still skips a bot-authored same-head marker when gh api user fails", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 60,
+		failUserApi: true,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "github-actions[bot]" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 60, { timeoutMs: 1000 });
+
+	assert.equal(runnerInvocationCount(fixture), 0);
+	assert.deepEqual(readPosts(fixture.postLog), []);
+});
+
+test("runGithub does not skip an untrusted same-head marker when gh api user fails", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 61,
+		failUserApi: true,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "unrelated-attacker" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 61, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"user-api failure must not widen trust to untrusted authors",
+	);
+	assert.ok(postedReview(readPosts(fixture.postLog), 61));
+});
+
+test("runGithub does not skip a PAT-authored marker when gh api user fails", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 62,
+		authorLogin: "frank-pat",
+		failUserApi: true,
+		rawReview: defaultRawReview(),
+	});
+	seedReviews(fixture.reviewsState, [
+		{
+			id: 1,
+			body: stateReviewBody(fixture.headSha),
+			user: { login: "frank-pat" },
+		},
+	]);
+
+	await runGithub(fixture.repo, 62, { timeoutMs: 1000 });
+
+	assert.ok(
+		runnerInvocationCount(fixture) >= 1,
+		"fail-soft user lookup narrows to bot-only trust and extra-reviews",
+	);
+	assert.ok(postedReview(readPosts(fixture.postLog), 62));
 });
 
 // --- S5 invariant: error path posts a PR comment ---

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -70,6 +70,7 @@ test("runGithub normalizes relative repo paths before building prompts", async (
       )}); process.exit(0); }`,
       "if (args[1] === 'https://example.invalid/comments' || args[1] === 'https://example.invalid/reviews') { process.stdout.write('[]'); process.exit(0); }",
       "if (args[1] === '--paginate' && args[2] === '--slurp' && args[3] === 'repos/frankekn/needlefish/pulls/7/reviews') { process.stdout.write('[[]]'); process.exit(0); }",
+      "if (args[1] === 'user') { process.stdout.write(JSON.stringify({ login: 'github-actions[bot]' })); process.exit(0); }",
       "process.stderr.write(`unexpected gh args ${args.join(' ')}`);",
       "process.exit(2);",
     ].join("\n")

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -398,11 +398,19 @@ function findPreviousReview(
 	if (!Array.isArray(raw)) return null;
 	// flat(1) also tolerates a plain review list from stubs or older gh versions.
 	const reviews = raw.flat(1);
-	// Same author check as minimizePreviousRoundComments: a marker is ours
-	// only when the author is bot-shaped or equals the identity this run
-	// posts as. Humans quoting the marker must not suppress review.
-	// authenticatedLogin is called once, not per review. Empty login
-	// fail-softs to bot-only trust — that can extra-review, never suppress.
+	// TRUST BOUNDARY. What this function returns decides two things in
+	// runGithub: (a) the same-head dedupe, which returns *before* the model
+	// run, the review post and the check-run post; and (b) the review id whose
+	// body the next round is PUT onto. Anyone can submit a review on a public
+	// PR, so a marker accepted from an author we have not authenticated is a
+	// silent review-suppression bypass — needlefish reports nothing and the PR
+	// looks unreviewed-but-fine. Authorization therefore runs on identity
+	// GitHub asserts (isTrustedStateAuthor), never on the shape of a login the
+	// author picked. An untrusted marker is skipped, not fatal: the scan keeps
+	// walking to older reviews. authenticatedLogin() is called once per run,
+	// not per review; when it fails it returns "" and trust narrows to verified
+	// bot identities, which can cause an extra review but never a suppressed
+	// one — the safe direction here, unlike the cosmetic cleanup path.
 	const selfLogin = authenticatedLogin();
 	for (let i = reviews.length - 1; i >= 0; i--) {
 		const item = reviews[i];
@@ -411,8 +419,7 @@ function findPreviousReview(
 		if (!state) continue;
 		const id = item.id;
 		if (typeof id !== "number") continue;
-		const author = nestedString(item, "user", "login");
-		if (!isBotAuthor(item) && !(selfLogin && author === selfLogin)) continue;
+		if (!isTrustedStateAuthor(item, selfLogin)) continue;
 		return { id, state };
 	}
 	return null;
@@ -556,9 +563,48 @@ function postRoundComment(
 	postIssueComment(repo, prNumber, body);
 }
 
-function isBotAuthor(item: JsonRecord): boolean {
+// COSMETIC ONLY — not a trust boundary. `includes("github-actions")` is a
+// substring test, and `z-github-actions-z` is a registrable GitHub username,
+// so an attacker can satisfy this at will. It is tolerated here because the
+// only thing it gates is minimizePreviousRoundComments: worst case a stranger
+// who copied `<!-- needlefish-round -->` into their own comment gets that
+// comment collapsed as OUTDATED — visible, reversible, and it decides nothing
+// about whether a review happens. Anything that gates review behaviour must
+// use isTrustedStateAuthor instead; that split is deliberate, do not merge
+// them back together.
+function isLooselyBotShaped(item: JsonRecord): boolean {
 	const login = nestedString(item, "user", "login");
 	return login.includes("github-actions") || /\[bot\]$/.test(login);
+}
+
+// SECURITY-GRADE author check for needlefish-state markers. See the trust
+// boundary note in findPreviousReview for what rides on it.
+//
+// Only two identities are authorized, both attested by something outside the
+// attacker's control:
+//
+//   1. login === selfLogin — the exact identity this run authenticates as
+//      (`gh api user`). Self-hosted runners often use a PAT, so our own marker
+//      can legitimately carry a plain user login. Exact equality, never a
+//      prefix/substring, and never when selfLogin is empty.
+//   2. user.type === "Bot" AND the login ends in "[bot]" — both fields are set
+//      by GitHub, not by the account holder. A human account cannot obtain
+//      type "Bot", and "[" / "]" are not legal in a human username, so the
+//      pair cannot be forged from a normal account. Under GITHUB_TOKEN we post
+//      as github-actions[bot] / type "Bot" (confirmed against the live reviews
+//      API) and `gh api user` is not permitted to Actions tokens, so in
+//      production this is the branch that carries the dedupe.
+//
+// A substring match on the login is NOT sufficient and was the original bug:
+// "github-actions" is a substring of the perfectly registrable username
+// "z-github-actions-z", so any user could mint a trusted-looking marker.
+function isTrustedStateAuthor(item: JsonRecord, selfLogin: string): boolean {
+	const login = nestedString(item, "user", "login");
+	if (login === "") return false;
+	if (selfLogin !== "" && login === selfLogin) return true;
+	return (
+		nestedString(item, "user", "type") === "Bot" && /\[bot\]$/.test(login)
+	);
 }
 
 // Self-hosted runners often authenticate gh with a PAT, so Needlefish's own
@@ -598,8 +644,12 @@ function minimizePreviousRoundComments(
 		if (!body.includes("<!-- needlefish-round -->")) continue;
 		// Ours = bot-shaped author, or the identity this run posts as (PAT).
 		// The author check keeps humans quoting the marker from being swept.
+		// Deliberately the loose predicate: this path is cosmetic (see
+		// isLooselyBotShaped) and erring wide only over-collapses a comment,
+		// whereas the state-marker path erring wide suppresses a review.
 		const author = nestedString(item, "user", "login");
-		if (!isBotAuthor(item) && !(selfLogin && author === selfLogin)) continue;
+		if (!isLooselyBotShaped(item) && !(selfLogin && author === selfLogin))
+			continue;
 		const nodeId = stringField(item, "node_id");
 		if (!nodeId) continue;
 		const query =

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -577,33 +577,50 @@ function isLooselyBotShaped(item: JsonRecord): boolean {
 	return login.includes("github-actions") || /\[bot\]$/.test(login);
 }
 
+// The identity a GITHUB_TOKEN-authenticated run posts under. Not a target-repo
+// noun: it is the fixed platform identity GitHub attributes every Actions
+// token to, confirmed against the live reviews API for this repo's own runs
+// ({login: "github-actions[bot]", type: "Bot"}).
+const ACTIONS_BOT_LOGIN = "github-actions[bot]";
+
 // SECURITY-GRADE author check for needlefish-state markers. See the trust
 // boundary note in findPreviousReview for what rides on it.
 //
-// Only two identities are authorized, both attested by something outside the
-// attacker's control:
+// The rule is "the marker was written by the identity this run posts as",
+// never "the marker was written by something bot-shaped". Two ways to
+// establish that identity, both attested outside the author's control:
 //
-//   1. login === selfLogin — the exact identity this run authenticates as
-//      (`gh api user`). Self-hosted runners often use a PAT, so our own marker
-//      can legitimately carry a plain user login. Exact equality, never a
-//      prefix/substring, and never when selfLogin is empty.
-//   2. user.type === "Bot" AND the login ends in "[bot]" — both fields are set
-//      by GitHub, not by the account holder. A human account cannot obtain
-//      type "Bot", and "[" / "]" are not legal in a human username, so the
-//      pair cannot be forged from a normal account. Under GITHUB_TOKEN we post
-//      as github-actions[bot] / type "Bot" (confirmed against the live reviews
-//      API) and `gh api user` is not permitted to Actions tokens, so in
-//      production this is the branch that carries the dedupe.
+//   1. login === selfLogin — the identity `gh api user` reports. Exact
+//      equality only, never a prefix/substring, and never when selfLogin is
+//      empty. This covers PAT-authenticated self-hosted runners, where our
+//      own review carries a plain user login.
+//   2. login === ACTIONS_BOT_LOGIN AND user.type === "Bot" — the Actions
+//      default identity. Actions tokens are not permitted `GET /user`, so
+//      selfLogin is empty in that mode and this branch is what carries the
+//      dedupe in production. Both fields are set by GitHub: a human account
+//      cannot obtain type "Bot", and "[" / "]" are not legal in a human
+//      username, so neither half is forgeable from a normal account.
 //
-// A substring match on the login is NOT sufficient and was the original bug:
-// "github-actions" is a substring of the perfectly registrable username
-// "z-github-actions-z", so any user could mint a trusted-looking marker.
+// Deliberately NOT trusted:
+//   - a substring match on the login. That was the original bug:
+//     "github-actions" is a substring of the registrable username
+//     "z-github-actions-z", so any user could mint a trusted-looking marker.
+//   - any other Bot-typed "[bot]" account. A different GitHub App installed on
+//     the repo is not us, and trusting it lets it suppress our review.
+//
+// Consequence, accepted: a deployment that authenticates as a custom GitHub
+// App (login "<app>[bot]", and `GET /user` also unavailable to installation
+// tokens) matches neither branch, so its markers are not trusted and every run
+// re-reviews and posts a new review instead of updating. That is noisy but it
+// is the safe direction — an unrecognized author costs an extra review, never
+// a suppressed one.
 function isTrustedStateAuthor(item: JsonRecord, selfLogin: string): boolean {
 	const login = nestedString(item, "user", "login");
 	if (login === "") return false;
 	if (selfLogin !== "" && login === selfLogin) return true;
 	return (
-		nestedString(item, "user", "type") === "Bot" && /\[bot\]$/.test(login)
+		login === ACTIONS_BOT_LOGIN &&
+		nestedString(item, "user", "type") === "Bot"
 	);
 }
 

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -398,6 +398,12 @@ function findPreviousReview(
 	if (!Array.isArray(raw)) return null;
 	// flat(1) also tolerates a plain review list from stubs or older gh versions.
 	const reviews = raw.flat(1);
+	// Same author check as minimizePreviousRoundComments: a marker is ours
+	// only when the author is bot-shaped or equals the identity this run
+	// posts as. Humans quoting the marker must not suppress review.
+	// authenticatedLogin is called once, not per review. Empty login
+	// fail-softs to bot-only trust — that can extra-review, never suppress.
+	const selfLogin = authenticatedLogin();
 	for (let i = reviews.length - 1; i >= 0; i--) {
 		const item = reviews[i];
 		if (!isRecord(item)) continue;
@@ -405,6 +411,8 @@ function findPreviousReview(
 		if (!state) continue;
 		const id = item.id;
 		if (typeof id !== "number") continue;
+		const author = nestedString(item, "user", "login");
+		if (!isBotAuthor(item) && !(selfLogin && author === selfLogin)) continue;
 		return { id, state };
 	}
 	return null;


### PR DESCRIPTION
Closes #48.

## Problem

`findPreviousReview` scanned a PR's reviews newest-first and trusted the **first parseable** `<!-- needlefish-state: … -->` marker, with **no author check**:

```ts
const state = parseState(stringField(item, "body"));
if (!state) continue;
const id = item.id;
if (typeof id !== "number") continue;
return { id, state };
```

That state drives same-head dedupe, which returns **before** the model call, the review post, and the check-run post:

```ts
if (prev && prev.state.headSha === headSha && !recheck) { … return; }
```

On a public repository any user can submit a PR review, so anyone could **suppress Needlefish's review** of a given head by posting a crafted marker — in a tool whose entire value is that its verdicts are trustworthy.

The sibling cleanup path (`minimizePreviousRoundComments`) already got this right, with the comment *"The author check keeps humans quoting the marker from being swept."* This applies the same test at the dedupe seam.

## Change

```ts
const selfLogin = authenticatedLogin();   // once per run, not per review
…
const author = nestedString(item, "user", "login");
if (!isBotAuthor(item) && !(selfLogin && author === selfLogin)) continue;
```

Reuses the existing `isBotAuthor` / `authenticatedLogin` helpers rather than inventing a second notion of "ours" — two divergent trust models in one file is how this drifted in the first place.

The check sits **after** `parseState`, so an untrusted newest marker is *skipped* and the scan continues to older reviews rather than aborting. `parseState`, the marker format, `RoundState`, and the returned `{ id, state }` shape are unchanged.

**Failure direction:** if `gh api user` fails, `selfLogin` is `""` and trust narrows to bot-shaped authors. That can cause an *extra* review; it can never cause a suppressed one. The risk direction is inverted from the cleanup path, and that is deliberate.

## Verification

The security test asserts the review **actually proceeds** — not merely that the parser returned null. Dedupe returns before the runner, so a null-check would prove nothing:

```ts
assert.ok(runnerInvocationCount(fixture) >= 1, "untrusted marker must not suppress the model runner");
assert.ok(postedReview(readPosts(fixture.postLog), 53), "untrusted marker must not suppress posting a review");
```

13 tests added, covering: trusted bot author, `[bot]`-suffix author, authenticated PAT identity, untrusted user, an untrusted review **quoting** a trusted marker, malformed review objects, an untrusted newest marker followed by an older trusted one (both same-SHA and different-SHA), pagination across pages, `--recheck` still forcing, and all three `gh api user`-failure directions.

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 42 / fail 0` |
| remove the author trust check | `pass 35 / fail 7` ✅ |
| trust everyone | `pass 35 / fail 7` ✅ |
| untrusted newest **aborts** the scan instead of skipping | `pass 39 / fail 3` ✅ |
| restored | `pass 42 / fail 0` |

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **547 pass / 0 fail** (exit 0).

## Risk / not verified

- **No live GitHub API exercise** — `gh` is stubbed with temp scripts, the repo's established pattern. The trust rule depends on `gh api user` returning the identity this run posts as; that mapping is assumed from the existing cleanup path's use of the same helper, not re-confirmed against a live token.
- `findPreviousReview` now makes one additional `gh api user` call per run.
- Bot-shape detection remains string-based (`github-actions`, `*[bot]`), inherited from `isBotAuthor` and deliberately unchanged. A user account literally named to match would be trusted — pre-existing, and out of scope for this fix.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, mutation testing including the skip-vs-abort distinction, assertion review)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)