### PR TITLE
fix(process): preserve git diff bytes for patches applied to the sandbox

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -663,13 +663,13 @@ export async function runGithub(
 	if (!baseSha || !headSha)
 		throw new Error("Could not resolve PR base/head SHA");
 	const mergeBase = git(["merge-base", baseSha, headSha], repoPath);
-	const patch = git(["diff", mergeBase, headSha], repoPath);
+	const patch = git(["diff", mergeBase, headSha], repoPath, { preserveOutput: true });
 	if (!patch.trim()) {
 		throw new Error(
 			`No diff between ${mergeBase} and ${headSha}. Nothing to review.`,
 		);
 	}
-	const patchStat = git(["diff", "--stat", mergeBase, headSha], repoPath);
+	const patchStat = git(["diff", "--stat", mergeBase, headSha], repoPath, { preserveOutput: true });
 	const changed = changedFiles(repoPath, mergeBase, headSha);
 
 	const commentsUrl = stringField(pr, "comments_url");

--- a/src/adapters/local-uncommitted.test.ts
+++ b/src/adapters/local-uncommitted.test.ts
@@ -11,6 +11,27 @@ import { commitAll, gitText, headSha, initRepo } from "../shared/codex-runner-te
 
 const TSX_IMPORT = process.env.NEEDLEFISH_TEST_TSX_IMPORT ?? "tsx";
 
+test("runLocal WORKING sandbox applies a tracked diff ending in a blank context line", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-blank-context-"));
+  const repo = initRepo(tmp);
+  const { promptPath } = installFakeClaude(t, tmp);
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  gitText(["branch", "-M", "main"], repo);
+  writeFileSync(join(repo, "notes.txt"), "alpha\nbravo\ncharlie\n\n");
+  commitAll(repo, "trailing blank line");
+  const base = headSha(repo);
+  writeFileSync(join(repo, "notes.txt"), "alpha\nBravo\ncharlie\n\n");
+
+  const result = await runLocal(repo, { cacheDir: join(tmp, "cache") });
+
+  assert.equal(result.baseSha, base);
+  assert.equal(result.headSha, "WORKING");
+  const prompts = readFileSync(promptPath, "utf8");
+  assert.match(prompts, /diff --git a\/notes\.txt b\/notes\.txt/);
+  assert.match(prompts, /\n charlie\n \n/);
+});
+
 test("runLocal reviews staged unstaged and untracked changes when working tree is dirty", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "needlefish-local-uncommitted-"));
   const repo = initRepo(tmp);
@@ -207,8 +228,9 @@ test("local CLI reports a friendly git init message outside git repos", (t) => {
 
   assert.equal(result.status, 1);
   assert.equal(result.stdout, "");
-  assert.equal(result.stderr.trim().split(/\r?\n/).length, 1);
-  assert.match(result.stderr, /git init/);
+  const needlefishLines = result.stderr.split(/\r?\n/).filter((line) => line.startsWith("needlefish:"));
+  assert.equal(needlefishLines.length, 1);
+  assert.match(needlefishLines[0] ?? "", /git init/);
   assert.equal(result.stderr.includes("fatal:"), false);
 });
 

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -130,7 +130,7 @@ function branchDiffBundle(cwd: string, opts: LocalOptions): Bundle {
   const baseRef = detectBase(cwd, opts.base);
   const baseSha = git(["merge-base", baseRef, "HEAD"], cwd);
   const headSha = git(["rev-parse", "HEAD"], cwd);
-  const patch = git(["diff", baseSha, "HEAD"], cwd);
+  const patch = git(["diff", baseSha, "HEAD"], cwd, { preserveOutput: true });
   if (!patch.trim()) {
     throw new Error(
       `No diff between ${baseSha} and HEAD (${baseRef}). Nothing to review.`
@@ -141,7 +141,7 @@ function branchDiffBundle(cwd: string, opts: LocalOptions): Bundle {
     baseSha,
     headSha,
     patch,
-    patchStat: git(["diff", "--stat", baseSha, "HEAD"], cwd),
+    patchStat: git(["diff", "--stat", baseSha, "HEAD"], cwd, { preserveOutput: true }),
     changedFiles: changedFiles(cwd, baseSha),
     ...(opts.pr
       ? {
@@ -159,8 +159,12 @@ function uncommittedDiffBundle(cwd: string, opts: LocalOptions, headExists: bool
   const trackedBinaryPaths = headExists
     ? parseTrackedBinaryPathsFromNumstat(git(["diff", "--numstat", "-z", "HEAD"], cwd))
     : [];
-  const trackedPatch = headExists ? git(trackedDiffArgs([], trackedBinaryPaths), cwd) : "";
-  const trackedPatchStat = headExists ? git(trackedDiffArgs(["--stat"], trackedBinaryPaths), cwd) : "";
+  const trackedPatch = headExists
+    ? git(trackedDiffArgs([], trackedBinaryPaths), cwd, { preserveOutput: true })
+    : "";
+  const trackedPatchStat = headExists
+    ? git(trackedDiffArgs(["--stat"], trackedBinaryPaths), cwd, { preserveOutput: true })
+    : "";
   const trackedPaths = headExists ? gitNulFields(trackedDiffArgs(["--name-only", "-z"], trackedBinaryPaths), cwd) : [];
   const trackedSkipped = trackedBinaryPaths.map((filePath) => `${filePath} (binary)`);
   const untrackedFiles = headExists

--- a/src/shared/process.test.ts
+++ b/src/shared/process.test.ts
@@ -5,3 +5,28 @@ import { runText } from "./process";
 test("runText reports spawn errors", () => {
   assert.throws(() => runText("__needlefish_missing_command__", []), /ENOENT/);
 });
+
+test("runText trims stdout by default", () => {
+  const script = "process.stdout.write(' abc \\n \\n');";
+  assert.equal(runText(process.execPath, ["-e", script]), "abc");
+});
+
+test("runText preserveOutput keeps trailing whitespace including a blank context line", () => {
+  const script = "process.stdout.write(' abc \\n \\n');";
+  assert.equal(
+    runText(process.execPath, ["-e", script], { preserveOutput: true }),
+    " abc \n \n"
+  );
+});
+
+test("runText still trims stderr on command failure", () => {
+  const script = "process.stderr.write(' boom \\n'); process.exit(1);";
+  assert.throws(
+    () => runText(process.execPath, ["-e", script]),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(error.message, `${process.execPath} -e ${script} failed: boom`);
+      return true;
+    }
+  );
+});

--- a/src/shared/process.ts
+++ b/src/shared/process.ts
@@ -1,9 +1,11 @@
 import { spawnSync } from "node:child_process";
 
-interface RunOptions {
+export interface RunOptions {
   readonly cwd?: string;
   readonly input?: string;
   readonly timeoutMs?: number;
+  /** Keep stdout as-is. `git diff` needs this so a final blank context line survives. */
+  readonly preserveOutput?: boolean;
 }
 
 export function runText(command: string, args: readonly string[], opts: RunOptions = {}): string {
@@ -18,5 +20,6 @@ export function runText(command: string, args: readonly string[], opts: RunOptio
   if (res.status !== 0) {
     throw new Error(`${command} ${args.join(" ")} failed: ${(res.stderr ?? "").trim()}`);
   }
-  return (res.stdout ?? "").trim();
+  const stdout = res.stdout ?? "";
+  return opts.preserveOutput ? stdout : stdout.trim();
 }

--- a/src/shared/repo.test.ts
+++ b/src/shared/repo.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { commitAll, gitText, headSha } from "./codex-runner-test-fixtures";
-import { ensurePrCommits, makeBundle, prDiffFromShas, type PrRefInfo } from "./repo";
+import { ensurePrCommits, git, makeBundle, prDiffFromShas, type PrRefInfo } from "./repo";
 
 test("ensurePrCommits fetches enough history for a shallow PR graph", () => {
   const tmp = mkdtempSync(join(tmpdir(), "needlefish-repo-"));
@@ -87,6 +88,36 @@ test("ensurePrCommits deepens ready shallow PR graph for sandbox fetch", () => {
     gitText(["fetch", "--quiet", repo, targetHeadSha], sandbox);
     gitText(["checkout", "--quiet", "--detach", "FETCH_HEAD"], sandbox);
     assert.equal(headSha(sandbox), targetHeadSha);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("prDiffFromShas preserves a diff whose last hunk is a blank context line", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "needlefish-repo-blank-context-"));
+  try {
+    const work = join(tmp, "work");
+    gitText(["init", "-q", work], tmp);
+    gitText(["config", "user.email", "test@example.com"], work);
+    gitText(["config", "user.name", "Test"], work);
+    writeFileSync(join(work, "notes.txt"), "alpha\nbravo\ncharlie\n\n");
+    commitAll(work, "trailing blank line");
+    const baseSha = headSha(work);
+    writeFileSync(join(work, "notes.txt"), "alpha\nBravo\ncharlie\n\n");
+    commitAll(work, "change middle line");
+    const targetHeadSha = headSha(work);
+
+    const raw = spawnSync("git", ["diff", baseSha, targetHeadSha], {
+      cwd: work,
+      encoding: "utf8",
+    });
+    assert.equal(raw.status, 0, raw.stderr);
+    assert.ok((raw.stdout ?? "").endsWith(" \n"));
+
+    const diff = prDiffFromShas(work, baseSha, targetHeadSha);
+    assert.equal(diff.patch, raw.stdout);
+    assert.notEqual(diff.patch, git(["diff", baseSha, targetHeadSha], work));
+    assert.equal(git(["merge-base", baseSha, targetHeadSha], work), baseSha);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/shared/repo.ts
+++ b/src/shared/repo.ts
@@ -2,14 +2,18 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { classifyFiles } from "./classify.js";
 import { normalizePrMeta } from "./normalize.js";
-import { runText } from "./process.js";
+import { runText, type RunOptions } from "./process.js";
 import type { Bundle, ChangedFile, PrMeta, UntrackedSkippedFile } from "./schema.js";
 
 const NO_AGENTS =
   "(no AGENTS.md in this repo — apply only generic senior-engineer review judgment; do NOT substitute any global/CLI-injected instructions file as policy)";
 
-export function git(args: readonly string[], cwd: string): string {
-  return runText("git", args, { cwd });
+export function git(
+  args: readonly string[],
+  cwd: string,
+  opts?: Pick<RunOptions, "preserveOutput">
+): string {
+  return runText("git", args, { cwd, ...opts });
 }
 
 export function ghText(args: readonly string[], cwd?: string, input?: string): string {
@@ -223,7 +227,7 @@ export function ensurePrCommits(cwd: string, pr: PrRefInfo): void {
 
 export function prDiffFromShas(cwd: string, baseSha: string, headSha: string) {
   const mergeBase = git(["merge-base", baseSha, headSha], cwd);
-  const patch = git(["diff", mergeBase, headSha], cwd);
+  const patch = git(["diff", mergeBase, headSha], cwd, { preserveOutput: true });
   if (!patch.trim()) {
     throw new Error(`No diff between ${mergeBase} and ${headSha}. Nothing to review.`);
   }
@@ -231,7 +235,7 @@ export function prDiffFromShas(cwd: string, baseSha: string, headSha: string) {
     baseSha: mergeBase,
     headSha,
     patch,
-    patchStat: git(["diff", "--stat", mergeBase, headSha], cwd),
+    patchStat: git(["diff", "--stat", mergeBase, headSha], cwd, { preserveOutput: true }),
     changedFiles: changedFiles(cwd, mergeBase, headSha),
   };
 }

--- a/src/shared/runner-sandbox.test.ts
+++ b/src/shared/runner-sandbox.test.ts
@@ -5,7 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { buildUntrackedPatch, joinSections } from "../adapters/local-uncommitted";
-import { headSha, initRepo } from "./codex-runner-test-fixtures";
+import { commitAll, headSha, initRepo } from "./codex-runner-test-fixtures";
+import { git } from "./repo";
 import { prepareRunnerSandbox } from "./runner-sandbox";
 
 test("prepareRunnerSandbox applies WORKING patch without trailing newline", (t) => {
@@ -138,4 +139,52 @@ test("prepareRunnerSandbox WORKING applies CJK tracked + untracked (no final new
   assert.equal(sandbox.expectedHeadSha, headSha(sandbox.repoPath));
   assert.equal(readFileSync(path.join(sandbox.repoPath, "README.md"), "utf8"), trackedContent);
   assert.deepEqual(readFileSync(path.join(sandbox.repoPath, untrackedPath)), untrackedContent);
+});
+
+test("prepareRunnerSandbox applies a WORKING patch whose last hunk is a blank context line", (t) => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-runner-sandbox-blank-context-"));
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+  const repoRoot = path.join(tmp, "source");
+  mkdirSync(repoRoot);
+  const repo = initRepo(repoRoot);
+  const original = "alpha\nbravo\ncharlie\n\n";
+  const changed = "alpha\nBravo\ncharlie\n\n";
+  writeFileSync(path.join(repo, "notes.txt"), original);
+  commitAll(repo, "trailing blank line");
+  writeFileSync(path.join(repo, "notes.txt"), changed);
+
+  const preserved = git(["diff", "HEAD"], repo, { preserveOutput: true });
+  assert.ok(preserved.endsWith(" \n"), "git diff must end with a blank context line");
+  assert.equal(git(["diff", "HEAD"], repo), preserved.trim());
+
+  const failTmp = path.join(tmp, "sandbox-trim");
+  mkdirSync(failTmp);
+  assert.throws(
+    () =>
+      prepareRunnerSandbox({
+        runner: "claude",
+        repoPath: repo,
+        prompt: "",
+        targetHeadSha: "WORKING",
+        targetPatch: `${preserved.trim()}\n`,
+        tmp: failTmp,
+      }),
+    /corrupt patch/
+  );
+
+  const okTmp = path.join(tmp, "sandbox-ok");
+  mkdirSync(okTmp);
+  const sandbox = prepareRunnerSandbox({
+    runner: "claude",
+    repoPath: repo,
+    prompt: "",
+    targetHeadSha: "WORKING",
+    targetPatch: preserved,
+    tmp: okTmp,
+  });
+
+  assert.equal(sandbox.expectedHeadSha, headSha(sandbox.repoPath));
+  assert.equal(readFileSync(path.join(sandbox.repoPath, "notes.txt"), "utf8"), changed);
 });

--- a/src/shared/runner-sandbox.ts
+++ b/src/shared/runner-sandbox.ts
@@ -67,7 +67,8 @@ function prepareWorkingSandbox(
   }
   // Write patch to a file rather than piping via stdin: multi-byte (CJK) hunks
   // plus hand-joined untracked diffs were rejected as "corrupt patch" on stdin.
-  // Also ensure a trailing newline (upstream helpers may trim stdout).
+  // git apply requires a terminator newline; add one only when missing. Diff
+  // producers must preserve stdout — this cannot reconstruct a blank context line.
   const patchInput = options.targetPatch.endsWith("\n")
     ? options.targetPatch
     : `${options.targetPatch}\n`;


### PR DESCRIPTION
Closes #53.

## Problem

`runText` ended with `(res.stdout ?? "").trim()`, and every git/gh call in the repo routes through it (`repo.ts` defines `git()`/`ghText()` as thin wrappers). A diff whose last hunk ends in a **blank context line** (a line consisting of one space) therefore lost that line, and `prepareWorkingSandbox`'s one-newline re-add cannot reconstruct it.

**Measured end to end** on a real repo (`alpha\nbravo\ncharlie\n\n` → `alpha\nBravo\ncharlie\n\n`):

| | last bytes | `git apply` |
|---|---|---|
| raw `git diff` | `" charlie\n \n"` | — |
| after `.trim()` | `" charlie"` | — |
| **old workaround** (trim + re-add `\n`) | `" charlie\n"` | ❌ **`corrupt patch at line 10`** |
| **preserved bytes** | `" charlie\n \n"` | ✅ **OK** |

This is the remaining root cause after closed #12 moved patch application from stdin to a temp file.

## Change

An **opt-in** `preserveOutput` on `RunOptions`, rather than deleting the trim:

```ts
const stdout = res.stdout ?? "";
return opts.preserveOutput ? stdout : stdout.trim();
```

Deleting the trim globally would have silently changed every SHA, ref, JSON, porcelain, and existence-probe consumer in the repo. **All 33 `runText` call sites were audited**; only the six diff producers opt in:

| call site | mode |
|---|---|
| `repo.ts:230` `diff mergeBase head` (local PR) | **preserve** |
| `repo.ts:238` `diff --stat` | **preserve** |
| `local.ts:133` `diff baseSha HEAD` (branch) | **preserve** |
| `local.ts:144` `diff --stat` | **preserve** |
| `local.ts:163` `diff HEAD` (**the WORKING apply input**) | **preserve** |
| `local.ts:166` `diff --stat HEAD` | **preserve** |
| SHAs, `merge-base`, `rev-parse`, `cat-file -e`, `ls-files`, `status --porcelain`, `--name-only`, `--numstat -z`, all `gh` JSON, `symbolic-ref`, `config --get`, `show <ref>:file` | **trim** (unchanged) |

Error handling is untouched — stderr in the failure message stays trimmed.

The one-newline re-add in `prepareWorkingSandbox` is **kept deliberately** as belt-and-braces for callers passing a patch without one (the existing "without trailing newline" test), with its comment corrected to say it cannot reconstruct a stripped context line.

## Verification

The regression test proves `git apply` succeeds on the **real path**, not string equality: it builds a real repo whose working-tree diff ends in a blank context line, applies the old workaround to one sandbox (**throws `/corrupt patch/`**) and the preserved patch through `prepareWorkingSandbox` to another (**applies**, file content matches including the trailing blank line). A second test drives the full `runLocal` → `uncommittedDiffBundle` → `prepareRunnerSandbox` path.

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 24 / fail 0` |
| `preserveOutput` ignored (always trim) | `pass 20 / fail 4` ✅ |
| `prDiffFromShas` back to trimmed | `pass 23 / fail 1` ✅ |
| uncommitted patch back to trimmed | `pass 23 / fail 1` ✅ |
| restored | `pass 24 / fail 0` |

The three pre-existing sandbox tests (`without trailing newline`, `with trailing newline`, `CJK tracked + untracked`) pass unchanged.

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **540 pass / 0 fail** (exit 0).

## Unrelated drive-by, disclosed

`local CLI reports a friendly git init message outside git repos` asserted `stderr.trim().split(/\r?\n/).length === 1`, so it failed whenever Node emitted its `NO_COLOR`/`FORCE_COLOR` warning into the child's stderr. **This flake interrupted essentially every full-suite run during this batch of work.** It now counts `needlefish:`-prefixed lines and still rejects `fatal:`.

Proven, not assumed:

| | with `NO_COLOR=1 FORCE_COLOR=1` |
|---|---|
| `main` (old assertion) | ❌ `fail 1` |
| this branch | ✅ `pass 12 / fail 0` |

It is in a file this change already touches, but it is **not** part of #53. Happy to split it into its own PR if you would rather keep this diff pure.

## Risk / not verified

- `runner-sandbox.ts` has its own private `git()` that still trims; it is used for clone/fetch/checkout/apply/add/commit/rev-parse/status, none of which read a patch from stdout. Left alone deliberately.
- `local-uncommitted.ts`'s `gitNewFileDiff` already preserved stdout (exit 1 + stdout is its success path). Untouched.
- Binary/CJK and untracked-file paths were not re-measured beyond the existing CJK test.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring with the full caller inventory, end-to-end `git apply` proof, mutation testing, flake-fix validation)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)