### PR TITLE
docs: reconcile versions, runner options, and hosted command claims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# Release: on a semver tag push, verify the tagged commit and roll the
-# floating v1 tag so `uses: frankekn/needlefish@v1` consumers get it.
+# Release: on a semver tag push, verify the tagged commit and force-update
+# the floating major tag derived from the tag name (`v0.4.1` → `v0`) so
+# `uses: frankekn/needlefish@v0` consumers get the latest v0.x.y.
 name: needlefish-release
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,5 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-06-30 11:57:07 CST
-**Commit:** 853e2f8
-**Branch:** main
-
 Frank owns this. Keep replies and docs terse unless formal prose is requested.
 
 ## OVERVIEW
@@ -31,7 +27,7 @@ needlefish/
 
 | Task | Location | Notes |
 | --- | --- | --- |
-| CLI flags or modes | `src/cli.ts`, `src/cli/args.ts` | `--fix` is parsed but intentionally errors in v0.2. |
+| CLI flags or modes | `src/cli.ts`, `src/cli/args.ts` | `--fix` is parsed but intentionally errors. |
 | Review pipeline | `src/core/review.ts` | Small path is review + critic; large path is map + deep + critic. |
 | Verdict rules | `src/core/verdict.ts` | Deterministic; do not let model prose decide pass/fail. |
 | Local review | `src/adapters/local.ts` | Writes `~/.cache/needlefish/<repo>/last-review.json`. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Docs: synchronize README / CLI version copy with `package.json`, align
+  English and zh-TW runner configuration with the supported CLI and action
+  surfaces, and drop the hosted-action claim that `@needlefish` comment
+  commands are installed in consumer repos.
 - GitHub: execute the exact immutable release selected by
   `needlefish_release_sha`, so a newer deployment cannot invalidate or replace a
   caller-pinned review runtime.

--- a/README.md
+++ b/README.md
@@ -447,9 +447,9 @@ Cost and behavior notes:
   low-latency option.
 
 The composite action does not add PR comment commands to the consumer repo.
-This repository's `.github/workflows/commands.yml` listens for
-`@needlefish recheck` and `@needlefish explain <finding>` comments from
-maintainers with write access to this repository. Recheck dispatches this repo's
+This repository's `.github/workflows/commands.yml` listens for maintainer
+`@needlefish recheck` and `@needlefish explain <finding>` comments
+(OWNER / MEMBER / COLLABORATOR only). Recheck dispatches this repo's
 `review.yml`; explain runs `needlefish explain` on a self-hosted runner that
 already has `~/.local/bin/needlefish`. Copying that file into another repo
 only works after you retarget those two jobs.

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ in place (fresh / still-open / resolved) instead of stacking new ones.
 
 Cost: 2 model calls per review on small PRs (~56s at the workflow default,
 `gpt-5.6-terra` at `high` effort), 1 map + N deep calls + 1 critic on large ones. Docs-only PRs and
-unchanged heads skip the model entirely. Maintainers can comment
-`@needlefish recheck` or `@needlefish explain <finding>` on the PR.
+unchanged heads skip the model entirely.
 
 ## Benchmarks
 
@@ -381,9 +380,10 @@ jobs:
 
 No self-hosted runner required: this repo doubles as a composite action that
 runs on GitHub-hosted `ubuntu-latest`. Add a workflow to the target repo. The
-hosted action installs the runners listed in `action.yml`; use the self-hosted
-workflow above for Grok 4.5 because the hosted action does not install the
-Grok CLI.
+hosted action's install step only accepts `codex`, `claude`, `opencode`, or
+`pi`. Use the self-hosted workflow above for Grok 4.5; the hosted action does
+not install the Grok CLI, and passing `runner: grok` (or `openai` / `acp`)
+fails that install step.
 
 ```yaml
 name: needlefish
@@ -408,22 +408,25 @@ jobs:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
 ```
 
-Runner authentication (repo secrets, passed via `env` on the action step):
+Runner authentication for the runners the hosted action can install
+(repo secrets, passed via `env` on the action step):
 
 | runner   | secret(s)                                                |
 | -------- | -------------------------------------------------------- |
 | codex    | `CODEX_AUTH_JSON` (contents of a logged-in `~/.codex/auth.json`) or `CODEX_API_KEY` |
 | claude   | `ANTHROPIC_API_KEY`                                       |
 | opencode | provider key for the chosen model (e.g. `OPENAI_API_KEY`) |
-| openai   | `OPENAI_API_KEY`                                          |
-| grok     | Grok CLI auth or provider-specific key (self-hosted lane) |
 | pi       | `PI_AUTH_JSON` (contents of a logged-in `~/.pi/agent/auth.json`) |
-| acp      | agent-specific auth plus `NEEDLEFISH_ACP_BIN` on the runner |
 
 The claude auth vars (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`) and
 opencode's `OPENAI_API_KEY` are allowlisted through to the runner subprocess;
 other providers' keys need `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR` (see
 "Runner subprocess environment").
+
+`grok` is a self-hosted-lane runner (authenticated `grok` CLI on `PATH`).
+`openai` (HTTP, `OPENAI_API_KEY` plus `--model` / `OPENAI_MODEL`) and `acp`
+(`NEEDLEFISH_ACP_BIN`) are CLI runners; the hosted action does not install
+them.
 
 Inputs (all optional): `pr_number` (defaults to the event PR), `runner`
 (default `codex`), `model`, `timeout_ms`, `codex_reasoning_effort`,
@@ -443,10 +446,20 @@ Cost and behavior notes:
   install, roughly a minute). The self-hosted path above stays the
   low-latency option.
 
+The composite action does not add PR comment commands to the consumer repo.
+This repository's `.github/workflows/commands.yml` listens for maintainer
+`@needlefish recheck` and `@needlefish explain <finding>` comments
+(OWNER / MEMBER / COLLABORATOR only). Recheck dispatches this repo's
+`review.yml`; explain runs `needlefish explain` on a self-hosted runner that
+already has `~/.local/bin/needlefish`. Copying that file into another repo
+only works after you retarget those two jobs.
+
 ## Model runner invocation
 
-`src/shared/codex.ts` invokes the selected runner. Use `--runner`, `--model`,
-and `--timeout-ms`, or the matching env vars:
+`src/shared/codex.ts` invokes the selected runner. `--runner` /
+`NEEDLEFISH_RUNNER` accepts `codex`, `claude`, `opencode`, `openai`, `grok`,
+`pi`, or `acp`. Use `--runner`, `--model`, and `--timeout-ms`, or the matching
+env vars:
 
 | option | env | default |
 | --- | --- | --- |
@@ -460,14 +473,25 @@ The opencode idle deadline resets whenever the CLI emits stdout or stderr. If a
 provider stream stops producing output, Needlefish terminates that attempt and
 uses the normal runner retry instead of waiting for an extended per-call timeout.
 
-Runner-specific binary env vars are `CODEX_BIN`, `CLAUDE_BIN`, `OPENCODE_BIN`,
-`GROK_BIN`, `PI_BIN`, and `NEEDLEFISH_ACP_BIN`. `NEEDLEFISH_ACP_BIN` is required
-for the `acp` runner. Existing `CODEX_MODEL`, `CODEX_TIMEOUT_MS`, and
-`CODEX_RETRY_MS` still work for Codex compatibility.
+Per-runner env vars. For CLI runners, binary / model / listed auth vars are
+in that runner's subprocess allowlist. The `openai` runner is HTTP and reads
+its env in-process (its subprocess allowlist is empty). Defaults in
+parentheses are the executable names used when the `*_BIN` var is unset:
+
+| runner | binary | model / other |
+| --- | --- | --- |
+| `codex` | `CODEX_BIN` (`codex`) | `CODEX_MODEL`, `CODEX_TIMEOUT_MS`, `CODEX_RETRY_MS`, `CODEX_REASONING_EFFORT` |
+| `claude` | `CLAUDE_BIN` (`claude`) | `CLAUDE_MODEL`; auth `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` |
+| `opencode` | `OPENCODE_BIN` (`opencode`) | `OPENCODE_MODEL`; auth `OPENAI_API_KEY` |
+| `grok` | `GROK_BIN` (`grok`) | `GROK_MODEL` |
+| `pi` | `PI_BIN` (`pi`) | `PI_MODEL`, `PI_PROVIDER` (default `openai-codex`) |
+| `acp` | `NEEDLEFISH_ACP_BIN` (required) | — |
+| `openai` | none (HTTP, not a CLI) | `OPENAI_API_KEY` (required), `--model` / `OPENAI_MODEL` (required), `OPENAI_BASE_URL` (default `https://api.openai.com/v1`) |
 
 When neither `--runner` nor `NEEDLEFISH_RUNNER` is set and none of `codex`,
 `claude`, or `opencode` can be found, Needlefish exits with install commands
-for those three CLIs instead of a stack trace.
+for those three CLIs instead of a stack trace. Auto-detect does not look for
+`grok`, `pi`, `openai`, or `acp`.
 
 Codex runs with `--ignore-user-config --ignore-rules
 --dangerously-bypass-approvals-and-sandbox` so its inspection commands are not
@@ -476,7 +500,7 @@ still runs it inside a throwaway clean clone, strips GitHub tokens, fixes the
 expected `HEAD`, and rejects any worktree mutation. `medium` is the default; set
 `CODEX_REASONING_EFFORT=high` to restore the old default, or `xhigh` for the
 highest-effort mode. Claude Code runs with
-`--dangerously-skip-permissions`, `--safe-mode`, and no session persistence.
+`--dangerously-skip-permissions`, `--safe-mode`, and `--no-session-persistence`.
 Grok runs with `--always-approve --permission-mode bypassPermissions --no-plan
 --sandbox off`. opencode runs with `--auto` in headless mode and an inline
 `permission: "allow"` override for its global and build-agent permissions. pi
@@ -521,8 +545,10 @@ P3-only findings are reported but do not block (check stays green).
 
 ## Status
 
-v0.3.4. Read-only. Shipped: inline review comments, sticky re-review
-(fresh/open/resolved across pushes), `@needlefish recheck` / `@needlefish
-explain` maintainer commands, docs-only fast path (no model calls),
+v0.4.1. Read-only. Shipped: inline review comments, sticky re-review
+(fresh/open/resolved across pushes), docs-only fast path (no model calls),
 same-head dedupe, hosted-runner repo inspection (best-effort AppArmor
-sysctl). `--fix` stays unimplemented by design.
+sysctl). `--fix` stays unimplemented by design. Maintainer `@needlefish
+recheck` / `@needlefish explain` comments exist in this repository's
+`.github/workflows/commands.yml`; the published composite action does not
+install that workflow.

--- a/README.md
+++ b/README.md
@@ -424,9 +424,9 @@ other providers' keys need `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR` (see
 "Runner subprocess environment").
 
 `grok` is a self-hosted-lane runner (authenticated `grok` CLI on `PATH`).
-`openai` (HTTP, `OPENAI_API_KEY` plus `--model` / `OPENAI_MODEL`) and `acp`
-(`NEEDLEFISH_ACP_BIN`) are CLI runners; the hosted action does not install
-them.
+`acp` (`NEEDLEFISH_ACP_BIN`) is also a CLI runner. `openai` is HTTP, not a
+CLI (`OPENAI_API_KEY` plus `--model` / `OPENAI_MODEL`). The hosted action
+installs none of these.
 
 Inputs (all optional): `pr_number` (defaults to the event PR), `runner`
 (default `codex`), `model`, `timeout_ms`, `codex_reasoning_effort`,
@@ -447,9 +447,9 @@ Cost and behavior notes:
   low-latency option.
 
 The composite action does not add PR comment commands to the consumer repo.
-This repository's `.github/workflows/commands.yml` listens for maintainer
-`@needlefish recheck` and `@needlefish explain <finding>` comments
-(OWNER / MEMBER / COLLABORATOR only). Recheck dispatches this repo's
+This repository's `.github/workflows/commands.yml` listens for
+`@needlefish recheck` and `@needlefish explain <finding>` comments from
+maintainers with write access to this repository. Recheck dispatches this repo's
 `review.yml`; explain runs `needlefish explain` on a self-hosted runner that
 already has `~/.local/bin/needlefish`. Copying that file into another repo
 only works after you retarget those two jobs.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -40,6 +40,7 @@ Needlefish 會在 merge 前檢查 diff，只回報真正的缺陷：錯誤、回
 - [開發環境安裝](#開發環境安裝)
 - [本機使用](#本機使用唯讀不會寫入-github)
 - [機器介面](#機器介面)
+- [基準偵測](#基準偵測)
 - [GitHub Action 模式（self-hosted runner）](#github-action-模式self-hosted-runner)
 - [GitHub Action（hosted，任何 repo）](#github-actionhosted任何-repo)
 - [Model runner 執行方式](#model-runner-執行方式)
@@ -91,8 +92,7 @@ fresh／still-open／resolved，不會不斷堆疊新 review。
 
 小型 PR 每次審查使用 2 次模型呼叫（workflow 預設 `gpt-5.6-terra` @ `high`，約 56 秒）；大型 PR 使用
 1 次 map、N 次 deep（預設並行數 3）及 1 次 critic。純文件 PR 與未變更的
-head 會跳過模型。維護者可以在 PR 留言
-`@needlefish recheck` 或 `@needlefish explain <finding>`。
+head 會跳過模型。
 
 ## Benchmarks
 
@@ -235,8 +235,9 @@ needlefish --repo . --json | jq .verdict
 | `stats` | 選用的 runner 呼叫時間與嘗試次數。 |
 | `totalDurationMs` | 選用的總審查時間（毫秒）。 |
 
-base 預設依序為 `--base`、`origin/HEAD`、`main`；可用
-`--base <ref>` 覆寫。
+## 基準偵測
+
+`--base` → `origin/HEAD` → `main`。用 `--base <ref>` 覆寫。
 
 ## GitHub Action 模式（self-hosted runner）
 
@@ -328,7 +329,11 @@ jobs:
 
 ## GitHub Action（hosted，任何 repo）
 
-此 repo 也提供在 GitHub-hosted `ubuntu-latest` 執行的 composite action：
+此 repo 也提供在 GitHub-hosted `ubuntu-latest` 執行的 composite action。
+hosted action 的安裝步驟只接受 `codex`、`claude`、`opencode` 或 `pi`。
+Grok CLI 不在其中；要使用 Grok 4.5，請使用上方的 self-hosted reusable
+workflow。對 hosted action 傳入 `runner: grok`（或 `openai`／`acp`）會在
+安裝步驟失敗。
 
 ```yaml
 name: needlefish
@@ -352,30 +357,48 @@ jobs:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
 ```
 
-Hosted action 只會安裝 `action.yml` 列出的 runner；Grok CLI 不在其中。要
-使用 Grok 4.5，請使用上方的 self-hosted reusable workflow。
-
-runner 認證方式：
+hosted action 能安裝的 runner，其認證方式（repo secrets，透過 action step 的
+`env` 傳入）：
 
 | runner | secret／認證 |
 | --- | --- |
-| codex | `CODEX_AUTH_JSON` 或 `CODEX_API_KEY` |
+| codex | `CODEX_AUTH_JSON`（已登入的 `~/.codex/auth.json` 內容）或 `CODEX_API_KEY` |
 | claude | `ANTHROPIC_API_KEY` |
 | opencode | 所選模型的 provider key，例如 `OPENAI_API_KEY` |
-| grok | Grok CLI auth 或 provider key（self-hosted lane） |
-| pi | `PI_AUTH_JSON` |
-| acp | agent-specific auth 與 runner 上的 `NEEDLEFISH_ACP_BIN` |
+| pi | `PI_AUTH_JSON`（已登入的 `~/.pi/agent/auth.json` 內容） |
+
+claude 的 `ANTHROPIC_API_KEY`、`CLAUDE_CODE_OAUTH_TOKEN` 與 opencode 的
+`OPENAI_API_KEY` 會進入 runner subprocess allowlist；其他 provider 的 key
+需設定 `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR`（見「Runner subprocess 環境」）。
+
+`grok` 屬於 self-hosted lane（runner `PATH` 上需有已登入的 `grok` CLI）。
+`openai`（HTTP，`OPENAI_API_KEY` 加上 `--model`／`OPENAI_MODEL`）與 `acp`
+（`NEEDLEFISH_ACP_BIN`）是 CLI runner；hosted action 不會安裝它們。
+
+輸入（皆可選）：`pr_number`（預設為事件 PR）、`runner`（預設 `codex`）、
+`model`、`timeout_ms`、`codex_reasoning_effort`、`runner_version`（要安裝的
+runner CLI npm 版本）、`repo_path`（預設為 workspace checkout）、
+`github_token`（預設為 workflow token）。
 
 Fork PR 預設不會收到 secrets，workflow 會跳過它們；不要在不了解風險前使用
 `pull_request_target`，因為它會把 secrets 交給由 fork code 觸發的 workflow。
 
+composite action 不會把 PR 留言指令加進 consumer repo。本 repo 的
+`.github/workflows/commands.yml` 會監聽維護者（僅 OWNER／MEMBER／
+COLLABORATOR）的 `@needlefish recheck` 與 `@needlefish explain <finding>`
+留言。recheck 會 dispatch 本 repo 的 `review.yml`；explain 在已部署
+`~/.local/bin/needlefish` 的 self-hosted runner 上執行 `needlefish explain`。
+把該檔案複製到其他 repo 之前，必須改寫這兩個 job 的目標。
+
 ## Model runner 執行方式
 
-可使用 `--runner`、`--model`、`--timeout-ms`，或相同的環境變數：
+`--runner`／`NEEDLEFISH_RUNNER` 可為 `codex`、`claude`、`opencode`、`openai`、
+`grok`、`pi` 或 `acp`。可使用 `--runner`、`--model`、`--timeout-ms`，或相同的
+環境變數：
 
 | 選項 | 環境變數 | 預設 |
 | --- | --- | --- |
-| runner | `NEEDLEFISH_RUNNER` | 自動偵測 codex → claude → opencode |
+| runner | `NEEDLEFISH_RUNNER` | 自動偵測 `codex`，然後 `claude`，然後 `opencode` |
 | model | `NEEDLEFISH_MODEL` | runner 預設值 |
 | Codex reasoning effort | `CODEX_REASONING_EFFORT` | `medium`（reusable workflow：`gpt-5.6-terra` 時為 `high`） |
 | timeout | `NEEDLEFISH_TIMEOUT_MS` | `600000` |
@@ -385,25 +408,50 @@ opencode CLI 每次產生 stdout 或 stderr 都會重設 idle deadline。若 pro
 stream 停止輸出，Needlefish 會終止該 attempt 並使用既有 runner retry，不再等待
 被拉長的完整 per-call timeout。
 
+各 runner 的環境變數。CLI runner 的 binary／model／所列認證變數在該
+runner 的 subprocess allowlist 內。`openai` runner 是 HTTP，在 process 內
+讀取環境變數（subprocess allowlist 為空）。括號內是未設定 `*_BIN` 時使用的
+執行檔名：
+
+| runner | binary | model／其他 |
+| --- | --- | --- |
+| `codex` | `CODEX_BIN`（`codex`） | `CODEX_MODEL`、`CODEX_TIMEOUT_MS`、`CODEX_RETRY_MS`、`CODEX_REASONING_EFFORT` |
+| `claude` | `CLAUDE_BIN`（`claude`） | `CLAUDE_MODEL`；認證 `ANTHROPIC_API_KEY`、`CLAUDE_CODE_OAUTH_TOKEN` |
+| `opencode` | `OPENCODE_BIN`（`opencode`） | `OPENCODE_MODEL`；認證 `OPENAI_API_KEY` |
+| `grok` | `GROK_BIN`（`grok`） | `GROK_MODEL` |
+| `pi` | `PI_BIN`（`pi`） | `PI_MODEL`、`PI_PROVIDER`（預設 `openai-codex`） |
+| `acp` | `NEEDLEFISH_ACP_BIN`（必填） | — |
+| `openai` | 無（HTTP，不是 CLI） | `OPENAI_API_KEY`（必填）、`--model`／`OPENAI_MODEL`（必填）、`OPENAI_BASE_URL`（預設 `https://api.openai.com/v1`） |
+
+若未指定 `--runner` 或 `NEEDLEFISH_RUNNER`，且找不到 `codex`、`claude`、
+`opencode`，Needlefish 會輸出這三個 CLI 的安裝指令後結束，而不是 stack
+trace。自動偵測不會尋找 `grok`、`pi`、`openai` 或 `acp`。
+
 Codex 使用 `--ignore-user-config --ignore-rules
 --dangerously-bypass-approvals-and-sandbox`，避免檢查命令遭 execpolicy rule、
 approval prompt 或 host sandbox 阻擋。Needlefish 仍會把它放在 throwaway clean
 clone 內執行、移除 GitHub token、固定預期 `HEAD`，並拒絕任何 worktree 變更。
-Claude 使用 `--dangerously-skip-permissions`；Grok 使用 `--always-approve
---permission-mode bypassPermissions --no-plan --sandbox off`；opencode 使用
-`--auto` headless mode，並以 inline `permission: "allow"` 覆寫 global 與
-build-agent 權限；pi 使用預設完整 toolset。這些 production runner 都不需要額外的
-unsandboxed opt-in。
-ACP 透過 `NEEDLEFISH_ACP_BIN` 使用 JSON-RPC 2.0 stdio process，timeout 時會先送
-`session/cancel` 再終止 process group。
+`medium` 是預設；設 `CODEX_REASONING_EFFORT=high` 可恢復舊預設，`xhigh` 為
+最高 effort。Claude 使用 `--dangerously-skip-permissions`、`--safe-mode`、
+`--no-session-persistence`。Grok 使用 `--always-approve --permission-mode
+bypassPermissions --no-plan --sandbox off`。opencode 使用 `--auto` headless
+mode，並以 inline `permission: "allow"` 覆寫 global 與 build-agent 權限。pi
+使用 `--no-session --mode text --provider openai-codex --thinking <level>`
+與預設完整 toolset。這些 production runner 都不需要額外的 unsandboxed
+opt-in。ACP 透過 `NEEDLEFISH_ACP_BIN` 使用 JSON-RPC 2.0 stdio process，
+timeout 時會先送 `session/cancel` 再終止 process group。
 
 所有 CLI runner 都會在 review head 的 throwaway clean clone 中執行；每次成功
-呼叫後都會確認 clone 沒有未提交變更且 `HEAD` 沒有移動。
+呼叫後都會以
+`git status --porcelain --untracked-files=all --ignored=matching`
+確認 clone 沒有未提交變更，並驗證 `HEAD` 沒有移動。
 
 ### Runner subprocess 環境
 
-Runner 只會收到 allowlist 環境，不會繼承完整的 parent `process.env`。若要
-額外傳遞變數，設定：
+CLI runner（`codex`、`claude`、`opencode`、`grok`、`pi`、`acp`）只會收到
+allowlist 環境，不會繼承完整的 parent `process.env`——僅 locale／proxy／path
+基礎變數加上各 runner 自己的 `_BIN`／`_MODEL` 類變數。若要額外傳遞變數，
+設定：
 
 ```bash
 NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR1,VAR2
@@ -413,9 +461,11 @@ GitHub Actions 的非機密 `RUNNER_TRACKING_ID` job marker 會自動保留，�
 self-hosted runner 在 job 被取消時能終止 detached model process。
 
 ACP 認證還需要宣告 `NEEDLEFISH_ACP_AUTH_ENV_VARS`，並把相同名稱放入
-`NEEDLEFISH_RUNNER_ENV_PASSTHROUGH`；或者以
-`NEEDLEFISH_ACP_AUTH_FILES` 指定要複製到 disposable HOME 的 HOME-relative
-credential files。
+`NEEDLEFISH_RUNNER_ENV_PASSTHROUGH`，例如
+`NEEDLEFISH_ACP_AUTH_ENV_VARS=MY_AGENT_TOKEN` 搭配
+`NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=MY_AGENT_TOKEN`。任意 passthrough 設定
+本身不能證明已認證。或者以 `NEEDLEFISH_ACP_AUTH_FILES` 指定要複製到
+disposable HOME 的 HOME-relative credential files。
 
 ## Verdict 推導（確定性）
 
@@ -427,7 +477,10 @@ credential files。
 
 ## 狀態
 
-v0.3.4。唯讀。已提供 inline review comment、sticky re-review
-（fresh／open／resolved）、`@needlefish recheck`／`@needlefish explain`、
-純文件 fast path（不呼叫模型）、same-head dedupe、以及 hosted runner 的
-repo inspection（best-effort AppArmor sysctl）。`--fix` 仍刻意未實作。
+v0.4.1。唯讀。已提供 inline review comment、sticky re-review
+（fresh／open／resolved）、純文件 fast path（不呼叫模型）、same-head
+dedupe、以及 hosted runner 的 repo inspection（best-effort AppArmor
+sysctl）。`--fix` 仍刻意未實作。維護者 `@needlefish recheck`／
+`@needlefish explain` 留言指令存在於本 repo 的
+`.github/workflows/commands.yml`；已發布的 composite action 不會安裝該
+workflow。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -372,8 +372,9 @@ claude 的 `ANTHROPIC_API_KEY`、`CLAUDE_CODE_OAUTH_TOKEN` 與 opencode 的
 需設定 `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH=VAR`（見「Runner subprocess 環境」）。
 
 `grok` 屬於 self-hosted lane（runner `PATH` 上需有已登入的 `grok` CLI）。
-`openai`（HTTP，`OPENAI_API_KEY` 加上 `--model`／`OPENAI_MODEL`）與 `acp`
-（`NEEDLEFISH_ACP_BIN`）是 CLI runner；hosted action 不會安裝它們。
+`acp`（`NEEDLEFISH_ACP_BIN`）也是 CLI runner。`openai` 是 HTTP，不是 CLI
+（`OPENAI_API_KEY` 加上 `--model`／`OPENAI_MODEL`）。hosted action 不會安裝
+上述任何一個。
 
 輸入（皆可選）：`pr_number`（預設為事件 PR）、`runner`（預設 `codex`）、
 `model`、`timeout_ms`、`codex_reasoning_effort`、`runner_version`（要安裝的
@@ -384,8 +385,8 @@ Fork PR 預設不會收到 secrets，workflow 會跳過它們；不要在不了�
 `pull_request_target`，因為它會把 secrets 交給由 fork code 觸發的 workflow。
 
 composite action 不會把 PR 留言指令加進 consumer repo。本 repo 的
-`.github/workflows/commands.yml` 會監聽維護者（僅 OWNER／MEMBER／
-COLLABORATOR）的 `@needlefish recheck` 與 `@needlefish explain <finding>`
+`.github/workflows/commands.yml` 會監聽對本 repo 具有 write 權限之維護者的
+`@needlefish recheck` 與 `@needlefish explain <finding>`
 留言。recheck 會 dispatch 本 repo 的 `review.yml`；explain 在已部署
 `~/.local/bin/needlefish` 的 self-hosted runner 上執行 `needlefish explain`。
 把該檔案複製到其他 repo 之前，必須改寫這兩個 job 的目標。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -385,8 +385,8 @@ Fork PR 預設不會收到 secrets，workflow 會跳過它們；不要在不了�
 `pull_request_target`，因為它會把 secrets 交給由 fork code 觸發的 workflow。
 
 composite action 不會把 PR 留言指令加進 consumer repo。本 repo 的
-`.github/workflows/commands.yml` 會監聽對本 repo 具有 write 權限之維護者的
-`@needlefish recheck` 與 `@needlefish explain <finding>`
+`.github/workflows/commands.yml` 會監聽維護者（僅 OWNER／MEMBER／
+COLLABORATOR）的 `@needlefish recheck` 與 `@needlefish explain <finding>`
 留言。recheck 會 dispatch 本 repo 的 `review.yml`；explain 在已部署
 `~/.local/bin/needlefish` 的 self-hosted runner 上執行 `needlefish explain`。
 把該檔案複製到其他 repo 之前，必須改寫這兩個 job 的目標。

--- a/scripts/docs-version.test.mjs
+++ b/scripts/docs-version.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const version = JSON.parse(readFileSync("package.json", "utf8")).version;
+const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+test("README Status versions match package.json", () => {
+	const en = readFileSync("README.md", "utf8");
+	const zh = readFileSync("README.zh-TW.md", "utf8");
+	assert.match(
+		en,
+		new RegExp(`^## Status\\n\\nv${escaped}\\.`, "m"),
+		`README.md Status must start with v${version}`,
+	);
+	assert.match(
+		zh,
+		new RegExp(`^## 狀態\\n\\nv${escaped}。`, "m"),
+		`README.zh-TW.md 狀態 must start with v${version}`,
+	);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ async function main() {
   switch (command.kind) {
     case "github": {
       if (command.fix) {
-        process.stderr.write("--fix is not implemented in v0.2 (see FUTURE_TODO.md).\n");
+        process.stderr.write("--fix is not implemented (see FUTURE_TODO.md).\n");
         process.exitCode = 2;
         return;
       }
@@ -45,13 +45,13 @@ async function main() {
     case "local":
     case "pr": {
       if (command.fix) {
-        process.stderr.write("--fix is not implemented in v0.2 (see FUTURE_TODO.md).\n");
+        process.stderr.write("--fix is not implemented (see FUTURE_TODO.md).\n");
         process.exitCode = 2;
         return;
       }
       if (command.recheck) {
         process.stderr.write(
-          "v0.2 --recheck runs a full re-review; smart prior-findings verification is TODO.\n"
+          "--recheck runs a full re-review; smart prior-findings verification is TODO.\n"
         );
       }
       const cwd = command.repo ?? process.cwd();


### PR DESCRIPTION
Closes #60.

P3 by severity, but one item was a **promise to consumers that the shipped artifact does not deliver**.

## Version drift → one source

`package.json` was `0.4.1`; both READMEs advertised **v0.3.4**; `src/cli.ts` said **v0.2** in three user-facing messages.

`package.json` is now the single source. The CLI messages **drop the version entirely** rather than acquiring a third place to keep in sync — they describe unimplemented features, not a release:

```diff
-"--fix is not implemented in v0.2 (see FUTURE_TODO.md)."
+"--fix is not implemented (see FUTURE_TODO.md)."
```

Verified: `package.json` `0.4.1` · `./bin/needlefish --version` → `needlefish 0.4.1` · README Status → `v0.4.1` · no `v0.3.4` or `v0.2` left in either README or `cli.ts`.

## Hosted command promise → removed

The quick-start told consumers they could comment `@needlefish recheck` / `explain`. A composite action **cannot** install workflows into the caller's repo (`action.yml` is `runs: using: composite`; it never writes `.github/workflows/`). And a copied `commands.yml` would not work unretargeted either: recheck dispatches **this** repo's `review.yml`, and explain needs a self-hosted runner with `~/.local/bin/needlefish`.

Replaced with what is actually true — the commands exist *in this repository*, and copying the file requires retargeting both jobs.

## English ⇄ zh-TW reconciled against the code

Every runner/env claim now carries `file:line` evidence, and both languages describe the same set — reconciled to the **code**, not to each other:

- **zh-TW was missing:** the `*_BIN` inventory, Codex compatibility vars, the no-runner install fallback, Claude `--safe-mode` / `--no-session-persistence`, pi flags, the hosted input list, and the `openai` HTTP runner.
- **English was wrong:** it listed `openai` / `grok` / `acp` in the **hosted** auth table, but `action.yml:56-62` installs only `codex`, `claude`, `opencode`, `pi` and exits on anything else.

## `release.yml` comment → corrected

The comment claimed it rolls floating **`v1`** for `uses: …@v1`. The step is `major="${GITHUB_REF_NAME%%.*}"` + `git tag -f "$major"`, so `v0.4.1` force-updates **`v0`** — which is what every example in the repo already uses.

## `AGENTS.md` metadata → removed, not refreshed

There is no generator behind that header, so a commit hash in it is stale on the very next commit. Removing it is honest; rewriting it would just restart the drift.

## Parity check

`scripts/docs-version.test.mjs` pins the one drift that actually recurred: both READMEs' Status version must equal `package.json`. **Mutation-verified** — setting the README to `v0.3.9` fails it (`pass 0 / fail 1`), restoring passes (`pass 1 / fail 0`).

Runner prose is deliberately **not** asserted; that would lock wording rather than a fact.

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **535 pass / 0 fail** (exit 0).

## Left for a human — found, deliberately not fixed

These are real inconsistencies discovered while reconciling, but outside this issue's scope or blocked by its constraints:

- **`src/cli/args.ts` `--help` USAGE** lists `CODEX_BIN` / `CLAUDE_BIN` / `OPENCODE_BIN` / `PI_BIN` / `NEEDLEFISH_ACP_BIN` but **omits `GROK_BIN`** (`args.ts:75-80` vs `codex.ts:75`).
- **`CODEX_SERVICE_TIER`** is live (`codex.ts:756-760`) and documented in neither README.
- **opencode** also passes `--pure` and `--format json` (`codex.ts:797-800`), still undocumented.
- **CLI default models differ from the workflow pins:** CLI grok → `grok-build`, CLI pi → `gpt-5.6-sol` (`codex.ts:831,893`), while the workflow pins `grok-4.5` / `gpt-5.6-terra`. The docs describe the workflow pins only.
- **`review.yml`'s `runner` input description** omits `openai` / `acp`, which the CLI accepts.
- **`GROK_API_KEY` / `XAI_API_KEY`** are not in the grok allowlist; they work only via `NEEDLEFISH_RUNNER_ENV_PASSTHROUGH`.

## Merge note

This PR's text describes `commands.yml` authorization as *"OWNER / MEMBER / COLLABORATOR only"*, which is accurate against `main` today but is exactly what **#67 (issue #51)** changes to a write-permission check. Whichever merges second needs that sentence updated.

## Risk

No runtime behavior changes beyond the three CLI message strings.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, version/claim re-verification, mutation testing)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)