### PR TITLE
ci: verify pull requests and gate main deployment on that verification

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -2,14 +2,15 @@
 
 ## OVERVIEW
 
-`.github/workflows/` is runtime behavior for Needlefish itself: reusable PR review and deploy-on-main for the self-hosted runner.
+`.github/workflows/` is runtime behavior for Needlefish itself: own-repo CI, reusable PR review, and gated deploy-on-main for the self-hosted runner.
 
 ## WHERE TO LOOK
 
 | Task | Location | Notes |
 | --- | --- | --- |
+| Own-repo CI | `ci.yml` | PRs and pushes to `main` on `ubuntu-latest`. Required check name: `needlefish-ci`. |
 | PR review workflow | `review.yml` | Reusable via `workflow_call`, manual via `workflow_dispatch`, and local repo PR trigger. |
-| Deploy workflow | `deploy.yml` | Push to `main` runs `scripts/deploy-ubuntu.sh` on self-hosted runner. |
+| Deploy workflow | `deploy.yml` | `workflow_run` after a successful `needlefish-ci` **push** to `main`, plus `workflow_dispatch`. Deploys `NEEDLEFISH_REF=<verified SHA>`. |
 
 ## CONVENTIONS
 
@@ -25,3 +26,6 @@
 - Do not install Needlefish on every PR review run; deploy is separate.
 - Do not broaden workflow permissions without a concrete posting need.
 - Do not run untrusted fork PR code on the persistent self-hosted runner.
+- Do not run own-repo CI on `self-hosted`.
+- Do not deploy `main`'s current tip from a `workflow_run`; deploy `head_sha`.
+- Do not let a `pull_request` `workflow_run` deploy; filter `event == 'push'`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     name: needlefish-ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
       - name: Install and verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+# Own-repo verification for pull requests and pushes to main.
+# Required branch-protection check name: needlefish-ci
+# Does not deploy. deploy.yml waits on a successful main-push run of this workflow.
+name: needlefish-ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: needlefish-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  needlefish-ci:
+    name: needlefish-ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install and verify
+        run: |
+          corepack enable
+          PNPM_VERSION=$(node -p "require('./package.json').packageManager")
+          corepack prepare "$PNPM_VERSION" --activate
+          pnpm install --frozen-lockfile
+          pnpm check
+          pnpm lint
+          pnpm test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout verified SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ steps.sha.outputs.sha }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ steps.sha.outputs.sha }}
+          persist-credentials: false
 
       - name: Deploy verified SHA
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,84 @@
+# Deploy the SHA that already passed needlefish-ci. A job here cannot
+# `needs:` a job in ci.yml, so this waits on workflow_run instead.
+#
+# workflow_run.branches matches the triggering workflow's branch, and for
+# pull_request runs GitHub may treat that as the PR base. Restrict to
+# event == 'push' so a green PR targeting main cannot deploy.
+# scripts/deploy-ubuntu.sh fetches NEEDLEFISH_REF (default: main) into a temp
+# clone, so this workflow must pass the verified SHA rather than a branch name.
 name: needlefish-deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: [needlefish-ci]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: needlefish-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
-      - run: scripts/deploy-ubuntu.sh
+      - name: Resolve deploy SHA
+        id: sha
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            sha="$WORKFLOW_SHA"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            sha="$DISPATCH_SHA"
+          else
+            echo "unsupported event: $EVENT_NAME" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "refusing to deploy without a 40-character lowercase SHA (event=$EVENT_NAME sha=${sha:-empty})" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout verified SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.sha.outputs.sha }}
+
+      - name: Deploy verified SHA
+        env:
+          NEEDLEFISH_REF: ${{ steps.sha.outputs.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s\n' "$NEEDLEFISH_REF" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "NEEDLEFISH_REF must be a 40-character lowercase commit SHA, got: $NEEDLEFISH_REF" >&2
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            tip="$(git ls-remote --heads origin main | cut -f1)"
+            if [ -z "$tip" ]; then
+              echo "could not resolve origin/main" >&2
+              exit 1
+            fi
+            if [ "$NEEDLEFISH_REF" != "$tip" ]; then
+              echo "Skipping deploy of $NEEDLEFISH_REF because origin/main is now $tip"
+              exit 0
+            fi
+          fi
+          scripts/deploy-ubuntu.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ needlefish/
 | Git/PR bundle shape | `src/shared/repo.ts`, `src/shared/schema.ts` | `agentsMd` is read from target repo root only. |
 | Prompt behavior | `prompts/*.md` | Must remain read-only and output JSON contracts exactly. |
 | Tests | `src/**/*.test.ts`, `scripts/test.mjs` | Node test runner, no Jest/Vitest. |
-| CI/deploy | `.github/workflows/*.yml`, `scripts/deploy-ubuntu.sh` | Self-hosted runner must already have `needlefish` deployed. |
+| CI/deploy | `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`, `scripts/deploy-ubuntu.sh` | Own-repo required check is `needlefish-ci`; deploy waits on that SHA. |
 
 ## CODE MAP
 
@@ -99,6 +99,7 @@ PNPM_VERSION=$(node -p "require('./package.json').packageManager")
 corepack prepare "$PNPM_VERSION" --activate
 pnpm install --frozen-lockfile
 pnpm check
+pnpm lint
 pnpm test
 pnpm review -- --repo /path/to/target
 ```
@@ -109,3 +110,4 @@ pnpm review -- --repo /path/to/target
 - GitHub Action mode requires `gh`, a self-hosted runner, and `~/.local/bin/needlefish`; the reusable workflow does not reinstall Needlefish.
 - `changes_requested` maps to a failed check-run but still posts a non-sticky COMMENT review, not a GitHub blocking review state.
 - Closed PRs and stale heads must be skipped before posting.
+- Own-repo CI is the GitHub Actions check named `needlefish-ci` (job `needlefish-ci` in `.github/workflows/ci.yml`). Mark **`needlefish-ci`** required on `main`. It runs on `ubuntu-latest` and must not reference `secrets.*`. `needlefish-deploy` is not a merge gate; it deploys `workflow_run.head_sha` after a successful `needlefish-ci` **push** to `main`. `workflow_dispatch` on `needlefish-deploy` remains for recovery. Branch protection is a repo setting, not a workflow file.

--- a/scripts/ci-deploy-workflow.test.mjs
+++ b/scripts/ci-deploy-workflow.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const ci = readFileSync(".github/workflows/ci.yml", "utf8");
+const deploy = readFileSync(".github/workflows/deploy.yml", "utf8");
+
+function workflowScript(workflow, stepName) {
+  const escapedName = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const step = workflow.match(
+    new RegExp(`      - name: ${escapedName}\\n([\\s\\S]*?)(?=\\n      - name:|$)`),
+  );
+  assert.ok(step, `${stepName} step must exist`);
+  const runBlock = step[1].match(/        run: \|\n([\s\S]*)/);
+  assert.ok(runBlock, `${stepName} must have a run block`);
+  return runBlock[1]
+    .split("\n")
+    .map((line) => line.replace(/^          /, ""))
+    .join("\n");
+}
+
+const resolveScript = workflowScript(deploy, "Resolve deploy SHA");
+const deployScript = workflowScript(deploy, "Deploy verified SHA");
+const verifiedSha = "a".repeat(40);
+const laterSha = "b".repeat(40);
+
+function runResolve({
+  eventName = "workflow_run",
+  workflowSha = verifiedSha,
+  dispatchSha = laterSha,
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), "needlefish-ci-resolve-"));
+  const githubOutput = join(root, "github-output");
+  const result = spawnSync("bash", ["-c", resolveScript], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EVENT_NAME: eventName,
+      WORKFLOW_SHA: workflowSha,
+      DISPATCH_SHA: dispatchSha,
+      GITHUB_OUTPUT: githubOutput,
+    },
+  });
+  const output = {
+    ...result,
+    githubOutput: existsSync(githubOutput) ? readFileSync(githubOutput, "utf8") : "",
+  };
+  rmSync(root, { recursive: true, force: true });
+  return output;
+}
+
+function runDeploy({
+  eventName = "workflow_run",
+  needlefishRef = verifiedSha,
+  mainTip = verifiedSha,
+  lsRemoteFails = false,
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), "needlefish-ci-deploy-"));
+  const fakeBin = join(root, "fake-bin");
+  const scriptsDir = join(root, "scripts");
+  const deployLog = join(root, "deploy.log");
+  mkdirSync(fakeBin);
+  mkdirSync(scriptsDir);
+  writeFileSync(
+    join(fakeBin, "git"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "ls-remote" ] && [ "\${2:-}" = "--heads" ] && [ "\${3:-}" = "origin" ] && [ "\${4:-}" = "main" ]; then
+  if [ "\${LS_REMOTE_FAIL:-}" = "1" ]; then exit 1; fi
+  if [ -n "\${FAKE_MAIN_TIP:-}" ]; then printf '%s\\trefs/heads/main\\n' "$FAKE_MAIN_TIP"; fi
+  exit 0
+fi
+exit 64
+`,
+  );
+  chmodSync(join(fakeBin, "git"), 0o755);
+  writeFileSync(
+    join(scriptsDir, "deploy-ubuntu.sh"),
+    `#!/bin/sh
+printf 'deployed:%s\\n' "$NEEDLEFISH_REF" > "$DEPLOY_LOG"
+`,
+  );
+  chmodSync(join(scriptsDir, "deploy-ubuntu.sh"), 0o755);
+
+  const result = spawnSync("bash", ["-c", deployScript], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DEPLOY_LOG: deployLog,
+      EVENT_NAME: eventName,
+      FAKE_MAIN_TIP: mainTip,
+      LS_REMOTE_FAIL: lsRemoteFails ? "1" : "",
+      NEEDLEFISH_REF: needlefishRef,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+    },
+  });
+  const output = {
+    ...result,
+    deployLog: existsSync(deployLog) ? readFileSync(deployLog, "utf8") : "",
+  };
+  rmSync(root, { recursive: true, force: true });
+  return output;
+}
+
+test("ci runs the full frozen suite on ubuntu-latest without secrets or self-hosted", () => {
+  assert.match(ci, /^name: needlefish-ci$/m);
+  assert.match(ci, /^  needlefish-ci:$/m);
+  assert.match(ci, /^    name: needlefish-ci$/m);
+  assert.match(ci, /^  pull_request:$/m);
+  assert.match(ci, /^    branches: \[main\]$/m);
+  assert.match(ci, /^    runs-on: ubuntu-latest$/m);
+  assert.match(ci, /corepack enable/);
+  assert.match(ci, /corepack prepare "\$PNPM_VERSION" --activate/);
+  assert.match(ci, /pnpm install --frozen-lockfile/);
+  assert.match(ci, /pnpm check/);
+  assert.match(ci, /pnpm lint/);
+  assert.match(ci, /pnpm test/);
+  assert.match(ci, /node-version: 20/);
+  assert.doesNotMatch(ci, /self-hosted/);
+  assert.doesNotMatch(ci, /secrets\./);
+  assert.doesNotMatch(ci, /pull_request_target/);
+  assert.doesNotMatch(ci, /head\.repo/);
+});
+
+test("deploy is gated on a successful main-push CI run and keeps workflow_dispatch", () => {
+  assert.doesNotMatch(deploy, /^  push:$/m);
+  assert.match(deploy, /^  workflow_run:$/m);
+  assert.match(deploy, /workflows: \[needlefish-ci\]/);
+  assert.match(deploy, /^  workflow_dispatch:$/m);
+  assert.match(deploy, /github\.event\.workflow_run\.conclusion == 'success'/);
+  assert.match(deploy, /github\.event\.workflow_run\.event == 'push'/);
+  assert.match(deploy, /github\.event\.workflow_run\.head_branch == 'main'/);
+  assert.match(deploy, /github\.event\.workflow_run\.head_sha/);
+  assert.match(deploy, /NEEDLEFISH_REF: \$\{\{ steps\.sha\.outputs\.sha \}\}/);
+  assert.match(deploy, /ref: \$\{\{ steps\.sha\.outputs\.sha \}\}/);
+  assert.match(deploy, /^    runs-on: self-hosted$/m);
+  assert.doesNotMatch(deploy, /secrets\./);
+});
+
+test("resolve uses the workflow_run head SHA and rejects a missing or invalid SHA", () => {
+  const success = runResolve();
+  assert.equal(success.status, 0, success.stderr);
+  assert.equal(success.githubOutput, `sha=${verifiedSha}\n`);
+
+  const dispatch = runResolve({ eventName: "workflow_dispatch" });
+  assert.equal(dispatch.status, 0, dispatch.stderr);
+  assert.equal(dispatch.githubOutput, `sha=${laterSha}\n`);
+
+  const missing = runResolve({ workflowSha: "" });
+  assert.notEqual(missing.status, 0);
+  assert.match(missing.stderr, /40-character lowercase SHA/);
+  assert.equal(missing.githubOutput, "");
+
+  const invalid = runResolve({ workflowSha: "main" });
+  assert.notEqual(invalid.status, 0);
+  assert.equal(invalid.githubOutput, "");
+
+  const other = runResolve({ eventName: "push" });
+  assert.notEqual(other.status, 0);
+  assert.match(other.stderr, /unsupported event/);
+});
+
+test("automatic deploy skips when main has moved and still deploys the verified SHA when it is the tip", () => {
+  const current = runDeploy();
+  assert.equal(current.status, 0, current.stderr);
+  assert.equal(current.deployLog, `deployed:${verifiedSha}\n`);
+
+  const stale = runDeploy({ mainTip: laterSha });
+  assert.equal(stale.status, 0, stale.stderr);
+  assert.match(stale.stdout, /Skipping deploy/);
+  assert.equal(stale.deployLog, "");
+
+  const recovery = runDeploy({ eventName: "workflow_dispatch", mainTip: laterSha });
+  assert.equal(recovery.status, 0, recovery.stderr);
+  assert.equal(recovery.deployLog, `deployed:${verifiedSha}\n`);
+
+  const missingTip = runDeploy({ mainTip: "" });
+  assert.notEqual(missingTip.status, 0);
+  assert.match(missingTip.stderr, /could not resolve origin\/main/);
+  assert.equal(missingTip.deployLog, "");
+
+  const lsRemoteFail = runDeploy({ lsRemoteFails: true });
+  assert.notEqual(lsRemoteFail.status, 0);
+  assert.equal(lsRemoteFail.deployLog, "");
+
+  const invalidRef = runDeploy({ needlefishRef: "main" });
+  assert.notEqual(invalidRef.status, 0);
+  assert.match(invalidRef.stderr, /40-character lowercase commit SHA/);
+  assert.equal(invalidRef.deployLog, "");
+});


### PR DESCRIPTION
Closes #47.

## Problem

1. **Needlefish's own PRs had no CI.** `review.yml` runs the *deployed* reviewer against a PR — it never runs the candidate branch's `pnpm check` / `lint` / `test`. None of the six existing workflows was a CI workflow.
2. **Every push to `main` deployed, untested**, straight onto the self-hosted production review runner:
   ```yaml
   on: { push: { branches: [main] } }
   jobs: { deploy: { runs-on: self-hosted, steps: [checkout, scripts/deploy-ubuntu.sh] } }
   ```
   `release.yml`'s verification happens later and does not protect `main`.

## Change

**New `ci.yml`** — `pull_request` + `push` to `main`, on `ubuntu-latest`, pinned Corepack pnpm, `--frozen-lockfile`, then `pnpm check` / `lint` / `test`.

**`deploy.yml` loses `on.push`** and waits on `workflow_run` of `needlefish-ci`.

### Why `workflow_run` (option b)

`needs:` cannot cross workflow files. Verification must stay on `ubuntu-latest` so a broken `main` never occupies the production runner, while deploy must stay on `self-hosted` — so a single-file design would either put PR CI inside the deploy workflow or duplicate the verify job.

### Why a failing SHA cannot deploy

1. A push to `main` starts **only** `needlefish-ci`; `deploy.yml` has no `push` trigger.
2. Deploy runs on `workflow_run: completed`, gated on **all** of:
   ```yaml
   github.event.workflow_run.conclusion == 'success' &&
   github.event.workflow_run.event == 'push' &&
   github.event.workflow_run.head_branch == 'main'
   ```
3. **`event == 'push'` is load-bearing, not belt-and-braces:** `workflow_run` branch matching can treat a PR's *base* as `main`, so without it a green PR targeting `main` would deploy.
4. Red, cancelled, or PR-triggered runs skip the job — no self-hosted occupancy at all.

### Why the deployed SHA is the verified SHA

`scripts/deploy-ubuntu.sh` installs whatever `NEEDLEFISH_REF` points at (fetched into its own temp clone) — **not** the Actions workspace. So the workflow threads the verified SHA through:

- takes `github.event.workflow_run.head_sha`, **not** `github.sha` (which on `workflow_run` resolves to the default-branch tip)
- format-checks it as 40 lowercase hex at both the resolve and deploy steps
- checks out that SHA and exports `NEEDLEFISH_REF=<that SHA>`

**Race** (a second push lands while the first CI is in flight): the deploy compares the verified SHA against `git ls-remote origin main` and **skips** if it is no longer the tip. It never installs a newer, unverified tip on the strength of an older green run — that newer SHA deploys from its own green run. CI concurrency cancels superseded `main` runs, and a cancelled run is not a success. Manual dispatch skips the tip check so rollback still works.

`workflow_dispatch` stays ungated as the recovery path — which is also what `weekly-eval.yml:82` already uses (`gh workflow run deploy.yml --ref main`), so that path keeps working unchanged.

## Verification

**Fork safety, checked directly:** `ci.yml` is `pull_request` (not `pull_request_target`) ✅, `permissions: contents: read` ✅, contains **no** `secrets.` reference ✅.

`scripts/ci-deploy-workflow.test.mjs` pins the gate. **Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 4 / fail 0` |
| drop `conclusion == 'success'` | `pass 3 / fail 1` ✅ |
| deploy `github.sha` instead of the verified `head_sha` | `pass 3 / fail 1` ✅ |
| drop the `event == 'push'` guard | `pass 3 / fail 1` ✅ |
| CI stops running `pnpm test` | `pass 3 / fail 1` ✅ |
| restored | `pass 4 / fail 0` |

All YAML parses ✅ · `pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **538 pass / 0 fail** (exit 0).

## ⚠️ Action required from a maintainer

Branch protection cannot be set from a workflow file. **Mark `needlefish-ci` as a required status check on `main`.** Documented in `AGENTS.md` NOTES and `.github/workflows/AGENTS.md`. If GitHub's protection dropdown shows a slightly different string after the first run, use what it shows.

Until that is done, CI runs and reports but does not *block* merging — the deploy gate works regardless.

## Risk / not verified

- **The `workflow_run` chain has not executed** — it cannot until this merges to `main`. The reasoning above is traced from the GitHub Actions semantics plus static assertions, not observed. The first `main` push after merge is the real test; if the chain misfires, `workflow_dispatch` still deploys manually.
- `scripts/deploy-ubuntu.sh` is unchanged.
- Actions stay at `@v4` (#52 pins SHAs separately) and no `persist-credentials: false` here (#49 separately) — expect textual conflicts with those PRs in `deploy.yml`.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring with the mechanical `needs:` constraint, gate-logic trace, mutation testing)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)