### PR TITLE
fix(normalize): reject malformed residual_risks instead of passing

### DIFF
--- a/src/shared/normalize.test.ts
+++ b/src/shared/normalize.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { deriveVerdict } from "../core/verdict";
 import { normalizeBodyList, normalizeFinding, normalizeMap, normalizePrMeta, normalizeReview } from "./normalize";
 
 test("normalizeMap accepts a summary with no hotspots", () => {
@@ -408,6 +409,103 @@ test("normalizeReview rejects empty residual risk text", () => {
   };
 
   assert.throws(() => normalizeReview(raw), /residual risk text missing/);
+  assert.throws(() => normalizeReview(raw, true), /malformed review output: residual risk text missing/);
+  assert.throws(() => normalizeReview(raw, false), /malformed review output: residual risk text missing/);
+});
+
+function rawReview(residual_risks: unknown): Record<string, unknown> {
+  return {
+    summary: "s",
+    findings: [],
+    checked: ["x"],
+    residual_risks,
+  };
+}
+
+const NON_OBJECT_RESIDUAL_ENTRIES: readonly { readonly kind: string; readonly value: unknown }[] = [
+  { kind: "string", value: "could not verify the changed path" },
+  { kind: "number", value: 0 },
+  { kind: "null", value: null },
+  { kind: "boolean", value: false },
+  { kind: "array", value: [{ text: "nested residual", blocks: true }] },
+];
+
+for (const { kind, value } of NON_OBJECT_RESIDUAL_ENTRIES) {
+  test(`normalizeReview rejects ${kind} residual risk entry in both strict modes`, () => {
+    const raw = rawReview([value]);
+    const expected = /malformed review output: residual risk not an object/;
+    assert.throws(() => normalizeReview(raw), expected);
+    assert.throws(() => normalizeReview(raw, true), expected);
+    assert.throws(() => normalizeReview(raw, false), expected);
+  });
+}
+
+test("normalizeReview rejects boolean true residual risk entry in both strict modes", () => {
+  const raw = rawReview([true]);
+  const expected = /malformed review output: residual risk not an object/;
+  assert.throws(() => normalizeReview(raw), expected);
+  assert.throws(() => normalizeReview(raw, true), expected);
+  assert.throws(() => normalizeReview(raw, false), expected);
+});
+
+test("normalizeReview rejects mixed valid residual object and bare string in both strict modes", () => {
+  const raw = rawReview([
+    { text: "local helper untraced", blocks: false },
+    "could not verify the changed path",
+  ]);
+  const expected = /malformed review output: residual risk not an object/;
+  assert.throws(() => normalizeReview(raw), expected);
+  assert.throws(() => normalizeReview(raw, true), expected);
+  assert.throws(() => normalizeReview(raw, false), expected);
+});
+
+test("normalizeReview round-trips blocking residual risk to needs_human in both strict modes", () => {
+  const residual = { text: "could not verify the changed path", blocks: true };
+  for (const strict of [true, false] as const) {
+    const review = normalizeReview(rawReview([residual]), strict);
+    assert.deepEqual(review.residual_risks, [residual]);
+    assert.equal(deriveVerdict(review.findings, review.residual_risks), "needs_human");
+  }
+  const defaultReview = normalizeReview(rawReview([residual]));
+  assert.deepEqual(defaultReview.residual_risks, [residual]);
+  assert.equal(deriveVerdict(defaultReview.findings, defaultReview.residual_risks), "needs_human");
+});
+
+test("normalizeReview round-trips non-blocking residual risk to pass in both strict modes", () => {
+  const residual = { text: "low confidence private helper", blocks: false };
+  for (const strict of [true, false] as const) {
+    const review = normalizeReview(rawReview([residual]), strict);
+    assert.deepEqual(review.residual_risks, [residual]);
+    assert.equal(deriveVerdict(review.findings, review.residual_risks), "pass");
+  }
+  const defaultReview = normalizeReview(rawReview([residual]));
+  assert.deepEqual(defaultReview.residual_risks, [residual]);
+  assert.equal(deriveVerdict(defaultReview.findings, defaultReview.residual_risks), "pass");
+});
+
+test("normalizeReview accepts empty residual_risks in both strict modes", () => {
+  for (const strict of [true, false] as const) {
+    const review = normalizeReview(rawReview([]), strict);
+    assert.deepEqual(review.residual_risks, []);
+    assert.equal(deriveVerdict(review.findings, review.residual_risks), "pass");
+  }
+  const defaultReview = normalizeReview(rawReview([]));
+  assert.deepEqual(defaultReview.residual_risks, []);
+  assert.equal(deriveVerdict(defaultReview.findings, defaultReview.residual_risks), "pass");
+});
+
+test("normalizeReview loose mode still rejects malformed residuals after dropping malformed findings", () => {
+  const raw = {
+    summary: "s",
+    findings: [{ severity: "bad" }],
+    checked: ["x"],
+    residual_risks: ["could not verify the changed path"],
+  };
+
+  assert.throws(
+    () => normalizeReview(raw, false),
+    /malformed review output: residual risk not an object/,
+  );
 });
 
 test("normalizeReview drops malformed findings in loose mode", () => {

--- a/src/shared/normalize.ts
+++ b/src/shared/normalize.ts
@@ -197,8 +197,10 @@ export function normalizeReview(raw: unknown, strict = true): RawReview {
         })
         .filter((finding: Finding | null): finding is Finding => finding !== null);
   const residual = rawResidual.map((risk) => {
+    // Non-object entries are malformed. Coercing them to {text:"", blocks:false}
+    // erases the residual and lets deriveVerdict return pass.
     if (!isRecord(risk)) {
-      return { text: "", blocks: false };
+      throw new Error("malformed review output: residual risk not an object");
     }
     const text = String(risk.text ?? "").trim();
     if (!text) {


### PR DESCRIPTION
Closes #42. **Tier 1 — verdict integrity.**

## Problem

`normalizeReview` coerced any non-object `residual_risks[]` entry into a non-blocking empty risk:

```ts
if (!isRecord(risk)) {
  return { text: "", blocks: false };     // ← erases the residual
}
```

**Reproduced on `main`** with the issue's exact input:

```
normalized -> [{"text":"","blocks":false}]
verdict    -> pass          ← blocking uncertainty erased, run reported clean
```

A model trying to report *"could not verify the changed path"* as a bare string had that uncertainty silently deleted, and `deriveVerdict` returned `pass`.

The boundary was already internally inconsistent, which is what marks this as a bug rather than deliberate tolerance: an **object** entry with blank text **threw**, while a **bare string** — strictly more malformed — was accepted. `prompts/review.md:106` specifies `{ "text": "...", "blocks": false }`, so a string is malformed output.

## Change

Three lines in `src/shared/normalize.ts`. Fails closed at the normalization boundary:

```ts
// Non-object entries are malformed. Coercing them to {text:"", blocks:false}
// erases the residual and lets deriveVerdict return pass.
throw new Error("malformed review output: residual risk not an object");
```

**`deriveVerdict` is untouched** — it was never wrong. The thrown error feeds the existing retry path in `src/core/review.ts:295`, so rejection is handled, not fatal.

### strict vs non-strict — decided, not defaulted

Residuals fail closed in **both** modes. `strict` still governs **findings only** (drop vs throw), because the tradeoffs differ:

- a dropped **finding** loses a report;
- a dropped **residual** converts `needs_human` into `pass` — this exact bug.

Production (`review.ts:347`) uses the strict default already; locking loose mode too prevents a later "make residuals consistent with findings" refactor from quietly reopening the hole.

## Verification — tier-1 standard

Golden tests for **every** branch, including the directions that "cannot happen", each run in **both** strict modes:

| branch | behavior |
|---|---|
| string / number / null / `false` / `true` / array | throws `residual risk not an object` |
| mixed `[valid object, bare string]` | throws — the valid half must **not** survive |
| `{ text, blocks: true }` | round-trips → `deriveVerdict` = `needs_human` |
| `{ text, blocks: false }` | round-trips → `deriveVerdict` = `pass` |
| `{ text: "", blocks: true }` | throws (pre-existing behavior, now asserted in both modes) |
| `residual_risks: []` | normalizes, verdict `pass` |
| loose findings + malformed residual | findings still drop, residual still throws |

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 43 / fail 0` |
| restore the silent coercion (**the original bug**) | `pass 35 / fail 8` ✅ |
| fail closed only in strict mode | `pass 35 / fail 8` ✅ |
| drop the blank-text rejection | `pass 42 / fail 1` ✅ |
| restored | `pass 43 / fail 0` |

Note the happy-path round-trips stay green under the reverted implementation, exactly as they should — it is the eight rejection cases that carry the signal.

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **545 pass / 0 fail** (exit 0).

## Risk

- **The retry path was not exercised against a live model runner.** A model that habitually emits string residuals would now burn retries and fail the review rather than passing it — fail-closed, which is the correct direction for a verdict boundary, but it is a live behavior change and worth watching on the first real runs.
- No prompt, verdict, or pipeline file was touched, so `promptHash` is unchanged and no eval gate is triggered by this diff.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring, on-main bug reproduction, mutation testing across all three branches)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)