### PR TITLE
fix(eval): fail the ship gate on false positives and unarmed anti-cheat

### DIFF
--- a/scripts/gate-verdict.mjs
+++ b/scripts/gate-verdict.mjs
@@ -21,6 +21,24 @@ export function computeScorerHash() {
   return hash.digest("hex").slice(0, 16);
 }
 
+// The gate must track eval/shared/types.ts, not a copied literal that can rot
+// independently of the generation stamp writeReport actually emits.
+function readCurrentAnticheatVersion() {
+  const source = readFileSync(join(SCORER_DIR, "types.ts"), "utf8");
+  const match = source.match(/^export const ANTICHEAT_VERSION = ([0-9]+);\r?$/m);
+  if (!match) return null;
+  const version = Number(match[1]);
+  return Number.isInteger(version) ? version : null;
+}
+
+export function currentAnticheatVersion() {
+  const version = readCurrentAnticheatVersion();
+  if (version === null) {
+    throw new Error("eval/shared/types.ts does not export an integer ANTICHEAT_VERSION");
+  }
+  return version;
+}
+
 function output(pass, reasons, promptHash = "", fixtureSetHash = "") {
   process.stdout.write(`${JSON.stringify({ pass, reasons, promptHash, fixtureSetHash })}\n`);
 }
@@ -93,7 +111,8 @@ function validReport(value) {
     && result.score.mustFindTotal >= result.score.mustFindHits
     && Number.isInteger(result.score.noiseFindingCount)
     && result.score.noiseFindingCount >= 0
-    && typeof result.score.cheatDetected === "boolean");
+    && typeof result.score.cheatDetected === "boolean"
+    && typeof result.score.falsePositive === "boolean");
 }
 
 function recomputeAggregates(report) {
@@ -209,6 +228,14 @@ export function evaluateGate(report, criteria) {
   } else if (report.scorerHash !== computeScorerHash()) {
     reasons.push("scorer-hash-mismatch");
   }
+  const currentVersion = readCurrentAnticheatVersion();
+  if (currentVersion === null) {
+    reasons.push("anticheat-version-unreadable");
+  } else if (report.anticheatVersion === undefined) {
+    reasons.push("anticheat-version-missing");
+  } else if (report.anticheatVersion !== currentVersion) {
+    reasons.push("anticheat-version-mismatch");
+  }
   if (!equalRecallMaps(report.aggregates.recallByFixture, aggregates.recallByFixture)) {
     reasons.push("aggregate-mismatch:recallByFixture");
   }
@@ -260,9 +287,29 @@ export function evaluateGate(report, criteria) {
     reasons.push(`noise-threshold-exceeded:${aggregates.meanNoisePerPositive}>${criteria.maxMeanNoisePerPositive}`);
   }
   for (const fixtureId of criteriaFixturesInRun) {
-    if (!incompleteFixtures.has(fixtureId) && aggregates.recallByFixture[fixtureId] !== 1) {
-      reasons.push(`fixture-recall-missed:${fixtureId}`);
+    const kind = report.fixtureKinds[fixtureId];
+    // A honeypot is a canary, not a pass/fail criterion. Reject even when
+    // draws are incomplete so listing one in criteria cannot hide behind
+    // missing-draws.
+    if (kind === "honeypot") {
+      reasons.push(`honeypot-as-criteria:${fixtureId}`);
+      continue;
     }
+    if (incompleteFixtures.has(fixtureId)) continue;
+    if (kind === "negative") {
+      const draws = report.results.filter((result) => result.fixtureId === fixtureId);
+      if (draws.some((draw) => draw.score.falsePositive !== false)) {
+        reasons.push(`fixture-false-positive:${fixtureId}`);
+      }
+      continue;
+    }
+    if (kind === "positive" || kind === "parity") {
+      if (aggregates.recallByFixture[fixtureId] !== 1) {
+        reasons.push(`fixture-recall-missed:${fixtureId}`);
+      }
+      continue;
+    }
+    reasons.push(`unknown-criteria-kind:${fixtureId}`);
   }
   return { pass: reasons.length === 0, reasons, promptHash, fixtureSetHash };
 }

--- a/scripts/gate-verdict.test.mjs
+++ b/scripts/gate-verdict.test.mjs
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { computeScorerHash } from "./gate-verdict.mjs";
+import { computeScorerHash, currentAnticheatVersion } from "./gate-verdict.mjs";
 
 const script = new URL("./gate-verdict.mjs", import.meta.url);
 
@@ -19,16 +19,29 @@ function missEvidence() {
   return { findings: [], matchEvidence: [{ pattern: "bug", findingIndex: null }] };
 }
 
+function baseScore(overrides = {}) {
+  return {
+    recall: true,
+    mustFindHits: 0,
+    mustFindTotal: 0,
+    noiseFindingCount: 0,
+    cheatDetected: false,
+    falsePositive: false,
+    ...overrides,
+  };
+}
+
 function baseReport() {
   return {
     promptHash: "prompt-123",
     fixtureSetHash: "fixtures-456",
     scorerHash: computeScorerHash(),
+    anticheatVersion: currentAnticheatVersion(),
     fixtures: ["obvious-bug", "required-bug"],
     draws: 1,
     results: [
-      { fixtureId: "obvious-bug", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
-      { fixtureId: "required-bug", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
+      { fixtureId: "obvious-bug", draw: 0, score: baseScore(), ...emptyEvidence() },
+      { fixtureId: "required-bug", draw: 0, score: baseScore(), ...emptyEvidence() },
     ],
     aggregates: {
       cheatDetectedCount: 0,
@@ -145,7 +158,7 @@ test("fixture kinds reject values outside the declared union", () => {
   const report = baseReport();
   report.fixtures.push("typo-kind");
   report.fixtureKinds["typo-kind"] = "negativ";
-  report.results.push({ fixtureId: "typo-kind", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() });
+  report.results.push({ fixtureId: "typo-kind", draw: 0, score: baseScore(), ...emptyEvidence() });
   report.aggregates.recallByFixture["typo-kind"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
@@ -169,7 +182,7 @@ test("real-shaped reports allow recall keys beyond the positive tier keys", () =
   const report = baseReport();
   report.fixtures.push("negative-case");
   report.fixtureKinds["negative-case"] = "negative";
-  report.results.push({ fixtureId: "negative-case", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() });
+  report.results.push({ fixtureId: "negative-case", draw: 0, score: baseScore(), ...emptyEvidence() });
   report.aggregates.recallByFixture["negative-case"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 0);
@@ -205,7 +218,7 @@ test("a manifest-complete report passes", () => {
   const report = baseReport();
   report.fixtures.push("negative-honeypot");
   report.fixtureKinds["negative-honeypot"] = "honeypot";
-  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() });
+  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: baseScore(), ...emptyEvidence() });
   report.aggregates.recallByFixture["negative-honeypot"] = 1;
   const result = run(report, baseCriteria());
   assert.equal(result.status, 0);
@@ -254,10 +267,10 @@ test("duplicate draw indices fail completeness even when the raw count matches",
   const report = baseReport();
   report.draws = 2;
   report.results = [
-    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
-    { fixtureId: "obvious-bug", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
-    { fixtureId: "required-bug", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
-    { fixtureId: "required-bug", draw: 1, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
+    { fixtureId: "obvious-bug", draw: 0, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "obvious-bug", draw: 0, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "required-bug", draw: 0, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "required-bug", draw: 1, score: baseScore(), ...emptyEvidence() },
   ];
   const result = run(report, baseCriteria());
   assert.equal(result.status, 1);
@@ -296,7 +309,7 @@ test("overlapping tier-1 and criteria fixture emits one missing-draws reason", (
 test("resume-shaped reports require draws for every fixture tier entry", () => {
   const report = baseReport();
   report.results = [
-    { fixtureId: "resume-first", draw: 0, score: { recall: true, mustFindHits: 0, mustFindTotal: 0, noiseFindingCount: 0, cheatDetected: false }, ...emptyEvidence() },
+    { fixtureId: "resume-first", draw: 0, score: baseScore(), ...emptyEvidence() },
   ];
   report.aggregates.recallByFixture = { "resume-first": 1 };
   report.fixtureTiers = { "resume-first": 2, "resume-second": 2 };
@@ -407,9 +420,19 @@ test("missing or mismatched scorerHash fails closed", () => {
 });
 
 test("missing recomputation score fields make the report unreadable", () => {
-  for (const field of ["noiseFindingCount", "cheatDetected"]) {
+  for (const field of ["noiseFindingCount", "cheatDetected", "falsePositive"]) {
     const report = baseReport();
     delete report.results[0].score[field];
+    const result = run(report, baseCriteria());
+    assert.equal(result.status, 1);
+    assert.deepEqual(result.json.reasons, ["unreadable-report"]);
+  }
+});
+
+test("non-boolean falsePositive makes the report unreadable", () => {
+  for (const value of [0, 1, "false", null]) {
+    const report = baseReport();
+    report.results[0].score.falsePositive = value;
     const result = run(report, baseCriteria());
     assert.equal(result.status, 1);
     assert.deepEqual(result.json.reasons, ["unreadable-report"]);
@@ -502,6 +525,174 @@ test("entrypoint runs when invoked through a symlinked directory", () => {
   assert.equal(result.status, 2);
   assert.match(result.stderr, /^usage:/);
   assert.equal(result.stdout, "");
+});
+
+test("a negative criteria fixture with a false-positive draw fails", () => {
+  const report = baseReport();
+  report.fixtures.push("clean-diff");
+  report.fixtureKinds["clean-diff"] = "negative";
+  report.results.push({ fixtureId: "clean-diff", draw: 0, score: baseScore({ falsePositive: true }), ...emptyEvidence() });
+  report.aggregates.recallByFixture["clean-diff"] = 1;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["clean-diff"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["fixture-false-positive:clean-diff"]);
+});
+
+test("a negative criteria fixture with no false positives passes", () => {
+  const report = baseReport();
+  report.fixtures.push("clean-diff");
+  report.fixtureKinds["clean-diff"] = "negative";
+  report.results.push({ fixtureId: "clean-diff", draw: 0, score: baseScore(), ...emptyEvidence() });
+  report.aggregates.recallByFixture["clean-diff"] = 1;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["clean-diff"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("a negative criteria fixture fails if any draw is a false positive", () => {
+  const report = baseReport();
+  report.draws = 2;
+  report.fixtures.push("clean-diff");
+  report.fixtureKinds["clean-diff"] = "negative";
+  report.results = [
+    { fixtureId: "obvious-bug", draw: 0, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "obvious-bug", draw: 1, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "required-bug", draw: 0, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "required-bug", draw: 1, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "clean-diff", draw: 0, score: baseScore(), ...emptyEvidence() },
+    { fixtureId: "clean-diff", draw: 1, score: baseScore({ falsePositive: true }), ...emptyEvidence() },
+  ];
+  report.aggregates.recallByFixture["clean-diff"] = 1;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["clean-diff"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["fixture-false-positive:clean-diff"]);
+});
+
+test("an incomplete negative criteria fixture fails for missing draws only", () => {
+  const report = baseReport();
+  report.draws = 2;
+  report.fixtures.push("clean-diff");
+  report.fixtureKinds["clean-diff"] = "negative";
+  report.results.push({ fixtureId: "clean-diff", draw: 0, score: baseScore({ falsePositive: true }), ...emptyEvidence() });
+  report.aggregates.recallByFixture["clean-diff"] = 1;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["clean-diff"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("missing-draws:clean-diff"));
+  assert.ok(!result.json.reasons.includes("fixture-false-positive:clean-diff"));
+});
+
+test("a negative fixture not listed in criteria does not fail on false positives", () => {
+  const report = baseReport();
+  report.fixtures.push("clean-diff");
+  report.fixtureKinds["clean-diff"] = "negative";
+  report.results.push({ fixtureId: "clean-diff", draw: 0, score: baseScore({ falsePositive: true }), ...emptyEvidence() });
+  report.aggregates.recallByFixture["clean-diff"] = 1;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("a parity criteria fixture remains recall-gated", () => {
+  const report = baseReport();
+  report.fixtures.push("parity-throw");
+  report.fixtureKinds["parity-throw"] = "parity";
+  report.results.push({
+    fixtureId: "parity-throw",
+    draw: 0,
+    score: baseScore({ recall: false, mustFindTotal: 1 }),
+    ...missEvidence(),
+  });
+  report.aggregates.recallByFixture["parity-throw"] = 0;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["parity-throw"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["fixture-recall-missed:parity-throw"]);
+});
+
+test("a parity criteria fixture with perfect recall passes", () => {
+  const report = baseReport();
+  report.fixtures.push("parity-throw");
+  report.fixtureKinds["parity-throw"] = "parity";
+  report.results.push({ fixtureId: "parity-throw", draw: 0, score: baseScore(), ...emptyEvidence() });
+  report.aggregates.recallByFixture["parity-throw"] = 1;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["parity-throw"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json.reasons, []);
+});
+
+test("a honeypot listed as a criteria fixture fails with a distinct reason", () => {
+  const report = baseReport();
+  report.fixtures.push("negative-honeypot");
+  report.fixtureKinds["negative-honeypot"] = "honeypot";
+  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: baseScore(), ...emptyEvidence() });
+  report.aggregates.recallByFixture["negative-honeypot"] = 1;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["negative-honeypot"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["honeypot-as-criteria:negative-honeypot"]);
+});
+
+test("an incomplete honeypot criteria fixture still fails as a canary", () => {
+  const report = baseReport();
+  report.draws = 2;
+  report.fixtures.push("negative-honeypot");
+  report.fixtureKinds["negative-honeypot"] = "honeypot";
+  report.results.push({ fixtureId: "negative-honeypot", draw: 0, score: baseScore(), ...emptyEvidence() });
+  report.aggregates.recallByFixture["negative-honeypot"] = 1;
+  const criteria = baseCriteria();
+  criteria.fixtures = ["negative-honeypot"];
+  const result = run(report, criteria);
+  assert.equal(result.status, 1);
+  assert.ok(result.json.reasons.includes("honeypot-as-criteria:negative-honeypot"));
+  assert.ok(result.json.reasons.includes("missing-draws:negative-honeypot"));
+});
+
+test("missing anticheatVersion fails closed", () => {
+  const report = baseReport();
+  delete report.anticheatVersion;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["anticheat-version-missing"]);
+});
+
+test("stale anticheatVersion fails closed", () => {
+  const report = baseReport();
+  const current = currentAnticheatVersion();
+  report.anticheatVersion = current === 0 ? 1 : 0;
+  const result = run(report, baseCriteria());
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.json.reasons, ["anticheat-version-mismatch"]);
+});
+
+test("current anticheatVersion is read from eval/shared/types.ts", () => {
+  const source = readFileSync(new URL("../eval/shared/types.ts", import.meta.url), "utf8");
+  const match = source.match(/^export const ANTICHEAT_VERSION = ([0-9]+);$/m);
+  assert.ok(match);
+  assert.equal(currentAnticheatVersion(), Number(match[1]));
+});
+
+test("a guarded report that meets all criteria still passes", () => {
+  const result = run(baseReport(), baseCriteria());
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.json, {
+    pass: true,
+    reasons: [],
+    promptHash: "prompt-123",
+    fixtureSetHash: "fixtures-456",
+  });
+  assert.equal(baseReport().anticheatVersion, currentAnticheatVersion());
 });
 
 test("entrypoint runs when the argv path cannot be canonicalized", () => {


### PR DESCRIPTION
Closes #45. **Tier 1 — eval ship-gate integrity.**

## Problem — two independent fail-open paths

**Measured on `main`.** Five separately unsafe reports, all fed to the real gate with real criteria:

| report | `main` | this branch |
|---|---|---|
| valid guarded report | `PASS []` | `PASS []` |
| negative criteria fixture, one **false-positive** draw | 🔴 `PASS []` | ✅ `FAIL ['fixture-false-positive:neg-b']` |
| **no** `anticheatVersion` | 🔴 `PASS []` | ✅ `FAIL ['anticheat-version-missing']` |
| **stale** `anticheatVersion` | 🔴 `PASS []` | ✅ `FAIL ['anticheat-version-mismatch']` |
| missing per-result `falsePositive` | 🔴 `PASS []` | ✅ `FAIL ['unreadable-report']` |
| honeypot listed as a criteria fixture | 🔴 `PASS []` | ✅ `FAIL ['honeypot-as-criteria:neg-b']` |

**Why each was open:**

1. Fixtures without `mustFind` score `recall: true` unconditionally (`score.ts:209-210`), and the criteria loop checked **only** `recallByFixture`. A negative fixture therefore satisfied the gate no matter how many blocking false positives it produced — `falsePositive` appeared **nowhere** in `gate-verdict.mjs`.
2. `cheatDetectedCount` was checked, but `anticheatVersion` never was. `eval/run.ts:594-603` stamps that version *only* when the run was actually guarded, so a run with `NEEDLEFISH_EVAL_TRACE=0` has **unarmed detectors** and a structurally guaranteed zero count — which the gate accepted as evidence of honesty.

## Change

**Criteria gated by fixture kind:**
- `positive` / `parity` — recall, as before
- `negative` — **every** draw must have `score.falsePositive === false`
- `honeypot` — rejected as an ordinary criterion with its own reason; it is a canary, not a criterion

**`anticheatVersion` must equal the current constant**, with distinct `anticheat-version-missing` / `anticheat-version-mismatch` reasons.

**Per-result `score.falsePositive` is validated** and fails closed when missing or non-boolean.

The version is **parsed from `eval/shared/types.ts` at runtime** and throws if that export disappears — so the `.mjs` gate cannot silently drift from the constant it claims to enforce, and no literal `2` is hardcoded.

**No opt-out.** Exploratory lanes may still run; they simply cannot authorize shipping.

## Compatibility — checked, not assumed

Scanned all **68** recorded reports under `eval/results/` and `eval/baselines/`:

| | count |
|---|---|
| with any non-boolean `score.falsePositive` | **0** ← the new validation rejects none of them |
| without the current `anticheatVersion` | 55 |
| fully compatible with both new checks | 13 |

The 55 are the **intended** fail-closed for pre-guard runs, not a regression. No recorded report was rewritten, and nothing was loosened to accommodate them.

## Verification

Gate test file grows 44 → **58** tests. **Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 58 / fail 0` |
| remove the anticheat-version checks | `pass 56 / fail 2` ✅ |
| remove the negative-fixture false-positive criteria | `pass 56 / fail 2` ✅ |
| remove honeypot-as-criteria rejection | `pass 56 / fail 2` ✅ |
| restored | `pass 58 / fail 0` |

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **548 pass / 0 fail** (exit 0).

## Risk / not verified

- **A real eval run was not executed** — no model runners or credentials here. Everything above uses constructed reports against the real gate binary, which is the contract the gate owns.
- `eval/shared/score.ts` is deliberately untouched: changing it moves `scorerHash` and invalidates every baseline (that is #55's separate, disclosed consequence). This PR leaves `scorerHash` unchanged.
- The `ANTICHEAT_VERSION` parse is a regex over `types.ts`. It is brittle to reformatting of that one line — but it **throws loudly** rather than defaulting, which is the correct failure direction.
- **Operational consequence:** after this merges, the next ship gate requires a report produced under the current guards. If your most recent report predates them, it must be re-run before it can authorize anything.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring with pre-verified compatibility data, main-vs-branch gate comparison across all five paths, recorded-report scan, mutation testing)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)