### PR TITLE
fix(classify): stop auto-passing policy and code through the docs fast path

### DIFF
--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import test from "node:test";
 import { review } from "./review";
 import type { ReviewTraceEvent } from "./review-trace";
+import { classifySurface } from "../shared/classify";
 import { headSha, initRepo } from "../shared/codex-runner-test-fixtures";
 import type { Bundle } from "../shared/schema";
 
@@ -1461,8 +1462,8 @@ test("review docs-only fast path skips all model calls", async (t) => {
 		patch: "diff --git a/README.md b/README.md\n+docs\n",
 		patchStat: " README.md | 1 +",
 		changedFiles: [
-			{ path: "README.md", surface: "docs" },
-			{ path: "docs/guide.md", surface: "docs" },
+			{ path: "README.md", surface: classifySurface("README.md") },
+			{ path: "docs/guide.md", surface: classifySurface("docs/guide.md") },
 		],
 		agentsMd: "(none)",
 		prMeta: null,
@@ -1495,6 +1496,140 @@ test("review docs-only fast path skips all model calls", async (t) => {
 			"runner must not be invoked for docs-only bundle",
 		);
 	}
+});
+
+test("review does not fast-path policy markdown or executable files under docs paths", async (t) => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		retry: process.env.CODEX_RETRY_MS,
+		noFastPath: process.env.NEEDLEFISH_NO_FAST_PATH,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.retry === undefined) delete process.env.CODEX_RETRY_MS;
+		else process.env.CODEX_RETRY_MS = previous.retry;
+		if (previous.noFastPath === undefined)
+			delete process.env.NEEDLEFISH_NO_FAST_PATH;
+		else process.env.NEEDLEFISH_NO_FAST_PATH = previous.noFastPath;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"let input = '';",
+			"process.stdin.setEncoding('utf8');",
+			"process.stdin.on('data', (chunk) => { input += chunk; });",
+			"process.stdin.on('end', () => {",
+			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
+			"  const review = { summary: 'clean', findings: [], checked: ['looked'], residual_risks: [] };",
+			"  fs.appendFileSync(" + JSON.stringify(calls) + ", 'x\\n');",
+			"  fs.writeFileSync(out, JSON.stringify(review));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.CODEX_RETRY_MS = "1";
+	delete process.env.NEEDLEFISH_NO_FAST_PATH;
+
+	const cases = [
+		"src/api/docs/handler.ts",
+		"docs/build.ts",
+		"prompts/review.md",
+		"AGENTS.md",
+	];
+	for (const filePath of cases) {
+		if (existsSync(calls)) rmSync(calls);
+		const bundle: Bundle = {
+			repoPath: repo,
+			baseSha: "base",
+			headSha: headSha(repo),
+			patch: `diff --git a/${filePath} b/${filePath}\n+changed\n`,
+			patchStat: ` ${filePath} | 1 +`,
+			changedFiles: [{ path: filePath, surface: classifySurface(filePath) }],
+			agentsMd: "(none)",
+			prMeta: null,
+			deep: false,
+			focus: null,
+		};
+		const result = await review(bundle);
+		assert.ok(
+			existsSync(calls),
+			`runner must be invoked for ${filePath}`,
+		);
+		assert.doesNotMatch(
+			result.summary,
+			/Docs-only change/,
+			`${filePath} must not take the docs fast path`,
+		);
+		assert.ok(
+			!result.checked.some((line) => line.startsWith("FAST_PATH")),
+			`${filePath} must not record a FAST_PATH checked line`,
+		);
+	}
+});
+
+test("review still fast-paths genuine prose classified via classifySurface", async (t) => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-review-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const calls = path.join(tmp, "calls.log");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		noFastPath: process.env.NEEDLEFISH_NO_FAST_PATH,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.noFastPath === undefined)
+			delete process.env.NEEDLEFISH_NO_FAST_PATH;
+		else process.env.NEEDLEFISH_NO_FAST_PATH = previous.noFastPath;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			`fs.appendFileSync(${JSON.stringify(calls)}, 'called\\n');`,
+			"process.exit(1);",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	delete process.env.NEEDLEFISH_NO_FAST_PATH;
+
+	const bundle: Bundle = {
+		repoPath: repo,
+		baseSha: "base",
+		headSha: headSha(repo),
+		patch: "diff --git a/docs/guide.md b/docs/guide.md\n+docs\n",
+		patchStat: " docs/guide.md | 1 +",
+		changedFiles: [
+			{ path: "docs/guide.md", surface: classifySurface("docs/guide.md") },
+		],
+		agentsMd: "(none)",
+		prMeta: null,
+		deep: false,
+		focus: null,
+	};
+
+	const result = await review(bundle);
+	assert.equal(result.verdict, "pass");
+	assert.deepEqual(result.checked, [
+		"FAST_PATH docs-only files=[docs/guide.md]",
+	]);
+	assert.ok(
+		!existsSync(calls),
+		"runner must not be invoked for genuine prose docs",
+	);
 });
 
 test("review mixed docs+source bundle still invokes the model", async (t) => {

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -1544,11 +1544,18 @@ test("review does not fast-path policy markdown or executable files under docs p
 		"docs/build.ts",
 		"prompts/review.md",
 		"AGENTS.md",
-		// Agent policy is policy wherever it sits: a nested CLAUDE.md instructs
-		// edits under its directory, and .claude/ Markdown is agent config, not
-		// prose about the product. Both used to reach the deterministic pass.
+		// Agent policy is policy wherever it sits: a nested CLAUDE.md/GEMINI.md
+		// instructs edits under its directory, and agent-config dot-directory
+		// Markdown is policy, not prose about the product. All of these used to
+		// reach the deterministic pass.
 		"docs/CLAUDE.md",
+		"docs/GEMINI.md",
 		".claude/README.md",
+		".gemini/README.md",
+		// No rule names this file; it is denied because unrecognized ALL-CAPS
+		// Markdown under docs/ fails closed. This is the case that stays fixed
+		// when the next agent CLI invents a filename.
+		"docs/CURSOR.md",
 	];
 	for (const filePath of cases) {
 		if (existsSync(calls)) rmSync(calls);

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -1544,6 +1544,11 @@ test("review does not fast-path policy markdown or executable files under docs p
 		"docs/build.ts",
 		"prompts/review.md",
 		"AGENTS.md",
+		// Agent policy is policy wherever it sits: a nested CLAUDE.md instructs
+		// edits under its directory, and .claude/ Markdown is agent config, not
+		// prose about the product. Both used to reach the deterministic pass.
+		"docs/CLAUDE.md",
+		".claude/README.md",
 	];
 	for (const filePath of cases) {
 		if (existsSync(calls)) rmSync(calls);

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -1551,7 +1551,7 @@ test("review does not fast-path policy markdown or executable files under docs p
 		"docs/CLAUDE.md",
 		"docs/GEMINI.md",
 		".claude/README.md",
-		".gemini/README.md",
+		".codex/README.md",
 		// No rule names this file; it is denied because unrecognized ALL-CAPS
 		// Markdown under docs/ fails closed. This is the case that stays fixed
 		// when the next agent CLI invents a filename.

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -9,6 +9,7 @@ import {
 	type RunnerOptions,
 	type RunStat,
 } from "../shared/runner.js";
+import { isDocsFastPathEligible } from "../shared/classify.js";
 import { envFlagOn } from "../shared/env.js";
 import {
 	REVIEW_RESULT_SCHEMA_VERSION,
@@ -656,14 +657,17 @@ async function reviewLarge(run: ReviewRun): Promise<ReviewResult> {
 	);
 }
 
-// Docs-only fast path: when every changed file is classified "docs" and the
-// escape hatch is unset, skip all model calls and return a deterministic pass.
-// classify.ts rule order already routes workflow yml to "workflow", so CI files
-// can never ride this path.
+// Docs-only fast path: skip model calls only when every changed file is
+// classified "docs" AND is user-facing prose (not model/agent policy
+// Markdown). classify.ts rule order already routes workflow yml to
+// "workflow", so CI files can never ride this path. Executable files under
+// a docs/ directory are not classified "docs" (Markdown extension required).
 function isDocsOnlyFastPath(bundle: Bundle): boolean {
 	return (
 		bundle.changedFiles.length > 0 &&
-		bundle.changedFiles.every((f) => f.surface === "docs") &&
+		bundle.changedFiles.every(
+			(f) => f.surface === "docs" && isDocsFastPathEligible(f.path),
+		) &&
 		!envFlagOn("NEEDLEFISH_NO_FAST_PATH")
 	);
 }

--- a/src/shared/classify.test.ts
+++ b/src/shared/classify.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { classifySurface } from "./classify";
+import { classifySurface, isDocsFastPathEligible } from "./classify";
 
 test("classifySurface identifies high-risk repo surfaces", () => {
   assert.equal(classifySurface(".github/workflows/review.yml"), "workflow");
@@ -8,4 +8,75 @@ test("classifySurface identifies high-risk repo surfaces", () => {
   assert.equal(classifySurface("docs/usage.md"), "docs");
   assert.equal(classifySurface("src/api/users.ts"), "public-api");
   assert.equal(classifySurface("src/core/review.ts"), "source");
+});
+
+test("classifySurface does not treat executable files as docs from directory names", () => {
+  assert.equal(classifySurface("src/api/docs/handler.ts"), "public-api");
+  assert.equal(classifySurface("docs/build.ts"), "source");
+  assert.equal(classifySurface("docs/cli/main.ts"), "cli");
+  assert.equal(classifySurface("docs/guide.md"), "docs");
+  assert.equal(classifySurface("doc/guide.md"), "docs");
+  assert.equal(classifySurface("README.md"), "docs");
+});
+
+test("classifySurface keeps policy markdown as docs (prose) without promoting it over earlier rules", () => {
+  assert.equal(classifySurface("prompts/review.md"), "docs");
+  assert.equal(classifySurface("prompt/system.md"), "docs");
+  assert.equal(classifySurface("instructions/policy.md"), "docs");
+  assert.equal(classifySurface("AGENTS.md"), "docs");
+  assert.equal(classifySurface("src/AGENTS.md"), "docs");
+  assert.equal(classifySurface("CLAUDE.md"), "docs");
+});
+
+test("classifySurface rule order is unchanged for non-docs surfaces", () => {
+  assert.equal(classifySurface(".github/workflows/review.yml"), "workflow");
+  assert.equal(classifySurface(".github/workflows/docs.yml"), "workflow");
+  assert.equal(classifySurface("docs/.github/workflows/ci.yml"), "workflow");
+  assert.equal(classifySurface("package.json"), "dependency");
+  assert.equal(classifySurface("pnpm-lock.yaml"), "dependency");
+  assert.equal(classifySurface("node_modules/foo/index.js"), "dependency");
+  assert.equal(classifySurface("src/foo.test.ts"), "test");
+  assert.equal(classifySurface("test/app.ts"), "test");
+  assert.equal(classifySurface("docs/foo.test.ts"), "test");
+  assert.equal(classifySurface("test/README.md"), "test");
+  assert.equal(classifySurface("migrations/001.sql"), "schema");
+  assert.equal(classifySurface("schema/foo.ts"), "schema");
+  assert.equal(classifySurface("db/foo.ts"), "schema");
+  assert.equal(classifySurface("foo.sql"), "schema");
+  assert.equal(classifySurface("bin/cli.ts"), "cli");
+  assert.equal(classifySurface("cli/main.ts"), "cli");
+  assert.equal(classifySurface("src/api/users.ts"), "public-api");
+  assert.equal(classifySurface("lib/api/foo.ts"), "public-api");
+  assert.equal(classifySurface("routes/index.ts"), "public-api");
+  assert.equal(classifySurface(".env"), "config");
+  assert.equal(classifySurface("app.config.ts"), "config");
+  assert.equal(classifySurface("config/app.yaml"), "config");
+  assert.equal(classifySurface(".needlefish/foo"), "config");
+  // .md still wins over later rules, same as before the directory-match removal.
+  assert.equal(classifySurface("schema/README.md"), "docs");
+  assert.equal(classifySurface("bin/README.md"), "docs");
+  assert.equal(classifySurface("src/api/README.md"), "docs");
+  assert.equal(classifySurface("config/README.md"), "docs");
+});
+
+test("isDocsFastPathEligible is a generic user-facing-docs allowlist", () => {
+  assert.equal(isDocsFastPathEligible("docs/guide.md"), true);
+  assert.equal(isDocsFastPathEligible("doc/guide.md"), true);
+  assert.equal(isDocsFastPathEligible("packages/pkg/docs/api.md"), true);
+  assert.equal(isDocsFastPathEligible("README.md"), true);
+  assert.equal(isDocsFastPathEligible("README.zh-TW.md"), true);
+  assert.equal(isDocsFastPathEligible("CHANGELOG.md"), true);
+  assert.equal(isDocsFastPathEligible("CONTRIBUTING.md"), true);
+  assert.equal(isDocsFastPathEligible("src/api/docs/handler.ts"), false);
+  assert.equal(isDocsFastPathEligible("docs/build.ts"), false);
+  assert.equal(isDocsFastPathEligible("prompts/review.md"), false);
+  assert.equal(isDocsFastPathEligible("prompt/system.md"), false);
+  assert.equal(isDocsFastPathEligible("instructions/policy.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/prompts/review.md"), false);
+  assert.equal(isDocsFastPathEligible("AGENTS.md"), false);
+  assert.equal(isDocsFastPathEligible("src/AGENTS.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/AGENTS.md"), false);
+  assert.equal(isDocsFastPathEligible("CLAUDE.md"), false);
+  assert.equal(isDocsFastPathEligible("DESIGN.md"), false);
+  assert.equal(isDocsFastPathEligible(".github/workflows/review.yml"), false);
 });

--- a/src/shared/classify.test.ts
+++ b/src/shared/classify.test.ts
@@ -146,12 +146,13 @@ test("isDocsFastPathEligible excludes GEMINI.md policy files anywhere in the tre
   assert.equal(isDocsFastPathEligible("docs/gemini-setup.md"), true);
 });
 
-// The agent-config dot-directories are policy trees: skills, commands, and
+// Dot-directories are tool/agent configuration trees: skills, commands, and
 // subagent definitions instruct agents, and the prose describing them is part of
-// that policy. They used to fail closed only incidentally, which left the two
+// that policy. They used to be denied only incidentally, which left the two
 // allowlist entries open -- `<dir>/README.md` (user-facing basename) and
-// `<dir>/docs/*.md` (DOCS_DIR).
-test("isDocsFastPathEligible excludes .claude agent-config Markdown", () => {
+// `<dir>/docs/*.md` (DOCS_DIR). No rule names .codex, .cursor or .aider; they
+// are denied by shape, which is what keeps the next tool's directory covered.
+test("isDocsFastPathEligible excludes dot-directory agent-config Markdown", () => {
   assert.equal(isDocsFastPathEligible(".claude/README.md"), false);
   assert.equal(isDocsFastPathEligible(".claude/docs/guide.md"), false);
   assert.equal(isDocsFastPathEligible(".claude/skills/review/SKILL.md"), false);
@@ -159,8 +160,16 @@ test("isDocsFastPathEligible excludes .claude agent-config Markdown", () => {
   assert.equal(isDocsFastPathEligible("packages/app/.claude/README.md"), false);
   assert.equal(isDocsFastPathEligible(".gemini/README.md"), false);
   assert.equal(isDocsFastPathEligible(".gemini/docs/guide.md"), false);
-  assert.equal(isDocsFastPathEligible(".gemini/commands/ship.md"), false);
+  assert.equal(isDocsFastPathEligible(".codex/README.md"), false);
+  assert.equal(isDocsFastPathEligible(".codex/docs/notes.md"), false);
+  assert.equal(isDocsFastPathEligible(".cursor/rules/style.md"), false);
+  assert.equal(isDocsFastPathEligible(".aider/README.md"), false);
+  assert.equal(isDocsFastPathEligible(".github/copilot-instructions.md"), false);
+  assert.equal(isDocsFastPathEligible("packages/app/.codex/docs/guide.md"), false);
   // A normal directory that merely starts with the same letters is still docs.
   assert.equal(isDocsFastPathEligible("claude/docs/guide.md"), true);
   assert.equal(isDocsFastPathEligible("gemini/docs/guide.md"), true);
+  assert.equal(isDocsFastPathEligible("codex/docs/guide.md"), true);
+  // A dotted *file* is not a dot-directory; this rule needs a path segment.
+  assert.equal(isDocsFastPathEligible("docs/.hidden-notes.md"), true);
 });

--- a/src/shared/classify.test.ts
+++ b/src/shared/classify.test.ts
@@ -81,11 +81,12 @@ test("isDocsFastPathEligible is a generic user-facing-docs allowlist", () => {
   assert.equal(isDocsFastPathEligible(".github/workflows/review.yml"), false);
 });
 
-// A CLAUDE.md is agent policy wherever it sits: agents read the nearest one for
-// the directory being edited, so a nested copy is as policy-bearing as the root
-// one. Before this rule, only a root CLAUDE.md failed closed (and by accident --
-// it matched no allowlist entry); any CLAUDE.md under a docs/ or doc/ directory
-// matched DOCS_DIR and took the deterministic pass with zero model calls.
+// An agent-instruction file is policy wherever it sits: agents read the nearest
+// one for the directory being edited, so a nested copy is as policy-bearing as
+// the root one. Before this rule, only a root CLAUDE.md/GEMINI.md failed closed
+// (and by accident -- it matched no allowlist entry); any copy under a docs/ or
+// doc/ directory matched DOCS_DIR and took the deterministic pass with zero
+// model calls.
 test("isDocsFastPathEligible excludes CLAUDE.md policy files anywhere in the tree", () => {
   assert.equal(isDocsFastPathEligible("CLAUDE.md"), false);
   assert.equal(isDocsFastPathEligible("docs/CLAUDE.md"), false);
@@ -106,16 +107,60 @@ test("isDocsFastPathEligible excludes CLAUDE.md policy files anywhere in the tre
   assert.equal(isDocsFastPathEligible("README.md"), true);
 });
 
-// `.claude/` is an agent-config tree: skills, commands, and subagent definitions
-// instruct agents, and the prose describing them is part of that policy. It used
-// to fail closed only incidentally, which left the two allowlist entries open --
-// `.claude/README.md` (user-facing basename) and `.claude/docs/*.md` (DOCS_DIR).
+// The backstop that closes the class rather than one vendor at a time: under a
+// docs/ tree the DOCS_DIR blanket used to pass everything, so each new agent CLI
+// filename was a fresh fail-open hole. An ALL-CAPS basename now has to be a
+// recognized human-facing convention or it is reviewed. These vendor names are
+// stand-ins for "a filename nobody has added a rule for yet" -- the point is
+// that no rule mentions them.
+test("isDocsFastPathEligible fails closed on unrecognized ALL-CAPS Markdown under docs/", () => {
+  assert.equal(isDocsFastPathEligible("docs/QWEN.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/CURSOR.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/WINDSURF.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/COPILOT.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/RULES.md"), false);
+  assert.equal(isDocsFastPathEligible("doc/NEWAGENT.md"), false);
+  assert.equal(isDocsFastPathEligible("packages/app/docs/CURSOR.local.md"), false);
+  // Recognized human-facing conventions still ride the fast path.
+  assert.equal(isDocsFastPathEligible("docs/README.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/CHANGELOG.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/CODE_OF_CONDUCT.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/LICENSE.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/README.zh-TW.md"), true);
+  // Descriptively named prose is unaffected -- this is not an uppercase ban.
+  assert.equal(isDocsFastPathEligible("docs/guide.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/api-reference.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/Getting-Started.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/qwen.md"), true);
+});
+
+test("isDocsFastPathEligible excludes GEMINI.md policy files anywhere in the tree", () => {
+  assert.equal(isDocsFastPathEligible("GEMINI.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/GEMINI.md"), false);
+  assert.equal(isDocsFastPathEligible("doc/GEMINI.md"), false);
+  assert.equal(isDocsFastPathEligible("packages/app/docs/guides/GEMINI.md"), false);
+  assert.equal(isDocsFastPathEligible("src/shared/GEMINI.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/gemini.md"), false);
+  assert.equal(isDocsFastPathEligible("GEMINI.local.md"), false);
+  // Prose that merely mentions the vendor is not an instruction file.
+  assert.equal(isDocsFastPathEligible("docs/gemini-setup.md"), true);
+});
+
+// The agent-config dot-directories are policy trees: skills, commands, and
+// subagent definitions instruct agents, and the prose describing them is part of
+// that policy. They used to fail closed only incidentally, which left the two
+// allowlist entries open -- `<dir>/README.md` (user-facing basename) and
+// `<dir>/docs/*.md` (DOCS_DIR).
 test("isDocsFastPathEligible excludes .claude agent-config Markdown", () => {
   assert.equal(isDocsFastPathEligible(".claude/README.md"), false);
   assert.equal(isDocsFastPathEligible(".claude/docs/guide.md"), false);
   assert.equal(isDocsFastPathEligible(".claude/skills/review/SKILL.md"), false);
   assert.equal(isDocsFastPathEligible(".claude/commands/ship.md"), false);
   assert.equal(isDocsFastPathEligible("packages/app/.claude/README.md"), false);
+  assert.equal(isDocsFastPathEligible(".gemini/README.md"), false);
+  assert.equal(isDocsFastPathEligible(".gemini/docs/guide.md"), false);
+  assert.equal(isDocsFastPathEligible(".gemini/commands/ship.md"), false);
   // A normal directory that merely starts with the same letters is still docs.
   assert.equal(isDocsFastPathEligible("claude/docs/guide.md"), true);
+  assert.equal(isDocsFastPathEligible("gemini/docs/guide.md"), true);
 });

--- a/src/shared/classify.test.ts
+++ b/src/shared/classify.test.ts
@@ -80,3 +80,42 @@ test("isDocsFastPathEligible is a generic user-facing-docs allowlist", () => {
   assert.equal(isDocsFastPathEligible("DESIGN.md"), false);
   assert.equal(isDocsFastPathEligible(".github/workflows/review.yml"), false);
 });
+
+// A CLAUDE.md is agent policy wherever it sits: agents read the nearest one for
+// the directory being edited, so a nested copy is as policy-bearing as the root
+// one. Before this rule, only a root CLAUDE.md failed closed (and by accident --
+// it matched no allowlist entry); any CLAUDE.md under a docs/ or doc/ directory
+// matched DOCS_DIR and took the deterministic pass with zero model calls.
+test("isDocsFastPathEligible excludes CLAUDE.md policy files anywhere in the tree", () => {
+  assert.equal(isDocsFastPathEligible("CLAUDE.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/CLAUDE.md"), false);
+  assert.equal(isDocsFastPathEligible("doc/CLAUDE.md"), false);
+  assert.equal(isDocsFastPathEligible("packages/app/docs/guides/CLAUDE.md"), false);
+  assert.equal(isDocsFastPathEligible("src/shared/CLAUDE.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/claude.md"), false);
+  assert.equal(isDocsFastPathEligible("CLAUDE.local.md"), false);
+  assert.equal(isDocsFastPathEligible("docs\\nested\\CLAUDE.md"), false);
+  // The AGENTS.md rule this mirrors, and ordinary docs, are unaffected.
+  assert.equal(isDocsFastPathEligible("AGENTS.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/AGENTS.md"), false);
+  assert.equal(isDocsFastPathEligible("packages/app/AGENTS.review.md"), false);
+  assert.equal(isDocsFastPathEligible("prompts/review.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/prompts/review.md"), false);
+  assert.equal(isDocsFastPathEligible("docs/guide.md"), true);
+  assert.equal(isDocsFastPathEligible("docs/claude-setup.md"), true);
+  assert.equal(isDocsFastPathEligible("README.md"), true);
+});
+
+// `.claude/` is an agent-config tree: skills, commands, and subagent definitions
+// instruct agents, and the prose describing them is part of that policy. It used
+// to fail closed only incidentally, which left the two allowlist entries open --
+// `.claude/README.md` (user-facing basename) and `.claude/docs/*.md` (DOCS_DIR).
+test("isDocsFastPathEligible excludes .claude agent-config Markdown", () => {
+  assert.equal(isDocsFastPathEligible(".claude/README.md"), false);
+  assert.equal(isDocsFastPathEligible(".claude/docs/guide.md"), false);
+  assert.equal(isDocsFastPathEligible(".claude/skills/review/SKILL.md"), false);
+  assert.equal(isDocsFastPathEligible(".claude/commands/ship.md"), false);
+  assert.equal(isDocsFastPathEligible("packages/app/.claude/README.md"), false);
+  // A normal directory that merely starts with the same letters is still docs.
+  assert.equal(isDocsFastPathEligible("claude/docs/guide.md"), true);
+});

--- a/src/shared/classify.ts
+++ b/src/shared/classify.ts
@@ -1,5 +1,11 @@
 import type { Surface } from "./schema.js";
 
+// Markdown only. A `doc/` or `docs/` directory must not classify executables
+// (docs/build.ts, src/api/docs/handler.ts) — those fall through to later rules
+// or source. First-match order is unchanged: workflow / dependency / test still
+// win, so CI yml and tests cannot become docs.
+const DOCS_EXT = /\.md$/i;
+
 const RULES: { test: RegExp; surface: Surface }[] = [
   { test: /(^|\/)\.github\/workflows\/.+\.ya?ml$/i, surface: "workflow" },
   { test: /(^|\/)node_modules\//i, surface: "dependency" },
@@ -8,7 +14,7 @@ const RULES: { test: RegExp; surface: Surface }[] = [
     surface: "dependency",
   },
   { test: /(^|\/)(test|tests|__tests__|spec|specs)\/|\.test\.|\.spec\.|-test\.|-spec\./i, surface: "test" },
-  { test: /\.md$|(^|\/)docs?\//i, surface: "docs" },
+  { test: DOCS_EXT, surface: "docs" },
   { test: /(^|\/)(migrations?|schema|db)\//i, surface: "schema" },
   { test: /\.sql$/i, surface: "schema" },
   { test: /(^|\/)(bin|cli|cmd)\//i, surface: "cli" },
@@ -19,6 +25,17 @@ const RULES: { test: RegExp; surface: Surface }[] = [
   },
 ];
 
+// Model/agent instruction directories — generic shape, not a repo-specific path.
+const POLICY_DIR = /(^|\/)(prompts?|instructions?)(\/|$)/i;
+const DOCS_DIR = /(^|\/)docs?\//i;
+// Portable repo-policy filename (any directory). Not a target-repo noun:
+// this is the file coding agents treat as review/instruction policy.
+const REPO_POLICY_BASENAME = /^agents(\.[a-z0-9_-]+)*\.md$/i;
+// Human-facing documentation basenames (optional locale suffix). Unknown
+// Markdown fails closed rather than riding the docs fast path.
+const USER_FACING_BASENAME =
+  /^(readme|changelog|changes|history|news|license|licence|copying|contributing|code[-_]of[-_]conduct|security|support|authors|notice|attribution|acknowledgements?|todo)(\.[a-z0-9_-]+)*\.md$/i;
+
 export function classifySurface(file: string): Surface {
   for (const rule of RULES) {
     if (rule.test.test(file)) return rule.surface;
@@ -28,4 +45,18 @@ export function classifySurface(file: string): Surface {
 
 export function classifyFiles(files: string[]): { path: string; surface: Surface }[] {
   return files.map((p) => ({ path: p, surface: classifySurface(p) }));
+}
+
+// True only for Markdown that is safe to skip model review: a docs/doc
+// directory, or a well-known human-facing basename; never a prompts-like
+// path or an AGENTS.md-shaped repo-policy file. review() also requires
+// surface === "docs".
+export function isDocsFastPathEligible(file: string): boolean {
+  const normalized = file.replace(/\\/g, "/");
+  if (!DOCS_EXT.test(normalized)) return false;
+  if (POLICY_DIR.test(normalized)) return false;
+  const base = normalized.slice(normalized.lastIndexOf("/") + 1);
+  if (REPO_POLICY_BASENAME.test(base)) return false;
+  if (DOCS_DIR.test(normalized)) return true;
+  return USER_FACING_BASENAME.test(base);
 }

--- a/src/shared/classify.ts
+++ b/src/shared/classify.ts
@@ -26,24 +26,45 @@ const RULES: { test: RegExp; surface: Surface }[] = [
 ];
 
 // Model/agent instruction directories — generic shape, not a repo-specific path.
-// `.claude/` is an agent-config tree, not prose: its Markdown (skills, commands,
-// subagent definitions, and the README/docs that describe them) instructs agents.
-// It was previously excluded only by accident — nothing under it matched
-// DOCS_DIR or USER_FACING_BASENAME — which left `.claude/README.md` and
-// `.claude/docs/*.md` riding the fast path. Exclude it by design instead.
-const POLICY_DIR = /(^|\/)(prompts?|instructions?|\.claude)(\/|$)/i;
+// The dot-directories are agent-config trees, not prose: their Markdown (skills,
+// commands, subagent definitions, and the README/docs describing them) instructs
+// agents. They were previously excluded only by accident — nothing under them
+// matched DOCS_DIR or USER_FACING_BASENAME — which left `<dir>/README.md` and
+// `<dir>/docs/*.md` riding the fast path. Exclude them by design instead.
+const POLICY_DIR = /(^|\/)(prompts?|instructions?|\.claude|\.gemini)(\/|$)/i;
 const DOCS_DIR = /(^|\/)docs?\//i;
-// Portable repo-policy filenames (any directory). Not target-repo nouns: these
-// are the files coding agents treat as review/instruction policy. A CLAUDE.md
-// is policy-bearing wherever it sits — agents read the nearest one for the
-// directory they are editing, so `docs/CLAUDE.md` instructs edits to `docs/**`
-// exactly as a root CLAUDE.md instructs the repo. Path, not content, is all the
-// classifier can see, so the basename alone must disqualify the fast path.
-const REPO_POLICY_BASENAME = /^(agents|claude)(\.[a-z0-9_-]+)*\.md$/i;
+// Portable repo-policy filenames (any directory). Not target-repo nouns: an
+// entry belongs here when an agent CLI reads that filename as instructions for
+// the directory it sits in — AGENTS.md (cross-vendor), CLAUDE.md, GEMINI.md.
+// Such a file is policy-bearing wherever it sits: agents read the nearest one
+// for the directory being edited, so `docs/CLAUDE.md` instructs edits to
+// `docs/**` exactly as a root CLAUDE.md instructs the repo, and DOCS_DIR would
+// otherwise hand it a blanket pass. Path, not content, is all the classifier
+// can see, so the basename alone must disqualify the fast path.
+const REPO_POLICY_BASENAME = /^(agents|claude|gemini)(\.[a-z0-9_-]+)*\.md$/i;
 // Human-facing documentation basenames (optional locale suffix). Unknown
 // Markdown fails closed rather than riding the docs fast path.
 const USER_FACING_BASENAME =
   /^(readme|changelog|changes|history|news|license|licence|copying|contributing|code[-_]of[-_]conduct|security|support|authors|notice|attribution|acknowledgements?|todo)(\.[a-z0-9_-]+)*\.md$/i;
+// An ALL-CAPS Markdown basename is a claim to a filename *convention*, and the
+// conventions split into two kinds: human-facing (README, CHANGELOG, LICENSE —
+// enumerated above) and agent-instruction (AGENTS, CLAUDE, GEMINI, and whatever
+// the next agent CLI names its file). Prose is not named this way; prose is
+// `guide.md`, `api-reference.md`, `Getting-Started.md`.
+//
+// The agent-instruction set is open-ended, so enumerating it can never be
+// complete — and in this function every miss fails OPEN: an unlisted policy file
+// under `docs/` gets a deterministic pass with zero model review. Inverting it
+// is what closes the class: inside a docs/ tree, where DOCS_DIR would otherwise
+// hand every file a blanket pass, an ALL-CAPS basename must be a *recognized*
+// human-facing one or it fails closed. A new agent CLI's `docs/NEWAGENT.md` is
+// then reviewed on the day it appears, with no change here.
+//
+// Deliberate cost: an unrecognized `docs/API.md` or `docs/ROADMAP.md` now gets a
+// real model review instead of a free pass. Spending a model call on prose is
+// the correct direction to be wrong in for a classifier that decides what
+// escapes review. Case-sensitive on purpose — lower-case `docs/api.md` is prose.
+const CONVENTIONAL_BASENAME = /^[A-Z][A-Z0-9_-]*(\.[A-Za-z0-9_-]+)*\.md$/;
 
 export function classifySurface(file: string): Surface {
   for (const rule of RULES) {
@@ -56,16 +77,21 @@ export function classifyFiles(files: string[]): { path: string; surface: Surface
   return files.map((p) => ({ path: p, surface: classifySurface(p) }));
 }
 
-// True only for Markdown that is safe to skip model review: a docs/doc
-// directory, or a well-known human-facing basename; never a prompts-like
-// path, an agent-config path, or an AGENTS.md/CLAUDE.md-shaped repo-policy
-// file. review() also requires surface === "docs".
+// True only for Markdown that is safe to skip model review: descriptively named
+// prose in a docs/doc directory, or a recognized human-facing basename; never a
+// prompts-like path, an agent-config path, a named repo-policy file, or an
+// unrecognized ALL-CAPS convention name. review() also requires
+// surface === "docs". Every branch that returns true is an allowlist branch:
+// Markdown this function does not recognize gets reviewed, not passed.
 export function isDocsFastPathEligible(file: string): boolean {
   const normalized = file.replace(/\\/g, "/");
   if (!DOCS_EXT.test(normalized)) return false;
   if (POLICY_DIR.test(normalized)) return false;
   const base = normalized.slice(normalized.lastIndexOf("/") + 1);
   if (REPO_POLICY_BASENAME.test(base)) return false;
-  if (DOCS_DIR.test(normalized)) return true;
-  return USER_FACING_BASENAME.test(base);
+  const userFacing = USER_FACING_BASENAME.test(base);
+  if (DOCS_DIR.test(normalized)) {
+    return !CONVENTIONAL_BASENAME.test(base) || userFacing;
+  }
+  return userFacing;
 }

--- a/src/shared/classify.ts
+++ b/src/shared/classify.ts
@@ -26,11 +26,20 @@ const RULES: { test: RegExp; surface: Surface }[] = [
 ];
 
 // Model/agent instruction directories — generic shape, not a repo-specific path.
-const POLICY_DIR = /(^|\/)(prompts?|instructions?)(\/|$)/i;
+// `.claude/` is an agent-config tree, not prose: its Markdown (skills, commands,
+// subagent definitions, and the README/docs that describe them) instructs agents.
+// It was previously excluded only by accident — nothing under it matched
+// DOCS_DIR or USER_FACING_BASENAME — which left `.claude/README.md` and
+// `.claude/docs/*.md` riding the fast path. Exclude it by design instead.
+const POLICY_DIR = /(^|\/)(prompts?|instructions?|\.claude)(\/|$)/i;
 const DOCS_DIR = /(^|\/)docs?\//i;
-// Portable repo-policy filename (any directory). Not a target-repo noun:
-// this is the file coding agents treat as review/instruction policy.
-const REPO_POLICY_BASENAME = /^agents(\.[a-z0-9_-]+)*\.md$/i;
+// Portable repo-policy filenames (any directory). Not target-repo nouns: these
+// are the files coding agents treat as review/instruction policy. A CLAUDE.md
+// is policy-bearing wherever it sits — agents read the nearest one for the
+// directory they are editing, so `docs/CLAUDE.md` instructs edits to `docs/**`
+// exactly as a root CLAUDE.md instructs the repo. Path, not content, is all the
+// classifier can see, so the basename alone must disqualify the fast path.
+const REPO_POLICY_BASENAME = /^(agents|claude)(\.[a-z0-9_-]+)*\.md$/i;
 // Human-facing documentation basenames (optional locale suffix). Unknown
 // Markdown fails closed rather than riding the docs fast path.
 const USER_FACING_BASENAME =
@@ -49,8 +58,8 @@ export function classifyFiles(files: string[]): { path: string; surface: Surface
 
 // True only for Markdown that is safe to skip model review: a docs/doc
 // directory, or a well-known human-facing basename; never a prompts-like
-// path or an AGENTS.md-shaped repo-policy file. review() also requires
-// surface === "docs".
+// path, an agent-config path, or an AGENTS.md/CLAUDE.md-shaped repo-policy
+// file. review() also requires surface === "docs".
 export function isDocsFastPathEligible(file: string): boolean {
   const normalized = file.replace(/\\/g, "/");
   if (!DOCS_EXT.test(normalized)) return false;

--- a/src/shared/classify.ts
+++ b/src/shared/classify.ts
@@ -26,12 +26,22 @@ const RULES: { test: RegExp; surface: Surface }[] = [
 ];
 
 // Model/agent instruction directories — generic shape, not a repo-specific path.
-// The dot-directories are agent-config trees, not prose: their Markdown (skills,
-// commands, subagent definitions, and the README/docs describing them) instructs
-// agents. They were previously excluded only by accident — nothing under them
-// matched DOCS_DIR or USER_FACING_BASENAME — which left `<dir>/README.md` and
-// `<dir>/docs/*.md` riding the fast path. Exclude them by design instead.
-const POLICY_DIR = /(^|\/)(prompts?|instructions?|\.claude|\.gemini)(\/|$)/i;
+const POLICY_DIR = /(^|\/)(prompts?|instructions?)(\/|$)/i;
+// Any dot-directory segment. A leading-dot directory is tool configuration, not
+// product documentation, and for agent CLIs it is where the policy lives:
+// `.claude/` (skills, commands, subagent definitions), `.codex/`, `.gemini/`,
+// `.cursor/`, `.github/copilot-instructions.md`. Naming them one at a time is
+// the same fail-open deny-list mistake as naming policy basenames one at a time
+// — the set grows with every new tool — so the whole shape is excluded instead.
+// Their Markdown was eligible only by accident before: `.codex/README.md` hit
+// USER_FACING_BASENAME and `.claude/docs/*.md` hit DOCS_DIR.
+//
+// Deliberate cost: genuine prose in a dot-directory (`.github/CONTRIBUTING.md`)
+// now gets a model review. A dot-directory is a small share of any repo's docs,
+// and `.github/` also holds agent policy, so failing closed here is cheap.
+// Matches a directory segment only — trailing "/" required — so `.env` and a
+// dotfile like `.README.md` are untouched by this rule.
+const DOT_DIR = /(^|\/)\.[^/]+\//;
 const DOCS_DIR = /(^|\/)docs?\//i;
 // Portable repo-policy filenames (any directory). Not target-repo nouns: an
 // entry belongs here when an agent CLI reads that filename as instructions for
@@ -79,7 +89,7 @@ export function classifyFiles(files: string[]): { path: string; surface: Surface
 
 // True only for Markdown that is safe to skip model review: descriptively named
 // prose in a docs/doc directory, or a recognized human-facing basename; never a
-// prompts-like path, an agent-config path, a named repo-policy file, or an
+// prompts-like path, a dot-directory, a named repo-policy file, or an
 // unrecognized ALL-CAPS convention name. review() also requires
 // surface === "docs". Every branch that returns true is an allowlist branch:
 // Markdown this function does not recognize gets reviewed, not passed.
@@ -87,6 +97,7 @@ export function isDocsFastPathEligible(file: string): boolean {
   const normalized = file.replace(/\\/g, "/");
   if (!DOCS_EXT.test(normalized)) return false;
   if (POLICY_DIR.test(normalized)) return false;
+  if (DOT_DIR.test(normalized)) return false;
   const base = normalized.slice(normalized.lastIndexOf("/") + 1);
   if (REPO_POLICY_BASENAME.test(base)) return false;
   const userFacing = USER_FACING_BASENAME.test(base);


### PR DESCRIPTION
Closes #43. **Tier 1 — verdict integrity.**

## ⚠️ EVAL GATE NOT RUN

This changes `src/core/review.ts` — the review pipeline — and `AGENTS.md` EVAL DISCIPLINE requires a gate. No model runners or credentials are available here, so **it has not been run**. A maintainer must, before merging:

```bash
node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort high \
  --draws 3 --holdout include --report eval/reports/gate-issue-43.json
node scripts/gate-verdict.mjs eval/reports/gate-issue-43.json --criteria <pre-declared-criteria.json>
```

Declare the criteria file **before** the run; confirm ×3 on any fixture that diverges.

**Hashes are unchanged** (`promptHash` covers `prompts/*.md`, `fixtureSetHash` covers fixture specs, `scorerHash` covers `eval/shared/` — this diff touches none), so existing baselines remain comparable.

## Problem — measured on `main`

`classifySurface`'s docs rule was `/\.md$|(^|\/)docs?\//i`, so a **directory name alone** made executables documentation:

```
prompts/review.md          surface=docs   → docs-only PR auto-passes, 0 model calls
AGENTS.md                  surface=docs   → docs-only PR auto-passes, 0 model calls
src/api/docs/handler.ts    surface=docs   → docs-only PR auto-passes, 0 model calls
docs/build.ts              surface=docs   → docs-only PR auto-passes, 0 model calls
```

A PR touching only `prompts/*.md` — the policy layer the operating manual ranks **tier 3**, above ordinary plumbing — received a deterministic `pass` without any model ever seeing it.

## Change — two parts, deliberately separate

**1. `classifySurface`'s docs rule is Markdown-only.** Directory names no longer classify executables. First-match order is untouched, so workflow YAML, lockfiles, and tests still win ahead of docs.

**2. The fast path additionally requires `isDocsFastPathEligible`:** Markdown in a `docs`/`doc` directory, or carrying a well-known user-facing basename (`readme`, `changelog`, `license`, `contributing`, …) — and **never** under a prompts-like or instructions-like path. **Unknown Markdown fails closed.**

Keeping the two separate matters: `test/README.md` still classifies as `test` (that rule wins), and `review()` requires **`surface === "docs"` AND eligibility**, so it is correctly not fast-pathed.

### On the no-target-repo-customization anti-pattern

The rule is written in **generic shape** — `prompts?`/`instructions?` directories and conventional documentation basenames — not needlefish's own paths. The *directory exclusion* is what protects `AGENTS.md` and `prompts/*.md` in any repo; there is no allowlist of our filenames.

## Verification

Full matrix, executed against the real functions:

| path | surface | fast-path | |
|---|---|---|---|
| `prompts/review.md` | docs | ❌ | policy — never |
| `AGENTS.md` | docs | ❌ | policy — never |
| `instructions/agent.md` | docs | ❌ | generic policy dir |
| `docs/prompts/x.md` | docs | ❌ | policy dir nested under docs |
| `src/api/docs/handler.ts` | **public-api** | ❌ | now reviewed |
| `docs/build.ts` | **source** | ❌ | now reviewed |
| `docs/cli/main.ts` | **cli** | ❌ | now reviewed |
| `notes.md` | docs | ❌ | unknown Markdown fails closed |
| `docs/guide.md` | docs | ✅ | genuine prose |
| `README.md` | docs | ✅ | user-facing basename |
| `.github/workflows/docs.yml` | workflow | ❌ | CI cannot ride the docs path |
| `docs/.github/workflows/ci.yml` | workflow | ❌ | rule order preserved |
| `test/README.md` | test | ❌ | test rule still wins |
| `package.json` | dependency | ❌ | rule order preserved |

**Mutation-verified:**

| Mutation | Result |
|---|---|
| baseline | `pass 32 / fail 0` |
| docs rule matches directories again | `pass 29 / fail 3` ✅ |
| policy dirs allowed to fast-path | `pass 31 / fail 1` ✅ |
| `review()` drops the eligibility gate | `pass 31 / fail 1` ✅ |
| restored | `pass 32 / fail 0` |

`pnpm check` ✅ · `pnpm lint` ✅ · `pnpm test` **540 pass / 0 fail** (exit 0).

Checked separately: no eval fixture spec depends on the old directory match (the only docs-only fixtures use `README.md`), and no `Surface` type member changed.

## Risk

- **The eval gate is the real risk owner here** and it has not run. Files that previously skipped the model now go through it, which changes cost and could change findings on docs-adjacent PRs.
- `NEEDLEFISH_NO_FAST_PATH` remains the only escape hatch; no second one was added.

---

**Orchestrator:** Claude Fable 5 (issue verification, prompt authoring including the generic-rule constraint, main-vs-branch classification matrix, mutation testing)
**Implementor:** grok-4.6, reasoning effort `xhigh` (via grok CLI)