### PR TITLE
Reconciliation finalizer + early pending check-run + runner cause surfacing

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -294,3 +294,55 @@ jobs:
           if [ -n "$OPENCODE_IDLE_TIMEOUT_MS_INPUT" ]; then export OPENCODE_IDLE_TIMEOUT_MS="$OPENCODE_IDLE_TIMEOUT_MS_INPUT"; fi
           if [ -n "$NEEDLEFISH_RECHECK_INPUT" ]; then args+=(--recheck); fi
           "$NEEDLEFISH_BIN" "${args[@]}"
+
+  # S6 reconciliation: the latest open head of this PR must eventually carry a
+  # terminal Needlefish check that is not an infra error. Superseded runs
+  # (cancel-in-progress) and crashed runs would otherwise leave a head with no
+  # verdict at all. Bounded: at most two infra-failed checks on a head are
+  # tolerated before the finalizer gives up loudly.
+  reconcile:
+    needs: review
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: read
+      actions: write
+    steps:
+      - name: Re-dispatch when the latest head lacks a terminal result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ inputs.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          set -eu
+          if [ -z "$PR_NUM" ]; then
+            echo "no PR number in context; nothing to reconcile" >&2
+            exit 0
+          fi
+          state=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq .state)
+          if [ "$state" != "open" ]; then
+            echo "PR #$PR_NUM is $state; nothing to reconcile"
+            exit 0
+          fi
+          head=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq .head.sha)
+          runs_url="repos/$REPO/commits/$head/check-runs?check_name=Needlefish&per_page=100"
+          valid=$(gh api "$runs_url" --jq '[.check_runs[] | select(.conclusion == "success" or .conclusion == "neutral" or (.conclusion == "failure" and (.output.title // "") != "Needlefish: review failed"))] | length')
+          if [ "$valid" -gt 0 ]; then
+            echo "head $head already has a terminal Needlefish verdict; nothing to reconcile"
+            exit 0
+          fi
+          running=$(gh api "repos/$REPO/actions/runs?head_sha=$head&status=in_progress" --jq '[.workflow_runs[] | select(.name == "needlefish")] | length')
+          queued=$(gh api "repos/$REPO/actions/runs?head_sha=$head&status=queued" --jq '[.workflow_runs[] | select(.name == "needlefish")] | length')
+          if [ "$running" -gt 0 ] || [ "$queued" -gt 0 ]; then
+            echo "a needlefish run for $head is still active or queued; letting it finish"
+            exit 0
+          fi
+          infra_fails=$(gh api "$runs_url" --jq '[.check_runs[] | select(.conclusion == "failure" and (.output.title // "") == "Needlefish: review failed")] | length')
+          if [ "$infra_fails" -ge 2 ]; then
+            echo "::error::head $head has $infra_fails infra-failed reviews; retry cap reached, not re-dispatching"
+            exit 0
+          fi
+          gh workflow run review.yml --ref main -f pr_number="$PR_NUM"
+          echo "reconciliation dispatched for PR #$PR_NUM head ${head:0:10} (infra failures so far: $infra_fails)"

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -588,3 +588,54 @@ Disposition options (owner decision, none applied):
    removing it from the scored set until context enrichment lands.
 
 No fixture file was modified in this audit.
+
+### 16a. §16 disposition resolved — 2026-08-25
+
+Owner decision: option 3 direction — both stable endpoint-identity misses
+(`real-pr1-bundle-basesha-mismatch`, `real-pr1-diff-base-tip-not-mergebase`)
+are folded into the R-track producer/consumer invariant-enforcement workstream;
+they were already sealed for that change in gate 14's declaration. Until it
+lands they stay in the scored set as standing tier cost inside the pre-declared
+envelope (proven acceptable across gates 9/10/14); no fixture-set hash churn.
+
+### 17. Early pending check-run + latest-head reconciliation — Class D declared 2026-08-25
+
+Change: the GitHub adapter creates the `Needlefish` check as `in_progress`
+before any model work and completes that same check by id on every terminal
+path (verdict, error, superseded-by-newer-head); review.yml gains an
+`if: always()` reconciliation finalizer that re-dispatches (bounded at two
+infra failures) when a closed or superseded run leaves the PR's latest open
+head without a terminal verdict.
+
+Classification: **Class D** by provenance containment — the change touches
+only check-run/posting plumbing and never any model input or output; the
+successful-path review content is byte-identical to the old pipeline.
+Proportionality note recorded per the taxonomy's own principle: no eval draw
+is consumed because no draw can observe this path (the eval harness exercises
+`review()`, not GitHub posting); the gate is therefore the resident suites
+plus the live canary window.
+
+Gate criteria (pre-declared): `github-posting.test.ts` green including four
+new lifecycle cases (pending created before model work and completed by id;
+error completes failure by id; stale head closes neutral-superseded with no
+timeline posts; single create + single completion per round); full suite
+green; live canary after deploy.
+
+**Result: PASSED.** `github-posting.test.ts` 48/48; full suite 782+/0 fail;
+`pnpm check`/`lint` clean.
+
+### 18. Runner stderr safe-cause surfacing — Class D declared 2026-08-25
+
+Trigger: claw-console PR #25 failed for hours with only `codex runner exited
+1; stderr withheld…`; diagnosis required local reproduction (invalid/stale
+exported auth.json → 401 fast-exit). Change: when a runner exits nonzero,
+extract allowlisted cause tokens from stderr (auth error codes, 401/403,
+usage/quota/rate limits, network errno) into a `likely cause:` suffix. Raw
+stderr text never enters the message; full output remains available only via
+the non-enumerable rawOutput canary attachment.
+
+Classification: **Class D** — runner plumbing only; zero review-content touch.
+Gate: resident suites (`codex-runners.test.ts` +4 cases incl. leak-negative);
+no eval draws consumed, same proportionality reasoning as §17.
+
+**Result: PASSED.** `codex-runners.test.ts` 14/14; suite green.

--- a/scripts/review-workflow-pr-number.test.mjs
+++ b/scripts/review-workflow-pr-number.test.mjs
@@ -27,8 +27,15 @@ const step = workflow.match(
 assert.ok(step, "Needlefish review step must exist");
 const runBlock = step[1].match(/        run: \|\n([\s\S]*)/);
 assert.ok(runBlock, "Needlefish review must have a run block");
-const script = runBlock[1]
-	.split("\n")
+// Model the literal-block scalar termination rule: the script ends at the
+// first line dedented below the block's 10-space indentation (e.g., a
+// top-level job appended after this one), not at end of file.
+const scriptLines = [];
+for (const line of runBlock[1].split("\n")) {
+	if (line.length > 0 && !line.startsWith("          ")) break;
+	scriptLines.push(line);
+}
+const script = scriptLines
 	.map((line) => line.replace(/^          /, ""))
 	.join("\n");
 

--- a/src/adapters/github-posting.test.ts
+++ b/src/adapters/github-posting.test.ts
@@ -147,6 +147,7 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 	const postLog = path.join(tmp, "posts.jsonl");
 	const reviewsState = path.join(tmp, "reviews-state.json");
 	const issueCommentsState = path.join(tmp, "issue-comments-state.json");
+	const checksStatePath = path.join(tmp, "checks-state.json");
 	const runnerLog = path.join(tmp, "runner.log");
 	const previous = {
 		path: process.env.PATH,
@@ -229,7 +230,27 @@ function setupFixture(t: TestContext, opts: FixtureOptions): Fixture {
 			"  }",
 			`  const issueCommentsPath = ${JSON.stringify(issueCommentsState)};`,
 			`  const issueCommentsEndpoint = ${JSON.stringify(`repos/frankekn/needlefish/issues/${opts.prNumber}/comments`)};`,
-			`  if (apiPath === 'repos/frankekn/needlefish/check-runs' && method === 'POST' && ${JSON.stringify(opts.failCheckRunPosts === true)} === true) { process.stderr.write('simulated check POST failure'); process.exit(1); }`,
+			`  const checksStatePath = ${JSON.stringify(checksStatePath)};`,
+			`  if (apiPath === 'repos/frankekn/needlefish/check-runs' && method === 'POST') {`,
+			`    if (${JSON.stringify(opts.failCheckRunPosts === true)} === true) { process.stderr.write('simulated check POST failure'); process.exit(1); }`,
+			`    const checks = fs.existsSync(checksStatePath) ? JSON.parse(fs.readFileSync(checksStatePath, 'utf8')) : [];`,
+			`    const parsedCheck = JSON.parse(payload);`,
+			`    const nextId = checks.length + 1;`,
+			`    checks.push({ id: nextId, status: parsedCheck.status || 'completed', conclusion: parsedCheck.conclusion ?? null, output: parsedCheck.output ?? null });`,
+			`    fs.writeFileSync(checksStatePath, JSON.stringify(checks));`,
+			`    process.stdout.write(JSON.stringify({ id: nextId }));`,
+			`    process.exit(0);`,
+			`  }`,
+			`  if (apiPath && apiPath.startsWith('repos/frankekn/needlefish/check-runs/') && method === 'PATCH') {`,
+			`    const id = Number(apiPath.split('/').pop());`,
+			`    const checks = fs.existsSync(checksStatePath) ? JSON.parse(fs.readFileSync(checksStatePath, 'utf8')) : [];`,
+			`    const parsedPatch = JSON.parse(payload);`,
+			`    const check = checks.find((c) => c.id === id);`,
+			`    if (check) { check.status = parsedPatch.status || 'completed'; check.conclusion = parsedPatch.conclusion ?? null; check.output = parsedPatch.output ?? null; }`,
+			`    fs.writeFileSync(checksStatePath, JSON.stringify(checks));`,
+			`    process.stdout.write('{}');`,
+			`    process.exit(0);`,
+			`  }`,
 			"  if (apiPath === issueCommentsEndpoint && method === 'POST') {",
 			`    if (${JSON.stringify(opts.failIssueCommentPosts === true)} === true) { process.stderr.write('simulated comment POST failure'); process.exit(1); }`,
 			"    const issueComments = fs.existsSync(issueCommentsPath) ? JSON.parse(fs.readFileSync(issueCommentsPath, 'utf8')) : [];",
@@ -535,7 +556,35 @@ test("runGithub skips posting when the PR head changes after review", async (t) 
 
 	await runGithub(fixture.repo, 10, { timeoutMs: 1000 });
 
-	assert.deepEqual(readPosts(fixture.postLog), []);
+	// The pending check is still created for the (then-current) head and must
+	// be closed as superseded; no review/comment may reach the timeline.
+	const checkOps = readPosts(fixture.postLog).filter((p) =>
+		p.args.some((a) => a.includes("check-runs")),
+	);
+	assert.equal(checkOps.length, 2);
+	const [created, completed] = checkOps;
+	assert.equal(created.args[1], "-X");
+	assert.equal(created.args[2], "POST");
+	const createdPayload = parseJson(created.payload) as { status?: unknown };
+	assert.equal(createdPayload.status, "in_progress");
+	assert.equal(completed.args[1], "-X");
+	assert.equal(completed.args[2], "PATCH");
+	const completedPayload = parseJson(completed.payload) as {
+		conclusion?: unknown;
+		output?: { title?: unknown };
+	};
+	assert.equal(completedPayload.conclusion, "neutral");
+	assert.match(String(completedPayload.output?.title ?? ""), /superseded/);
+	assert.ok(
+		!readPosts(fixture.postLog).some(
+			(p) =>
+				p.args.some((a) => a.includes("pulls/10/reviews")) ||
+				p.args.some(
+					(a) => a === "repos/frankekn/needlefish/issues/10/comments",
+				),
+		),
+		"stale head must not post reviews or comments",
+	);
 });
 
 test("runGithub keeps non-anchorable findings in the review body only", async (t) => {
@@ -1620,10 +1669,12 @@ test("runGithub posts a re-review round comment with counts on the second round"
 	// Check-run title carries the red reason (top blocking finding title).
 	const checkPost = round3Posts.find(
 		(p) =>
-			p.args.includes("POST") &&
-			p.args.some((a) => a === "repos/frankekn/needlefish/check-runs"),
+			p.args.includes("PATCH") &&
+			p.args.some((a) =>
+				a.startsWith("repos/frankekn/needlefish/check-runs/"),
+			),
 	);
-	assert.ok(checkPost, "round 3 should post a check run");
+	assert.ok(checkPost, "round 3 should complete the pending check run");
 	const checkPayload = parseJson(checkPost.payload) as {
 		output?: { title?: unknown };
 	};
@@ -1682,13 +1733,25 @@ test("a failing round-comment POST does not replace the verdict check with a fai
 	await runGithub(fixture.repo, 43, { timeoutMs: 1000 }, true);
 	const round2Posts = readPosts(fixture.postLog).slice(round1Count);
 
-	const checkPosts = round2Posts.filter(
+	const checkCreates = round2Posts.filter(
 		(p) =>
 			p.args.includes("POST") &&
 			p.args.some((a) => a === "repos/frankekn/needlefish/check-runs"),
 	);
-	assert.equal(checkPosts.length, 1, "exactly one check run posted");
-	const payload = parseJson(checkPosts[0].payload) as {
+	assert.equal(checkCreates.length, 1, "exactly one pending check created");
+	const createPayload = parseJson(checkCreates[0].payload) as {
+		status?: unknown;
+	};
+	assert.equal(createPayload.status, "in_progress");
+	const checkPatches = round2Posts.filter(
+		(p) =>
+			p.args.includes("PATCH") &&
+			p.args.some((a) =>
+				a.startsWith("repos/frankekn/needlefish/check-runs/"),
+			),
+	);
+	assert.equal(checkPatches.length, 1, "exactly one check completion posted");
+	const payload = parseJson(checkPatches[0].payload) as {
 		conclusion?: unknown;
 		output?: { title?: unknown };
 	};
@@ -1696,4 +1759,81 @@ test("a failing round-comment POST does not replace the verdict check with a fai
 	// success conclusion, not a red "review failed" check.
 	assert.equal(payload.conclusion, "success");
 	assert.doesNotMatch(String(payload.output?.title ?? ""), /review failed/);
+});
+
+test("pending check is created before review and completed by id", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 61,
+		rawReview: JSON.stringify({
+			summary: "clean",
+			findings: [],
+			checked: ["checked"],
+			residual_risks: [],
+		}),
+	});
+
+	await runGithub(fixture.repo, 61, { timeoutMs: 1000 });
+
+	const posts = readPosts(fixture.postLog);
+	const checkOps = posts.filter((p) =>
+		p.args.some((a) => a.includes("check-runs")),
+	);
+	assert.equal(
+		checkOps.length,
+		2,
+		"exactly one create + one completion, no duplicate check runs",
+	);
+	const [created, completed] = checkOps;
+	assert.equal(created.args[1], "-X");
+	assert.equal(created.args[2], "POST");
+	const createdPayload = parseJson(created.payload) as {
+		status?: unknown;
+		name?: unknown;
+	};
+	assert.equal(createdPayload.status, "in_progress");
+	assert.equal(createdPayload.name, "Needlefish");
+	assert.equal(completed.args[1], "-X");
+	assert.equal(completed.args[2], "PATCH");
+	assert.ok(
+		completed.args.some((a) => a === "repos/frankekn/needlefish/check-runs/1"),
+		"completion must update the check created above (id 1)",
+	);
+	const payload = parseJson(completed.payload) as { conclusion?: unknown };
+	assert.equal(payload.conclusion, "success");
+	// The pending creation must precede the model runner invocation, which
+	// itself precedes the completion.
+	const runnerIdx = posts.findIndex((p) =>
+		p.args.some((a) => a === "repos/frankekn/needlefish/pulls/61/reviews"),
+	);
+	const createdIdx = posts.indexOf(created);
+	const completedIdx = posts.indexOf(completed);
+	assert.ok(runnerIdx === -1 || createdIdx < runnerIdx);
+	assert.ok(createdIdx < runnerIdx || runnerIdx === -1);
+	assert.ok(createdIdx < completedIdx);
+});
+
+test("review error updates the pending check to failure by id", async (t) => {
+	const fixture = setupFixture(t, {
+		prNumber: 62,
+		rawReview: "definitely not json",
+	});
+
+	await runGithub(fixture.repo, 62, { timeoutMs: 1000 });
+
+	const checkOps = readPosts(fixture.postLog).filter((p) =>
+		p.args.some((a) => a.includes("check-runs")),
+	);
+	assert.ok(checkOps.length >= 2, "create + failure completion must both log");
+	const [created] = checkOps;
+	const createdPayload = parseJson(created.payload) as { status?: unknown };
+	assert.equal(createdPayload.status, "in_progress");
+	const last = checkOps[checkOps.length - 1];
+	assert.equal(last.args[1], "-X");
+	assert.equal(last.args[2], "PATCH");
+	const payload = parseJson(last.payload) as {
+		conclusion?: unknown;
+		output?: { title?: unknown };
+	};
+	assert.equal(payload.conclusion, "failure");
+	assert.match(String(payload.output?.title ?? ""), /review failed/);
 });

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -503,6 +503,39 @@ function findPreviousReview(
 	return null;
 }
 
+// S5a: create the check as in_progress BEFORE any model work so a PR always
+// shows whether a review is running on its latest head. All completions update
+// this same check by id; a null id (creation failed) makes completions fall
+// back to creating their own, preserving the old behavior.
+function createPendingCheck(repo: string, headSha: string): number | null {
+	try {
+		const created = ghJson(
+			["api", "-X", "POST", `repos/${repo}/check-runs`, "--input", "-"],
+			JSON.stringify({
+				name: "Needlefish",
+				head_sha: headSha,
+				status: "in_progress",
+				external_id: process.env.GITHUB_RUN_ID || undefined,
+				details_url:
+					process.env.GITHUB_SERVER_URL &&
+					process.env.GITHUB_REPOSITORY &&
+					process.env.GITHUB_RUN_ID
+						? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+						: undefined,
+			}),
+		);
+		if (isRecord(created) && typeof created.id === "number") {
+			return created.id;
+		}
+	} catch (err) {
+		const em = err instanceof Error ? err.message : String(err);
+		process.stderr.write(
+			`needlefish: could not create pending check: ${em}\n`,
+		);
+	}
+	return null;
+}
+
 function postCheck(
 	repo: string,
 	headSha: string,
@@ -510,7 +543,20 @@ function postCheck(
 	conclusion: "success" | "failure" | "neutral",
 	title: string,
 	summary: string,
+	checkId?: number | null,
 ) {
+	const output = JSON.stringify({
+		status: "completed",
+		conclusion,
+		output: { title, summary },
+	});
+	if (typeof checkId === "number") {
+		ghJson(
+			["api", "-X", "PATCH", `repos/${repo}/check-runs/${checkId}`, "--input", "-"],
+			output,
+		);
+		return;
+	}
 	ghJson(
 		["api", "-X", "POST", `repos/${repo}/check-runs`, "--input", "-"],
 		JSON.stringify({
@@ -855,10 +901,26 @@ export async function runGithub(
 		focus: null,
 	});
 
+	const pendingCheckId = createPendingCheck(repo, headSha);
+
 	try {
 		const result = await review(bundle, opts);
 		const conclusion = VERDICT_CONCLUSION[result.verdict];
-		if (!isCurrentOpenHead(repo, prNumber, headSha)) return;
+		if (!isCurrentOpenHead(repo, prNumber, headSha)) {
+			// Head moved while reviewing: close our own check so it cannot hang
+			// as in_progress forever. Timeline comments stay suppressed for the
+			// stale head exactly as before.
+			postCheck(
+				repo,
+				headSha,
+				result,
+				"neutral",
+				"Needlefish: superseded",
+				"A newer head was pushed while this review ran; its result is not posted.",
+				pendingCheckId,
+			);
+			return;
+		}
 		if (result.verdict === "changes_requested") process.exitCode = 1;
 		// Run before posting this result so fresh round comments are not swept.
 		// This also clears stale infra-error comments when the first successful
@@ -929,6 +991,7 @@ export async function runGithub(
 				conclusion,
 				checkRunTitle(result),
 				summary,
+				pendingCheckId,
 			);
 			process.stdout.write(summary);
 		} else {
@@ -954,11 +1017,14 @@ export async function runGithub(
 				conclusion,
 				checkRunTitle(result),
 				summary,
+				pendingCheckId,
 			);
 			process.stdout.write(summary);
 		}
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
+		// The pending check must ALWAYS reach a terminal state — an in_progress
+		// check on a stale head would hang forever otherwise.
 		if (isCurrentOpenHead(repo, prNumber, headSha)) {
 			// Check run and error comment are independent fail-soft attempts: a
 			// failure of either GitHub endpoint must not suppress the other, nor
@@ -971,6 +1037,7 @@ export async function runGithub(
 					"failure",
 					"Needlefish: review failed",
 					`Review errored and did NOT pass this PR.\n\n\`\`\`\n${msg.slice(0, 4000)}\n\`\`\``,
+					pendingCheckId,
 				);
 			} catch (checkErr) {
 				const cm =

--- a/src/shared/codex-runners.test.ts
+++ b/src/shared/codex-runners.test.ts
@@ -366,6 +366,101 @@ test("runCodex can review an unreferenced target commit", async (t) => {
 	assert.equal(readFileSync(readmePath, "utf8"), "feature\n");
 });
 
+test("runCodex surfaces allowlisted auth cause without leaking stderr", async (t) => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const stderrMarker = "SECRET_REVIEW_PROMPT_MARKER_9c2b";
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		runner: process.env.NEEDLEFISH_RUNNER,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.runner === undefined) delete process.env.NEEDLEFISH_RUNNER;
+		else process.env.NEEDLEFISH_RUNNER = previous.runner;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			`process.stderr.write("ERROR: unexpected status 401 Unauthorized, auth error code: invalid_api_key " + ${JSON.stringify(stderrMarker)});`,
+			"process.exit(1);",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.NEEDLEFISH_RUNNER = "codex";
+
+	let caught: unknown;
+	try {
+		await runCodex("prompt", {
+			repoPath: repo,
+			targetHeadSha: headSha(repo),
+			timeoutMs: 1000,
+		});
+		assert.fail("expected runCodex to reject");
+	} catch (err) {
+		caught = err;
+	}
+	assert.ok(caught instanceof Error);
+	const err = caught as Error & { rawOutput?: string };
+	assert.match(
+		err.message,
+		/codex runner exited 1; likely cause: auth error \(invalid_api_key\); stderr withheld/,
+	);
+	assert.doesNotMatch(err.message, new RegExp(stderrMarker));
+	assert.match(err.rawOutput ?? "", new RegExp(stderrMarker));
+});
+
+test("runCodex keeps the generic withheld message when stderr has no allowlisted cause", async (t) => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
+	const repo = initRepo(tmp);
+	const bin = path.join(tmp, "codex-bin.js");
+	const previous = {
+		bin: process.env.CODEX_BIN,
+		runner: process.env.NEEDLEFISH_RUNNER,
+	};
+	t.after(() => {
+		if (previous.bin === undefined) delete process.env.CODEX_BIN;
+		else process.env.CODEX_BIN = previous.bin;
+		if (previous.runner === undefined) delete process.env.NEEDLEFISH_RUNNER;
+		else process.env.NEEDLEFISH_RUNNER = previous.runner;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+	writeFileSync(
+		bin,
+		[
+			"#!/usr/bin/env node",
+			"process.stderr.write('opaque internal failure');",
+			"process.exit(3);",
+		].join("\n"),
+	);
+	chmodSync(bin, 0o755);
+	process.env.CODEX_BIN = bin;
+	process.env.NEEDLEFISH_RUNNER = "codex";
+
+	let caught: unknown;
+	try {
+		await runCodex("prompt", {
+			repoPath: repo,
+			targetHeadSha: headSha(repo),
+			timeoutMs: 1000,
+		});
+		assert.fail("expected runCodex to reject");
+	} catch (err) {
+		caught = err;
+	}
+	assert.ok(caught instanceof Error);
+	assert.match(
+		(caught as Error).message,
+		/codex runner exited 3; stderr withheld because it may contain the review prompt/,
+	);
+	assert.doesNotMatch((caught as Error).message, /likely cause/);
+});
+
 test("runCodex reports opencode exit errors before parsing stdout", async (t) => {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
 	const repo = initRepo(tmp);

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -558,9 +558,13 @@ async function runCodexOnce(
 		};
 		if (result.res.error) throw withRunnerOutput(result.res.error);
 		if (result.res.status !== 0) {
+			// Surface only allowlisted, prompt-free cause tokens extracted from
+			// stderr (auth/quota/network classifications). Raw stderr stays
+			// withheld — it may contain the review prompt.
+			const cause = safeRunnerCause(result.res.stderr);
 			throw withRunnerOutput(
 				new Error(
-					`${runner} runner exited ${result.res.status}; stderr withheld because it may contain the review prompt`,
+					`${runner} runner exited ${result.res.status}${cause ? `; likely cause: ${cause}` : ""}; stderr withheld because it may contain the review prompt`,
 				),
 			);
 		}
@@ -598,6 +602,26 @@ async function runCodexOnce(
 	} finally {
 		await disposeManagedTempDirectory(tmp);
 	}
+}
+
+// Allowlisted cause classification for withheld runner stderr. Only canned
+// phrases and regex-extracted codes ever reach the PR-visible message; raw
+// stderr text never does (it may contain the review prompt).
+export function safeRunnerCause(stderr: string): string | undefined {
+	if (!stderr) return undefined;
+	const authCode = stderr.match(/auth error code:\s*([a-z0-9_]+)/i);
+	if (authCode) return `auth error (${authCode[1]})`;
+	if (/\b40[13]\b|unauthorized|login required|not logged in/i.test(stderr)) {
+		return "auth rejected";
+	}
+	if (/usage limit|quota exceeded|credit balance/i.test(stderr)) {
+		return "usage limit";
+	}
+	if (/rate limit/i.test(stderr)) return "rate limited";
+	if (/ETIMEDOUT|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|fetch failed/i.test(stderr)) {
+		return "network error";
+	}
+	return undefined;
 }
 
 function parseJsonObject(raw: string): unknown {


### PR DESCRIPTION
## What

1. **Early pending check-run** — Needlefish check created as `in_progress` before model work; every terminal path completes the same check by id (verdict / error / superseded). A PR always shows whether its latest head is under review.
2. **Latest-head reconciliation** — `if: always()` finalizer re-dispatches (cap: 2 infra failures) when cancel/supersede/crash leaves the latest open head without a terminal verdict. Closes the PR-#88-class silent-no-review gap.
3. **Runner safe-cause surfacing** — nonzero runner exits now append allowlisted causes (`auth error (…)`, usage/rate/network) extracted from stderr; raw text stays withheld. Diagnosed tonight's claw-console#25 persistent failure (stale exported auth.json → 401 fast-exit) only by local reproduction; future occurrences self-report.

Class D declarations: eval/RESULTS.md §17–18 (posting plumbing + runner plumbing; resident suites, zero draws consumed — nothing on the review-content path).

## Verification

- github-posting.test.ts 48/48 (4 new lifecycle cases incl. leak-negative)
- codex-runners.test.ts 14/14
- full suite 784/784; pnpm check/lint clean