### PR TITLE
fix(workflow): resolve user-local Codex binary

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -278,6 +278,9 @@ jobs:
             echo "PR number must be a positive integer, received '$PR_NUM'." >&2
             exit 1
           fi
+          if [ "$NEEDLEFISH_RUNNER_INPUT" = "codex" ] && [ -z "${CODEX_BIN:-}" ] && [ -x "$HOME/.local/bin/codex" ]; then
+            export CODEX_BIN="$HOME/.local/bin/codex"
+          fi
           args=(--github --pr "$PR_NUM")
           if [ -z "$NEEDLEFISH_MODEL_INPUT" ]; then
             case "$NEEDLEFISH_RUNNER_INPUT" in

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -639,3 +639,30 @@ Gate: resident suites (`codex-runners.test.ts` +4 cases incl. leak-negative);
 no eval draws consumed, same proportionality reasoning as §17.
 
 **Result: PASSED.** `codex-runners.test.ts` 14/14; suite green.
+
+### 19. Self-hosted user-local Codex resolution — Class D declared 2026-08-25
+
+Trigger: the reusable workflow selected a valid immutable Needlefish release
+on `ubuntu-claw-console`, then failed with `spawn codex ENOENT` because Codex
+was installed at `$HOME/.local/bin/codex` while the runner service PATH did not
+include `$HOME/.local/bin`.
+
+Change: for the Codex runner only, `review.yml` selects the executable
+user-local install when `CODEX_BIN` is unset. An explicit `CODEX_BIN` remains
+authoritative; runner arguments, model inputs, normalization, scoring, and
+posting are unchanged.
+
+Classification: **Class D** by provenance containment — executable resolution
+only. Healthy existing runner paths are byte-identical, no signal is removed,
+and no model input or output contract changes. No eval draw can observe shell
+binary resolution, so the proportional gate is the executable workflow-script
+suite plus the live self-hosted canary.
+
+Gate criteria (pre-declared): workflow-script tests prove user-local fallback
+and explicit-override preservation; `actionlint`, `pnpm check`, `pnpm lint`,
+and full suite green; post-deploy claw-console canary reaches a terminal review
+verdict without runner infrastructure failure.
+
+Pre-deploy result: resident gate passed — workflow-script tests 13/13, full
+suite 788/788, and `actionlint`/`pnpm check`/`pnpm lint` clean. Live canary
+pending deployment.

--- a/scripts/review-workflow-pr-number.test.mjs
+++ b/scripts/review-workflow-pr-number.test.mjs
@@ -39,17 +39,25 @@ const script = scriptLines
 	.map((line) => line.replace(/^          /, ""))
 	.join("\n");
 
-function runReview(prNum) {
+function runReview(prNum, { runner = "", homeCodex = false, codexBin = "" } = {}) {
 	const root = mkdtempSync(join(tmpdir(), "needlefish-workflow-pr-"));
 	const fakeBin = join(root, "fake bin");
 	const argvLog = join(root, "argv.log");
+	const codexBinLog = join(root, "codex-bin.log");
 	const needlefishBin = join(fakeBin, "needlefish");
 	mkdirSync(fakeBin);
+	const expectedHomeCodex = join(root, ".local", "bin", "codex");
+	if (homeCodex) {
+		mkdirSync(join(root, ".local", "bin"), { recursive: true });
+		writeFileSync(expectedHomeCodex, "#!/bin/sh\nexit 0\n");
+		chmodSync(expectedHomeCodex, 0o755);
+	}
 	writeFileSync(
 		needlefishBin,
 		`#!/usr/bin/env bash
 set -euo pipefail
 for arg in "$@"; do printf '<%s>\\n' "$arg" >> "$ARGV_LOG"; done
+printf '%s' "\${CODEX_BIN:-}" > "$CODEX_BIN_LOG"
 `,
 	);
 	chmodSync(needlefishBin, 0o755);
@@ -60,11 +68,14 @@ for arg in "$@"; do printf '<%s>\\n' "$arg" >> "$ARGV_LOG"; done
 		env: {
 			...process.env,
 			ARGV_LOG: argvLog,
+			CODEX_BIN: codexBin,
+			CODEX_BIN_LOG: codexBinLog,
 			CODEX_REASONING_EFFORT: "",
+			HOME: root,
 			NEEDLEFISH_BIN: needlefishBin,
 			NEEDLEFISH_MODEL_INPUT: "",
 			NEEDLEFISH_RECHECK_INPUT: "",
-			NEEDLEFISH_RUNNER_INPUT: "",
+			NEEDLEFISH_RUNNER_INPUT: runner,
 			NEEDLEFISH_TIMEOUT_MS_INPUT: "",
 			OPENCODE_IDLE_TIMEOUT_MS_INPUT: "",
 			PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
@@ -74,6 +85,8 @@ for arg in "$@"; do printf '<%s>\\n' "$arg" >> "$ARGV_LOG"; done
 	const output = {
 		...result,
 		argvLog: existsSync(argvLog) ? readFileSync(argvLog, "utf8") : "",
+		codexBin: existsSync(codexBinLog) ? readFileSync(codexBinLog, "utf8") : "",
+		expectedHomeCodex,
 		pwned: existsSync(join(root, "pwned")),
 	};
 	rmSync(root, { recursive: true, force: true });
@@ -95,6 +108,24 @@ test("review invokes needlefish with a valid numeric PR number", () => {
 
 	assert.equal(result.status, 0, result.stderr);
 	assert.match(result.argvLog, /<--github>\n<--pr>\n<42>\n/);
+});
+
+test("review uses an installed user-local Codex CLI when CODEX_BIN is unset", () => {
+	const result = runReview("42", { runner: "codex", homeCodex: true });
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.codexBin, result.expectedHomeCodex);
+});
+
+test("review preserves an explicitly configured CODEX_BIN", () => {
+	const result = runReview("42", {
+		runner: "codex",
+		homeCodex: true,
+		codexBin: "/opt/codex/bin/codex",
+	});
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.codexBin, "/opt/codex/bin/codex");
 });
 
 test("review rejects PR number 0 before invoking needlefish", () => {


### PR DESCRIPTION
## Summary

- use `$HOME/.local/bin/codex` on self-hosted runners when `CODEX_BIN` is unset and the executable exists
- preserve explicit `CODEX_BIN` configuration
- record the Class D gate declaration and resident results

## Verification

- workflow-script tests 13/13
- full suite 788/788
- `actionlint .github/workflows/review.yml`
- `pnpm check`
- `pnpm lint`

Class D: executable resolution only; no model input/output or scoring changes. Live claw-console canary follows deployment.