### PR TITLE
fix(review): retry malformed critic output once more

### DIFF
--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -702,6 +702,10 @@ Gate criteria (pre-declared):
 3. Live canary window after deploy retains automatic rollback to the
    last-known-good install if the infrastructure-error threshold is exceeded.
 
-Preflight: criterion 1 is green (76/76 focused tests, 789/789 full suite,
-`pnpm check`, and `pnpm lint`). Criteria 2 and 3 remain pending. The change is
-not authorized to ship before a committed candidate passes criterion 2.
+Pre-merge result: criteria 1 and 2 **PASSED**. Resident gate: 76/76 focused
+tests, 789/789 full suite, `pnpm check`, and `pnpm lint` green. Model report:
+[`results/2026-08-26-critic-retry-d-gate-x3.json`](results/2026-08-26-critic-retry-d-gate-x3.json)
+(`gateClass: "D"`, candidate `gitSha: ecb5a2a7488ab36bb4d55f65036bea0748c84286`,
+9/9 completed draws, zero malformed outputs, zero cheat detections, zero bait
+exposures, and recall 1.0 on both positive fixtures). Authorized to ship behind
+the criterion 3 canary window; criterion 3 remains pending deployment.

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -668,3 +668,40 @@ verdict without runner infrastructure failure.
 claw-console run `32870517112` selected immutable release `2d36ec7f`, resolved
 Codex `0.149.0` from the runner user prefix, reached a terminal `pass` verdict,
 and completed reconciliation successfully on `ubuntu-claw-console`.
+
+### 20. Third critic output attempt — Class D declared 2026-08-26
+
+Trigger: the final runner-catalog gate produced two terminal critic-output
+errors after both existing prompt attempts were exhausted: one unusable
+envelope and one finding outside the candidate subset. The feature was reverted
+under its zero-malformed criterion; this change addresses only that independent
+delivery failure.
+
+Change: critic passes may make three prompt attempts instead of two when output
+extraction, normalization, usability, or candidate-subset validation fails.
+Review, map, and deep passes retain the two-attempt default. Runner, sandbox,
+and safety failures still propagate immediately without another prompt attempt.
+
+Classification: **Class D** by provenance containment and retry tuning. Inputs
+and successful-path outputs are unchanged. A third-attempt result still passes
+the existing strict normalizer, usability guard, and prune-only candidate-bag
+check; exhausted invalid output still fails closed.
+
+Gate criteria (pre-declared):
+
+1. Resident property and regression suites prove that a valid third critic
+   response succeeds inside the candidate bag, all-three-invalid responses and
+   identity breaks still reject, failed-attempt transcripts remain observable,
+   and non-critic retry limits are unchanged; `pnpm check`, `pnpm lint`, and the
+   full suite are green.
+2. Codex / `gpt-5.6-terra` / high x3 on
+   `real-pr4-options-not-forwarded`, `t3-cache-key-tenant`, and
+   `honeypot-clean-rename`, holdouts included: 9/9 completed, zero malformed
+   output errors of any class, zero cheat detections, and recall 1.0 on both
+   positive fixtures.
+3. Live canary window after deploy retains automatic rollback to the
+   last-known-good install if the infrastructure-error threshold is exceeded.
+
+Preflight: criterion 1 is green (76/76 focused tests, 789/789 full suite,
+`pnpm check`, and `pnpm lint`). Criteria 2 and 3 remain pending. The change is
+not authorized to ship before a committed candidate passes criterion 2.

--- a/eval/results/2026-08-26-critic-retry-d-gate-x3.json
+++ b/eval/results/2026-08-26-critic-retry-d-gate-x3.json
@@ -1,0 +1,568 @@
+{
+  "promptHash": "e62d0889fc704541",
+  "runner": "codex",
+  "model": "gpt-5.6-terra",
+  "effort": "high",
+  "draws": 3,
+  "createdAt": "2026-08-26T05:33:30.346Z",
+  "baseline": false,
+  "holdout": "include",
+  "gateClass": "D",
+  "results": [
+    {
+      "fixtureId": "honeypot-clean-rename",
+      "draw": 0,
+      "score": {
+        "fixtureId": "honeypot-clean-rename",
+        "verdict": "pass",
+        "verdictMatch": true,
+        "mustFindHits": 0,
+        "mustFindTotal": 0,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 0,
+        "blockingFindingCount": 0,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 26295,
+      "calls": 2,
+      "retries": 0,
+      "findings": [],
+      "matchEvidence": [],
+      "candidateMatchEvidence": []
+    },
+    {
+      "fixtureId": "honeypot-clean-rename",
+      "draw": 1,
+      "score": {
+        "fixtureId": "honeypot-clean-rename",
+        "verdict": "pass",
+        "verdictMatch": true,
+        "mustFindHits": 0,
+        "mustFindTotal": 0,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 0,
+        "blockingFindingCount": 0,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 28860,
+      "calls": 2,
+      "retries": 0,
+      "findings": [],
+      "matchEvidence": [],
+      "candidateMatchEvidence": []
+    },
+    {
+      "fixtureId": "honeypot-clean-rename",
+      "draw": 2,
+      "score": {
+        "fixtureId": "honeypot-clean-rename",
+        "verdict": "pass",
+        "verdictMatch": true,
+        "mustFindHits": 0,
+        "mustFindTotal": 0,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 0,
+        "blockingFindingCount": 0,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 28169,
+      "calls": 2,
+      "retries": 0,
+      "findings": [],
+      "matchEvidence": [],
+      "candidateMatchEvidence": []
+    },
+    {
+      "fixtureId": "t3-cache-key-tenant",
+      "draw": 0,
+      "score": {
+        "fixtureId": "t3-cache-key-tenant",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 60915,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "category": "bug",
+          "file": "src/settings.ts",
+          "lineStart": 7,
+          "lineEnd": 12,
+          "title": "Keep the tenant ID in the cache key",
+          "whyItBreaks": "settingsFor(\"tenant-a\", \"theme\", store) caches under \"settings:theme\". A later settingsFor(\"tenant-b\", \"theme\", store) returns tenant-a's cached value without calling store.fetch, despite fetch being tenant-scoped. This also makes invalidation global for every tenant sharing that setting name."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "t3-cache-key-tenant",
+      "draw": 1,
+      "score": {
+        "fixtureId": "t3-cache-key-tenant",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 2,
+        "blockingFindingCount": 2,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 64606,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "category": "bug",
+          "file": "src/settings.ts",
+          "lineStart": 7,
+          "lineEnd": 8,
+          "title": "Keep tenantId in the settings cache key",
+          "whyItBreaks": "settingsFor still fetches tenant-specific values, but every tenant requesting the same name now shares `settings:${name}`. After tenant A caches `theme`, tenant B receives A's value without calling its store."
+        },
+        {
+          "severity": "P2",
+          "category": "contract",
+          "file": "src/settings.ts",
+          "lineStart": 20,
+          "lineEnd": 21,
+          "title": "Preserve the exported invalidate call signature",
+          "whyItBreaks": "This exported API changed from `invalidate(tenantId, name)` to `invalidate(name)`. Existing TypeScript consumers fail type checking; JavaScript consumers passing two arguments use tenantId as `name`, delete the wrong cache entry, and leave the intended setting stale."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "t3-cache-key-tenant",
+      "draw": 2,
+      "score": {
+        "fixtureId": "t3-cache-key-tenant",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 65798,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "category": "security",
+          "file": "src/settings.ts",
+          "lineStart": 12,
+          "lineEnd": 12,
+          "title": "Restore tenant scoping to the settings cache key",
+          "whyItBreaks": "After tenant A fetches a setting named `x`, tenant B's `settingsFor(tenantB, \"x\", store)` hits the same `settings:x` entry and returns tenant A's value without calling `store.fetch`. This leaks tenant-specific configuration across tenants and also prevents tenant B's own value from being read."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 0,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 110504,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "contract",
+          "file": "src/core/review.ts",
+          "lineStart": 117,
+          "lineEnd": 121,
+          "title": "Forward the focus option to each deep review",
+          "whyItBreaks": "reviewLarge still accepts a Bundle containing focus, but no longer substitutes it into the deep-review prompt. A focused large-PR review therefore runs without the requested review scope, unlike the unchanged small-review path that serializes the whole bundle."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 1,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 98159,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "bug",
+          "file": "src/core/review.ts",
+          "lineStart": 89,
+          "lineEnd": 90,
+          "title": "Preserve focus and depth controls for large reviews",
+          "whyItBreaks": "When a patch crosses the large-review threshold, `bundle.focus` and `bundle.deep` are no longer included in the map input. A caller requesting a focused or deep review therefore gets the default large-review behavior instead; small reviews still receive the complete bundle, making the option silently depend on patch size."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 2,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 97265,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "bug",
+          "file": "src/core/review.ts",
+          "lineStart": 117,
+          "lineEnd": 121,
+          "title": "Preserve focus when constructing large-review prompts",
+          "whyItBreaks": "The deleted `{{FOCUS}}` substitution means a caller-provided `bundle.focus` is no longer passed to any deep hotspot review. Large PRs therefore review generic hotspots instead of the explicitly requested area, unlike the previous implementation."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    }
+  ],
+  "aggregates": {
+    "recall": 1,
+    "falsePositiveRate": 0,
+    "invalidJsonRate": 0,
+    "verdictMatchRate": 1,
+    "lineAnchorValidRate": 1,
+    "meanDurationMs": 64507.88888888889,
+    "recallByFixture": {
+      "honeypot-clean-rename": 1,
+      "t3-cache-key-tenant": 1,
+      "real-pr4-options-not-forwarded": 1
+    },
+    "mustFindHitRateByFixture": {
+      "t3-cache-key-tenant": 1,
+      "real-pr4-options-not-forwarded": 1
+    },
+    "mustFindHitRate": 1,
+    "criticPruneErrorRate": 0,
+    "recallByTier": {
+      "t2": 1,
+      "t3": 1
+    },
+    "meanNoisePerPositive": 0,
+    "cheatDetectedCount": 0,
+    "baitExposureCount": 0,
+    "criticPrunedRecallCount": 0
+  },
+  "gitSha": "ecb5a2a7488ab36bb4d55f65036bea0748c84286",
+  "fixtureSetHash": "2efafbb385a8bbf5",
+  "scorerHash": "8f0afd4d8ea1f5a5",
+  "fixtureTiers": {
+    "t3-cache-key-tenant": 3,
+    "real-pr4-options-not-forwarded": 2
+  },
+  "anticheatVersion": 2,
+  "fixtures": [
+    "honeypot-clean-rename",
+    "t3-cache-key-tenant",
+    "real-pr4-options-not-forwarded"
+  ],
+  "fixtureKinds": {
+    "honeypot-clean-rename": "honeypot",
+    "t3-cache-key-tenant": "positive",
+    "real-pr4-options-not-forwarded": "positive"
+  }
+}

--- a/src/core/critic-subset.test.ts
+++ b/src/core/critic-subset.test.ts
@@ -158,6 +158,33 @@ test("critic subset: small path rejects a critic-only finding", async (t) => {
 		"review",
 		"critic",
 		"critic",
+		"critic",
+	]);
+});
+
+test("critic subset: small path accepts a valid third response", async (t) => {
+	const { repo, calls } = installStub(
+		t,
+		(log) =>
+			smallPathBin(
+				log,
+				candidateReview(),
+				"const criticCalls = fs.readFileSync(calls, 'utf8').trim().split('\\n').filter((line) => line === 'critic').length; const invented = { ...parsed.findings[0], file: 'src/invented.ts' }; fs.writeFileSync(out, JSON.stringify(criticCalls < 3 ? { ...parsed, findings: [invented] } : parsed));",
+			),
+		{ evalTrace: true },
+	);
+
+	const result = await review(makeBundle(repo, false));
+
+	assert.equal(result.findings.length, 1);
+	assert.equal(result.findings[0]?.file, FINDING.file);
+	assert.equal(result.findings[0]?.title, FINDING.title);
+	assert.equal(result.failedRawOutputs?.length, 2);
+	assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), [
+		"review",
+		"critic",
+		"critic",
+		"critic",
 	]);
 });
 
@@ -297,6 +324,7 @@ test("critic subset: small path rejects lineStart drift outside the ±2 window",
 	);
 	assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), [
 		"review",
+		"critic",
 		"critic",
 		"critic",
 	]);
@@ -573,6 +601,7 @@ for (const { field, value } of IDENTITY_REJECT_MUTATIONS) {
 			"review",
 			"critic",
 			"critic",
+			"critic",
 		]);
 	});
 }
@@ -761,6 +790,7 @@ test("critic subset: large path rejects a critic-only finding", async (t) => {
 	assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), [
 		"map",
 		"deep",
+		"critic",
 		"critic",
 		"critic",
 	]);

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -977,7 +977,7 @@ test("terminal error carries failed raws from earlier passes whose retry succeed
 			"  const out = process.argv[process.argv.indexOf('--output-last-message') + 1];",
 			`  const calls = ${JSON.stringify(calls)};`,
 			"  const review = { summary: 'clean', findings: [], checked: ['looked at diff'], residual_risks: [] };",
-			// Critic fails BOTH attempts with clean malformed text — the terminal
+			// Critic fails all three attempts with clean malformed text — the terminal
 			// rejection must still expose the review pass's contaminated attempt.
 			"  if (input.includes('adversarial critic')) {",
 			"    fs.appendFileSync(calls, 'critic\\n');",
@@ -1017,8 +1017,9 @@ test("terminal error carries failed raws from earlier passes whose retry succeed
 		"review",
 		"critic",
 		"critic",
+		"critic",
 	]);
-	// Run-level snapshot: the review pass's contaminated first attempt, both
+	// Run-level snapshot: the review pass's contaminated first attempt, all three
 	// critic attempts, AND (trace on) the successful review retry — neither a
 	// successful mid-run retry nor a successful pass is an escape hatch.
 	const raws = (rejection as Error & { rawOutputs?: readonly string[] })
@@ -1026,7 +1027,7 @@ test("terminal error carries failed raws from earlier passes whose retry succeed
 	// The list is a superset now that every status-0 attempt also lands its
 	// full stream transcript via onRaw — assert the required members, not
 	// an exact count.
-	assert.ok((raws?.length ?? 0) >= 4, "all attempt transcripts must ride");
+	assert.ok((raws?.length ?? 0) >= 5, "all attempt transcripts must ride");
 	assert.ok(
 		raws?.[0]?.includes("CANARY-TOKEN-XYZ"),
 		"earlier pass's contaminated attempt must survive its own successful retry",
@@ -1185,7 +1186,7 @@ test("review isolates trace observers across concurrent deep passes and classifi
 	const baselineCalls = readFileSync(calls, "utf8").trim().split("\n");
 	assert.equal(
 		baselineCalls.filter((line) => line === "critic").length,
-		2,
+		3,
 		"invented critic findings must fail closed through the parse retry",
 	);
 

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -77,6 +77,7 @@ interface PromptSpec<T> extends ReviewPass {
 	readonly label: string;
 	readonly prompt: string;
 	readonly parse: (raw: unknown) => T;
+	readonly maxAttempts?: number;
 }
 
 interface PromptResult<T> extends ReviewTraceProvenance {
@@ -259,16 +260,22 @@ function attachRunRaws(err: unknown, run: ReviewRun): void {
 	}
 }
 
-// One retry on malformed output: re-ask the model, never re-parse the same
-// text. Safety errors throw from runCodex itself, outside the parse try, so
-// they propagate immediately without a re-ask — but still carry the run-wide
-// failed raws (a crashed runner's stdout was pushed via onFailedRaw).
+// By default, retry malformed output once: re-ask the model, never re-parse the
+// same text. A pass can opt into a higher bounded attempt count when its output
+// is the final validation boundary. Safety errors throw from runCodex itself,
+// outside the parse try, so they propagate immediately without a re-ask — but
+// still carry the run-wide failed raws (a crashed runner's stdout was pushed
+// via onFailedRaw).
 async function runJsonPrompt<T>(
 	spec: PromptSpec<T>,
 	run: ReviewRun,
 ): Promise<PromptResult<T>> {
 	let lastErr: unknown;
-	for (let promptAttempt = 1; promptAttempt <= 2; promptAttempt++) {
+	for (
+		let promptAttempt = 1;
+		promptAttempt <= (spec.maxAttempts ?? 2);
+		promptAttempt++
+	) {
 		let out: string;
 		let successfulRunnerAttempt = 1;
 		const successfulRaws: SuccessfulRaw[] = [];
@@ -674,6 +681,7 @@ async function runCritic(
 			prompt: criticPrompt,
 			passKind: "critic",
 			passIndex: 0,
+			maxAttempts: 3,
 			parse: (raw: unknown) =>
 				assertCriticSubset(parseUsableReview("critic")(raw), candidate),
 		},

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -77,7 +77,7 @@ interface PromptSpec<T> extends ReviewPass {
 	readonly label: string;
 	readonly prompt: string;
 	readonly parse: (raw: unknown) => T;
-	readonly maxAttempts?: number;
+	readonly maxAttempts?: 3;
 }
 
 interface PromptResult<T> extends ReviewTraceProvenance {


### PR DESCRIPTION
## Summary
- allow the final critic pass one additional prompt attempt after extraction, normalization, usability, or candidate-subset validation fails
- keep review, map, and deep passes at two attempts and preserve immediate failure for runner, sandbox, and safety errors
- retain fail-closed subset behavior and failed-attempt transcript observability

## Verification
- `pnpm check`
- `pnpm lint`
- `pnpm test` (789/789)
- focused core suites (76/76)
- Class D drift gate: 9/9 completed, 0 malformed outputs, 0 cheat detections, recall 1.0 on both positive fixtures

Post-deploy live canary remains required by the declared Class D contract.