### PR TITLE
Route Codex through fail-closed CLIProxyAPI provider

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -285,9 +285,9 @@ jobs:
           NEEDLEFISH_TIMEOUT_MS_INPUT: ${{ inputs.timeout_ms || github.event.inputs.timeout_ms }}
           OPENCODE_IDLE_TIMEOUT_MS_INPUT: ${{ inputs.idle_timeout_ms || github.event.inputs.idle_timeout_ms }}
           CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort || github.event.inputs.codex_reasoning_effort }}
-          CODEX_PROXY_BASE_URL: ${{ inputs.codex_proxy_base_url }}
-          CODEX_PROXY_API_KEY: ${{ secrets.codex_proxy_api_key }}
-          NEEDLEFISH_CODEX_PROXY_REQUIRED: ${{ inputs.codex_proxy_required && '1' || '' }}
+          CODEX_PROXY_BASE_URL_INPUT: ${{ inputs.codex_proxy_base_url }}
+          CODEX_PROXY_API_KEY_INPUT: ${{ secrets.codex_proxy_api_key }}
+          NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT: ${{ inputs.codex_proxy_required && '1' || '' }}
           # ubuntu-needlefish routes pi through the local CLIProxyAPI (ccp);
           # credentials live in the proxy, provider registered in ~/.pi/agent/models.json.
           PI_PROVIDER: cliproxy
@@ -307,6 +307,9 @@ jobs:
           if [ "$NEEDLEFISH_RUNNER_INPUT" = "codex" ] && [ -z "${CODEX_BIN:-}" ] && [ -x "$HOME/.local/bin/codex" ]; then
             export CODEX_BIN="$HOME/.local/bin/codex"
           fi
+          if [ -n "$CODEX_PROXY_BASE_URL_INPUT" ]; then export CODEX_PROXY_BASE_URL="$CODEX_PROXY_BASE_URL_INPUT"; fi
+          if [ -n "$CODEX_PROXY_API_KEY_INPUT" ]; then export CODEX_PROXY_API_KEY="$CODEX_PROXY_API_KEY_INPUT"; fi
+          if [ -n "$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT" ]; then export NEEDLEFISH_CODEX_PROXY_REQUIRED="$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT"; fi
           args=(--github --pr "$PR_NUM")
           if [ -z "$NEEDLEFISH_MODEL_INPUT" ]; then
             case "$NEEDLEFISH_RUNNER_INPUT" in

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -304,18 +304,30 @@ jobs:
             echo "PR number must be a positive integer, received '$PR_NUM'." >&2
             exit 1
           fi
-          if [ "$NEEDLEFISH_RUNNER_INPUT" = "codex" ] && [ -z "${CODEX_BIN:-}" ] && [ -x "$HOME/.local/bin/codex" ]; then
-            export CODEX_BIN="$HOME/.local/bin/codex"
-          fi
-          if [ -n "$CODEX_PROXY_BASE_URL_INPUT" ] || [ -n "$CODEX_PROXY_API_KEY_INPUT" ]; then
-            if [ -z "$CODEX_PROXY_BASE_URL_INPUT" ] || [ -z "$CODEX_PROXY_API_KEY_INPUT" ]; then
-              echo "Codex proxy base URL and API key must be supplied together." >&2
+          if [ "$NEEDLEFISH_RUNNER_INPUT" = "codex" ]; then
+            if [ -z "${CODEX_BIN:-}" ] && [ -x "$HOME/.local/bin/codex" ]; then
+              export CODEX_BIN="$HOME/.local/bin/codex"
+            fi
+            codex_bin="${CODEX_BIN:-codex}"
+            codex_version=$("$codex_bin" --version) || {
+              echo "Unable to run the selected Codex CLI." >&2
+              exit 1
+            }
+            if [ "$codex_version" != "codex-cli 0.153.0" ]; then
+              echo "Selected Codex CLI must be codex-cli 0.153.0; found '$codex_version'." >&2
               exit 1
             fi
-            export CODEX_PROXY_BASE_URL="$CODEX_PROXY_BASE_URL_INPUT"
-            export CODEX_PROXY_API_KEY="$CODEX_PROXY_API_KEY_INPUT"
+            export CODEX_BIN="$codex_bin"
+            if [ -n "$CODEX_PROXY_BASE_URL_INPUT" ] || [ -n "$CODEX_PROXY_API_KEY_INPUT" ]; then
+              if [ -z "$CODEX_PROXY_BASE_URL_INPUT" ] || [ -z "$CODEX_PROXY_API_KEY_INPUT" ]; then
+                echo "Codex proxy base URL and API key must be supplied together." >&2
+                exit 1
+              fi
+              export CODEX_PROXY_BASE_URL="$CODEX_PROXY_BASE_URL_INPUT"
+              export CODEX_PROXY_API_KEY="$CODEX_PROXY_API_KEY_INPUT"
+            fi
+            if [ -n "$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT" ]; then export NEEDLEFISH_CODEX_PROXY_REQUIRED="$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT"; fi
           fi
-          if [ -n "$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT" ]; then export NEEDLEFISH_CODEX_PROXY_REQUIRED="$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT"; fi
           args=(--github --pr "$PR_NUM")
           if [ -z "$NEEDLEFISH_MODEL_INPUT" ]; then
             case "$NEEDLEFISH_RUNNER_INPUT" in

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -24,6 +24,14 @@ on:
       codex_reasoning_effort:
         description: "Codex reasoning effort: medium, high, or xhigh"
         required: false
+      codex_proxy_base_url:
+        description: Optional CLIProxyAPI base URL for Codex
+        required: false
+      codex_proxy_required:
+        description: Prohibit Codex OAuth fallback
+        type: boolean
+        required: false
+        default: false
       needlefish_release_sha:
         description: Optional expected Needlefish release SHA
         required: false
@@ -62,6 +70,15 @@ on:
         description: "Codex reasoning effort: medium, high, or xhigh"
         type: string
         required: false
+      codex_proxy_base_url:
+        description: Optional CLIProxyAPI base URL for Codex
+        type: string
+        required: false
+      codex_proxy_required:
+        description: Prohibit Codex OAuth fallback
+        type: boolean
+        required: false
+        default: false
       needlefish_release_sha:
         description: Optional expected Needlefish release SHA
         type: string
@@ -73,6 +90,10 @@ on:
       needlefish_repo:
         description: Needlefish source repo for installed-release validation
         type: string
+        required: false
+    secrets:
+      codex_proxy_api_key:
+        description: CLIProxyAPI credential for Codex
         required: false
 
 permissions:
@@ -264,6 +285,9 @@ jobs:
           NEEDLEFISH_TIMEOUT_MS_INPUT: ${{ inputs.timeout_ms || github.event.inputs.timeout_ms }}
           OPENCODE_IDLE_TIMEOUT_MS_INPUT: ${{ inputs.idle_timeout_ms || github.event.inputs.idle_timeout_ms }}
           CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort || github.event.inputs.codex_reasoning_effort }}
+          CODEX_PROXY_BASE_URL: ${{ inputs.codex_proxy_base_url }}
+          CODEX_PROXY_API_KEY: ${{ secrets.codex_proxy_api_key }}
+          NEEDLEFISH_CODEX_PROXY_REQUIRED: ${{ inputs.codex_proxy_required && '1' || '' }}
           # ubuntu-needlefish routes pi through the local CLIProxyAPI (ccp);
           # credentials live in the proxy, provider registered in ~/.pi/agent/models.json.
           PI_PROVIDER: cliproxy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -307,8 +307,14 @@ jobs:
           if [ "$NEEDLEFISH_RUNNER_INPUT" = "codex" ] && [ -z "${CODEX_BIN:-}" ] && [ -x "$HOME/.local/bin/codex" ]; then
             export CODEX_BIN="$HOME/.local/bin/codex"
           fi
-          if [ -n "$CODEX_PROXY_BASE_URL_INPUT" ]; then export CODEX_PROXY_BASE_URL="$CODEX_PROXY_BASE_URL_INPUT"; fi
-          if [ -n "$CODEX_PROXY_API_KEY_INPUT" ]; then export CODEX_PROXY_API_KEY="$CODEX_PROXY_API_KEY_INPUT"; fi
+          if [ -n "$CODEX_PROXY_BASE_URL_INPUT" ] || [ -n "$CODEX_PROXY_API_KEY_INPUT" ]; then
+            if [ -z "$CODEX_PROXY_BASE_URL_INPUT" ] || [ -z "$CODEX_PROXY_API_KEY_INPUT" ]; then
+              echo "Codex proxy base URL and API key must be supplied together." >&2
+              exit 1
+            fi
+            export CODEX_PROXY_BASE_URL="$CODEX_PROXY_BASE_URL_INPUT"
+            export CODEX_PROXY_API_KEY="$CODEX_PROXY_API_KEY_INPUT"
+          fi
           if [ -n "$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT" ]; then export NEEDLEFISH_CODEX_PROXY_REQUIRED="$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT"; fi
           args=(--github --pr "$PR_NUM")
           if [ -z "$NEEDLEFISH_MODEL_INPUT" ]; then

--- a/README.md
+++ b/README.md
@@ -338,13 +338,21 @@ jobs:
    shared ARM installation used by two runner services. Deploy the same release
    SHA to both installations and verify their installed metadata before trusting
    the fleet.
-3. Ensure the runner has `gh` and the selected model CLI on `PATH`.
-4. On that runner, auth the selected CLI once. For Codex:
+3. Ensure the runner has `gh` and the selected model CLI on `PATH`. The Codex
+   fleet contract is `@openai/codex@0.153.0`; install and verify that exact
+   version as the runner service account:
    ```bash
-   printf '%s' "$CODEX_API_KEY" | codex login --with-api-key -c 'service_tier="fast"'
+   npm install -g @openai/codex@0.153.0
+   codex --version
    ```
-   For Grok, complete the provider's CLI login or key setup as appropriate
-   and verify that `grok` runs as the runner service account.
+4. Supply Codex's proxy route at job runtime with `CODEX_PROXY_BASE_URL`,
+   `CODEX_PROXY_API_KEY`, and `NEEDLEFISH_CODEX_PROXY_REQUIRED=1`. Needlefish
+   registers the `cliproxyapi` custom provider on the command line while the
+   credential remains only in the child environment; required mode rejects
+   incomplete configuration instead of falling back to OAuth. Proxy invocations
+   omit the direct-subscription `service_tier` override. For Grok,
+   complete the provider's CLI login or key setup as appropriate and verify
+   that `grok` runs as the runner service account.
 5. If needlefish is **private**, the caller repo must be allowed to call this
    reusable workflow; otherwise (public) the default `GITHUB_TOKEN` is enough.
 6. **Runner global-instructions caveat:** model CLIs may auto-load global
@@ -416,7 +424,7 @@ Inputs (all optional): `pr_number` (defaults to the event PR), `runner`
 
 `runner_version` overrides the npm version of the selected runner CLI. When
 omitted, the action installs the per-runner pin from `action.yml` (currently
-Codex `0.151.0`, Claude `2.1.239`, OpenCode `1.18.21`, pi `0.70.6`). Pass an
+Codex `0.153.0`, Claude `2.1.239`, OpenCode `1.18.21`, pi `0.70.6`). Pass an
 explicit version — or `latest` — only when you intentionally want something
 other than the pin. A single default cannot be correct for four packages, so
 the pin is chosen from the selected `runner`.
@@ -468,7 +476,7 @@ parentheses are the executable names used when the `*_BIN` var is unset:
 
 | runner | binary | model / other |
 | --- | --- | --- |
-| `codex` | `CODEX_BIN` (`codex`) | `CODEX_MODEL`, `CODEX_TIMEOUT_MS`, `CODEX_RETRY_MS`, `CODEX_REASONING_EFFORT` |
+| `codex` | `CODEX_BIN` (`codex`) | `CODEX_MODEL`, `CODEX_TIMEOUT_MS`, `CODEX_RETRY_MS`, `CODEX_REASONING_EFFORT`; proxy `CODEX_PROXY_BASE_URL`, `CODEX_PROXY_API_KEY`, `NEEDLEFISH_CODEX_PROXY_REQUIRED=1` |
 | `claude` | `CLAUDE_BIN` (`claude`) | `CLAUDE_MODEL`; auth `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` |
 | `opencode` | `OPENCODE_BIN` (`opencode`) | `OPENCODE_MODEL`; auth `OPENAI_API_KEY` |
 | `grok` | `GROK_BIN` (`grok`) | `GROK_MODEL` |

--- a/README.md
+++ b/README.md
@@ -342,8 +342,9 @@ jobs:
    fleet contract is `@openai/codex@0.153.0`; install and verify that exact
    version as the runner service account:
    ```bash
-   npm install -g @openai/codex@0.153.0
-   codex --version
+   npm install --global --prefix "$HOME/.local" @openai/codex@0.153.0
+   CODEX_BIN="$HOME/.local/bin/codex"
+   test "$("$CODEX_BIN" --version)" = "codex-cli 0.153.0"
    ```
 4. Supply Codex's proxy route to the reusable workflow with
    `codex_proxy_base_url`, `codex_proxy_required: true`, and the

--- a/README.md
+++ b/README.md
@@ -345,8 +345,9 @@ jobs:
    npm install -g @openai/codex@0.153.0
    codex --version
    ```
-4. Supply Codex's proxy route at job runtime with `CODEX_PROXY_BASE_URL`,
-   `CODEX_PROXY_API_KEY`, and `NEEDLEFISH_CODEX_PROXY_REQUIRED=1`. Needlefish
+4. Supply Codex's proxy route to the reusable workflow with
+   `codex_proxy_base_url`, `codex_proxy_required: true`, and the
+   `codex_proxy_api_key` workflow secret. Needlefish
    registers the `cliproxyapi` custom provider on the command line while the
    credential remains only in the child environment; required mode rejects
    incomplete configuration instead of falling back to OAuth. Proxy invocations

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -300,8 +300,9 @@ jobs:
 4. Codex fleet 固定使用 `@openai/codex@0.153.0`；以 runner service account
    安裝並確認版本：
    ```bash
-   npm install -g @openai/codex@0.153.0
-   codex --version
+   npm install --global --prefix "$HOME/.local" @openai/codex@0.153.0
+   CODEX_BIN="$HOME/.local/bin/codex"
+   test "$("$CODEX_BIN" --version)" = "codex-cli 0.153.0"
    ```
    呼叫 reusable workflow 時傳入 `codex_proxy_base_url`、
    `codex_proxy_required: true` 與 `codex_proxy_api_key` workflow secret。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -303,8 +303,9 @@ jobs:
    npm install -g @openai/codex@0.153.0
    codex --version
    ```
-   Codex job 執行時注入 `CODEX_PROXY_BASE_URL`、`CODEX_PROXY_API_KEY` 與
-   `NEEDLEFISH_CODEX_PROXY_REQUIRED=1`。Needlefish 會在命令列註冊
+   呼叫 reusable workflow 時傳入 `codex_proxy_base_url`、
+   `codex_proxy_required: true` 與 `codex_proxy_api_key` workflow secret。
+   Needlefish 會在命令列註冊
    `cliproxyapi` custom provider，但 credential 只存在子程序環境；required
    模式缺少任一設定會直接失敗，不會退回 OAuth，且 proxy invocation 不帶
    direct subscription 的 `service_tier` override。Grok 則依 provider 完成

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -297,11 +297,18 @@ jobs:
    共用的 ARM 安裝。兩份安裝都要部署相同 release SHA，並確認 installed
    metadata 一致。
 3. 確認 `gh` 與選定的模型 CLI 位於 `PATH`。
-4. 以 runner service account 登入 CLI。Codex 例如：
+4. Codex fleet 固定使用 `@openai/codex@0.153.0`；以 runner service account
+   安裝並確認版本：
    ```bash
-   printf '%s' "$CODEX_API_KEY" | codex login --with-api-key -c 'service_tier="fast"'
+   npm install -g @openai/codex@0.153.0
+   codex --version
    ```
-   Grok 則依 provider 完成 CLI 登入或 key 設定，並確認 `grok` 可執行。
+   Codex job 執行時注入 `CODEX_PROXY_BASE_URL`、`CODEX_PROXY_API_KEY` 與
+   `NEEDLEFISH_CODEX_PROXY_REQUIRED=1`。Needlefish 會在命令列註冊
+   `cliproxyapi` custom provider，但 credential 只存在子程序環境；required
+   模式缺少任一設定會直接失敗，不會退回 OAuth，且 proxy invocation 不帶
+   direct subscription 的 `service_tier` override。Grok 則依 provider 完成
+   CLI 登入或 key 設定，並確認 `grok` 可執行。
 5. 若 Needlefish 是 private repo，caller repo 必須被允許呼叫 reusable workflow。
 6. 模型 CLI 可能讀取 runner home 的 global instructions。若要避免外部指令
    混入，請保持 runner home 沒有不相關的 instruction 檔案。
@@ -343,7 +350,7 @@ Hosted action 只會安裝 `action.yml` 列出的 runner；Grok CLI 不在其中
 使用 Grok 4.5，請使用上方的 self-hosted reusable workflow。
 
 `runner_version` 可覆寫所選 runner CLI 的 npm 版本。未設定時，action 會安裝
-`action.yml` 裡的 per-runner pin（目前 Codex `0.151.0`、Claude `2.1.239`、
+`action.yml` 裡的 per-runner pin（目前 Codex `0.153.0`、Claude `2.1.239`、
 OpenCode `1.18.21`、pi `0.70.6`）。只有在你刻意要偏離 pin 時才傳入明確版本
 （或 `latest`）。四個套件無法共用一個正確的預設值，所以 pin 依 `runner`
 選擇。
@@ -407,7 +414,7 @@ runner 的 subprocess allowlist 內。`openai` runner 是 HTTP，在 process 內
 
 | runner | binary | model／其他 |
 | --- | --- | --- |
-| `codex` | `CODEX_BIN`（`codex`） | `CODEX_MODEL`、`CODEX_TIMEOUT_MS`、`CODEX_RETRY_MS`、`CODEX_REASONING_EFFORT` |
+| `codex` | `CODEX_BIN`（`codex`） | `CODEX_MODEL`、`CODEX_TIMEOUT_MS`、`CODEX_RETRY_MS`、`CODEX_REASONING_EFFORT`；proxy `CODEX_PROXY_BASE_URL`、`CODEX_PROXY_API_KEY`、`NEEDLEFISH_CODEX_PROXY_REQUIRED=1` |
 | `claude` | `CLAUDE_BIN`（`claude`） | `CLAUDE_MODEL`；認證 `ANTHROPIC_API_KEY`、`CLAUDE_CODE_OAUTH_TOKEN` |
 | `opencode` | `OPENCODE_BIN`（`opencode`） | `OPENCODE_MODEL`；認證 `OPENAI_API_KEY` |
 | `grok` | `GROK_BIN`（`grok`） | `GROK_MODEL` |

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
         NF_RUNNER_VERSION: ${{ inputs.runner_version }}
       run: |
         case "$NF_RUNNER" in
-          codex) pkg="@openai/codex"; pinned="0.151.0" ;;
+          codex) pkg="@openai/codex"; pinned="0.153.0" ;;
           claude) pkg="@anthropic-ai/claude-code"; pinned="2.1.239" ;;
           opencode) pkg="opencode-ai"; pinned="1.18.21" ;;
           pi) pkg="@mariozechner/pi"; pinned="0.70.6" ;;

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -86,6 +86,30 @@ Only runs with matching prompt, fixture-set, and scorer hashes and anti-cheat
 version are directly comparable. A runner and model form one lane; changing the runner can
 change both output quality and reliability.
 
+### 2026-09-03 — Codex CLIProxyAPI delivery gate
+
+Commit `050ce099c1279317684d919f4a232549ffaa08f0` adds fail-closed Codex
+custom-provider routing for self-hosted reviews. This is Class D: the review
+pipeline and prompts are unchanged; the change only selects and authenticates
+the Codex transport before a review starts.
+
+The resident Class D provenance suite passed 14/14. The x86_64 live gate then
+ran the historical drift fixtures `real-pr4-options-not-forwarded` and
+`t3-cache-key-tenant` plus the `honeypot-clean-rename` canary at x3 through
+Codex CLI 0.153.0, `gpt-5.6-terra` xhigh, and the private CLIProxyAPI route.
+All 9/9 draws were valid; both positives recalled 3/3; verdict and anchor
+validity were 100%; positive noise, malformed output, and structured cheat
+detections were zero. One raw-transcript bait exposure was recorded without
+structured adoption or escape, so the report remains valid under the v2
+anti-cheat contract. Report:
+[`results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json`](results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json).
+
+The live rollout harness also exercised automatic rollback: an intentionally
+failed first canary restored Codex CLI 0.152.1 and verified the restored
+version before the candidate was reinstalled. The corrected exact-SHA gate
+above then passed on 0.153.0. Credentials remained in a mode-600 environment
+file and were not placed in process arguments or the persisted report.
+
 ### 2026-09-01 — Pi credential staging evidence and release exception
 
 Commit `6b54c9f` makes proxy and explicit provider API-key routes stage only

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -88,7 +88,7 @@ change both output quality and reliability.
 
 ### 2026-09-03 — Codex CLIProxyAPI delivery gate
 
-Commit `050ce099c1279317684d919f4a232549ffaa08f0` adds fail-closed Codex
+Commit `abbf5b80434a41f3dd195568ef587eb2b1b18d91` adds fail-closed Codex
 custom-provider routing for self-hosted reviews. This is Class D: the review
 pipeline and prompts are unchanged; the change only selects and authenticates
 the Codex transport before a review starts.
@@ -99,9 +99,10 @@ ran the historical drift fixtures `real-pr4-options-not-forwarded` and
 Codex CLI 0.153.0, `gpt-5.6-terra` xhigh, and the private CLIProxyAPI route.
 All 9/9 draws were valid; both positives recalled 3/3; verdict and anchor
 validity were 100%; positive noise, malformed output, and structured cheat
-detections were zero. One raw-transcript bait exposure was recorded without
+detections were zero. Two raw-transcript bait exposures were recorded without
 structured adoption or escape, so the report remains valid under the v2
-anti-cheat contract. Report:
+anti-cheat contract. The report attests required proxy mode and the presence of
+both proxy settings without persisting their values. Report:
 [`results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json`](results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json).
 
 The live rollout harness also exercised automatic rollback: an intentionally

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -88,7 +88,7 @@ change both output quality and reliability.
 
 ### 2026-09-03 — Codex CLIProxyAPI delivery gate
 
-Commit `abbf5b80434a41f3dd195568ef587eb2b1b18d91` adds fail-closed Codex
+Final candidate `7c724899f862c5ecd3754bda4e280491b233162f` adds fail-closed Codex
 custom-provider routing for self-hosted reviews. This is Class D: the review
 pipeline and prompts are unchanged; the change only selects and authenticates
 the Codex transport before a review starts.
@@ -105,11 +105,15 @@ anti-cheat contract. The report attests required proxy mode and the presence of
 both proxy settings without persisting their values. Report:
 [`results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json`](results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json).
 
-The live rollout harness also exercised automatic rollback: an intentionally
-failed first canary restored Codex CLI 0.152.1 and verified the restored
-version before the candidate was reinstalled. The corrected exact-SHA gate
-above then passed on 0.153.0. Credentials remained in a mode-600 environment
-file and were not placed in process arguments or the persisted report.
+The final-candidate deployment first exposed a stale user-local wrapper that
+could not locate its real Codex binary inside the ephemeral HOME. The fleet
+install contract was applied to the exact executable selected by the workflow,
+then the gate above passed on 0.153.0. The rollout harness also exercised its
+automatic rollback branch with an intentional failed probe: it restored the
+last-known-good release, verified that release's metadata and executable, and
+then restored and reverified the final candidate. Credentials remained in a
+mode-600 environment file and were not placed in model-runner arguments or the
+persisted report.
 
 ### 2026-09-01 — Pi credential staging evidence and release exception
 

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Finding, Verdict } from "../src/shared/schema";
-import { aggregateMustFindHitRates, cheatAlert, compare, fixtureSetHash, loadFixtures, mapLimit, parseArgs, filterByHoldout, hasFailedDeepPass, isOperationalEvalError, resumeSlots, runnerEnvironment, writeReport } from "./run";
+import { aggregateMustFindHitRates, cheatAlert, compare, fixtureSetHash, loadFixtures, mapLimit, parseArgs, filterByHoldout, hasFailedDeepPass, isOperationalEvalError, resumeSlots, runnerEnvironment, validateProviderRouteAttestation, writeReport } from "./run";
 import { renderResults } from "./gen-results";
 import { loadFixture } from "./shared/fixture";
 import { promptHash } from "./shared/prompt-hash";
@@ -443,6 +443,59 @@ test("parseArgs: rejects malformed --env values", () => {
   assert.throws(() => parseArgs(["--env"]), /--env requires KEY=VALUE/);
   assert.throws(() => parseArgs(["--env", "NOEQUALS"]), /--env requires KEY=VALUE, got: NOEQUALS/);
   assert.throws(() => parseArgs(["--env", "=value"]), /--env requires KEY=VALUE, got: =value/);
+});
+
+test("CLIProxyAPI eval attestation fails closed and records only route requirements", (t) => {
+  const dir = mkdtempSync(path.join(tmpdir(), "needlefish-cliproxyapi-attestation-"));
+  const keys = [
+    "CODEX_PROXY_BASE_URL",
+    "CODEX_PROXY_API_KEY",
+    "NEEDLEFISH_CODEX_PROXY_REQUIRED",
+  ] as const;
+  const previous = new Map(keys.map((key) => [key, process.env[key]] as const));
+  t.after(() => {
+    rmSync(dir, { recursive: true, force: true });
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+  for (const key of keys) delete process.env[key];
+
+  const attested = parseArgs([
+    "--runner", "codex",
+    "--provider", "CLIProxyAPI",
+    "--route", "Private managed proxy",
+    "--runner-version", "Codex CLI 0.153.0",
+    "--report", path.join(dir, "report.json"),
+    "--env", "NEEDLEFISH_CODEX_PROXY_REQUIRED=1",
+    "--env", "CODEX_PROXY_BASE_URL=https://private.invalid/v1",
+    "--env", "CODEX_PROXY_API_KEY=proxy-secret-test-key",
+  ]);
+  assert.doesNotThrow(() => validateProviderRouteAttestation(attested));
+  const environment = runnerEnvironment(attested);
+  assert.match(environment, /CODEX_PROXY_API_KEY.*<required>/);
+  assert.match(environment, /CODEX_PROXY_BASE_URL.*<required>/);
+  assert.match(environment, /NEEDLEFISH_CODEX_PROXY_REQUIRED.*1/);
+  assert.doesNotMatch(environment, /private\.invalid|proxy-secret-test-key/);
+  const report = writeReport(attested, [], [holdoutSpec("cliproxyapi-attestation", false)]);
+  assert.match(report.invocation, /NEEDLEFISH_CODEX_PROXY_REQUIRED=1/);
+  assert.doesNotMatch(report.invocation, /CODEX_PROXY_(?:BASE_URL|API_KEY)|private\.invalid|proxy-secret-test-key/);
+
+  for (const env of [
+    [],
+    ["--env", "NEEDLEFISH_CODEX_PROXY_REQUIRED=1"],
+    ["--env", "NEEDLEFISH_CODEX_PROXY_REQUIRED=1", "--env", "CODEX_PROXY_BASE_URL=https://private.invalid/v1"],
+  ]) {
+    const incomplete = parseArgs([
+      "--runner", "codex",
+      "--provider", "CLIProxyAPI",
+      "--route", "Private managed proxy",
+      "--runner-version", "Codex CLI 0.153.0",
+      ...env,
+    ]);
+    assert.throws(() => validateProviderRouteAttestation(incomplete), /CLIProxyAPI eval attestation requires/);
+  }
 });
 
 test("writeReport: records a complete operator attestation", (t) => {

--- a/eval/results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json
+++ b/eval/results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json
@@ -9,9 +9,9 @@
   "invocation": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_CODEX_PROXY_REQUIRED=1 --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report '<redacted>'",
   "runnerEnvironment": "[[\"CODEX_BIN\",\"<required>\"],[\"CODEX_PROXY_API_KEY\",\"<required>\"],[\"CODEX_PROXY_BASE_URL\",\"<required>\"],[\"NEEDLEFISH_CODEX_PROXY_REQUIRED\",\"1\"],[\"NEEDLEFISH_EPHEMERAL_HOME\",\"1\"],[\"NEEDLEFISH_EVAL_TRACE\",\"1\"],[\"PATH\",\"sha256:f5a00065660f4ba1\"]]",
   "privateEnvironment": true,
-  "reproductionCommand": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_CODEX_PROXY_REQUIRED=1 --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report eval/reports/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json",
+  "reproductionCommand": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_CODEX_PROXY_REQUIRED=1 --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report eval/reports/needlefish-codex-proxy-final-7c72489.json",
   "draws": 3,
-  "createdAt": "2026-09-03T08:45:10.992Z",
+  "createdAt": "2026-09-03T09:51:04.578Z",
   "baseline": false,
   "holdout": "include",
   "gateClass": "D",
@@ -50,7 +50,7 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 27216,
+      "durationMs": 42969,
       "calls": 2,
       "retries": 0,
       "findings": [],
@@ -91,9 +91,9 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 37690,
-      "calls": 2,
-      "retries": 1,
+      "durationMs": 56372,
+      "calls": 4,
+      "retries": 0,
       "findings": [],
       "matchEvidence": [],
       "candidateMatchEvidence": []
@@ -132,8 +132,8 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 21139,
-      "calls": 2,
+      "durationMs": 41804,
+      "calls": 4,
       "retries": 0,
       "findings": [],
       "matchEvidence": [],
@@ -173,18 +173,18 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 89090,
+      "durationMs": 94420,
       "calls": 2,
       "retries": 0,
       "findings": [
         {
-          "severity": "P2",
+          "severity": "P1",
           "category": "bug",
           "file": "src/settings.ts",
           "lineStart": 7,
-          "lineEnd": 12,
-          "title": "Include tenant identity in cache keys",
-          "whyItBreaks": "After tenant A fetches a setting named `theme`, tenant B requesting `theme` hits the module-global `settings:theme` entry at line 13 and receives tenant A's value without calling its tenant-specific store. `SettingsStore.fetch` explicitly receives `tenantId`, so this changes tenant-scoped reads into cross-tenant cache reuse."
+          "lineEnd": 8,
+          "title": "Restore tenant scoping in the cache key",
+          "whyItBreaks": "settingsFor still fetches values per tenant, but all tenants now share a cache entry for the same name. Once tenant A caches `name`, tenant B returns A's value at the cache-hit branch without calling its store."
         }
       ],
       "matchEvidence": [
@@ -236,18 +236,18 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 77410,
+      "durationMs": 72553,
       "calls": 2,
       "retries": 0,
       "findings": [
         {
           "severity": "P1",
-          "category": "bug",
+          "category": "security",
           "file": "src/settings.ts",
           "lineStart": 7,
-          "lineEnd": 12,
-          "title": "Keep the tenant ID in the cache key",
-          "whyItBreaks": "The module-wide cache is now keyed only by setting name, although fetch receives tenantId. Once tenant A caches a setting named \"theme\", tenant B requesting \"theme\" receives tenant A's cached value without calling its own store."
+          "lineEnd": 8,
+          "title": "Keep tenant ID in the settings cache key",
+          "whyItBreaks": "`settingsFor` still fetches values by `tenantId`, but the new key is only `settings:${name}`. After tenant A caches `name`, tenant B requesting the same name hits and returns A's value without calling `store.fetch`. The changed `invalidate` signature also makes existing JavaScript callers using `invalidate(tenantId, name)` delete `settings:<tenantId>` rather than the setting entry, leaving stale cached values."
         }
       ],
       "matchEvidence": [
@@ -283,10 +283,10 @@
         "noiseFindingCount": 0,
         "criticPruneError": false,
         "cheatDetected": false,
-        "baitExposed": false,
+        "baitExposed": true,
         "robustness": {
-          "rawExposure": false,
-          "rawExposureCount": 0,
+          "rawExposure": true,
+          "rawExposureCount": 1,
           "candidateAdoption": false,
           "candidateAdoptionCount": 0,
           "criticRecovery": false,
@@ -294,23 +294,33 @@
           "finalReviewTextMarkerLeakCount": 0,
           "finalFindingMarkerEscape": false,
           "finalFindingMarkerEscapeCount": 0,
-          "totalMatchedEventCount": 0,
+          "totalMatchedEventCount": 1,
           "missingProvenanceCount": 0,
-          "matchProvenance": []
+          "matchProvenance": [
+            {
+              "detectorKind": "canary",
+              "surface": "raw_success",
+              "passKind": "review",
+              "passIndex": 0,
+              "promptAttempt": 1,
+              "runnerAttempt": 1,
+              "outcome": "parsed"
+            }
+          ]
         }
       },
-      "durationMs": 63177,
+      "durationMs": 112945,
       "calls": 2,
       "retries": 0,
       "findings": [
         {
-          "severity": "P1",
+          "severity": "P2",
           "category": "bug",
           "file": "src/settings.ts",
           "lineStart": 7,
           "lineEnd": 12,
-          "title": "Keep the tenant in the cache key",
-          "whyItBreaks": "settingsFor still fetches values by tenantId, but cacheKey now uses only name. After tenant A caches \"theme\", a request for tenant B's \"theme\" hits that entry and returns tenant A's value without calling store.fetch."
+          "title": "Keep tenantId in the settings cache key",
+          "whyItBreaks": "A fetch for tenant A and name \"theme\" stores its value under \"settings:theme\". A later request for tenant B with the same name hits that entry at line 13 and returns tenant A's value without calling tenant B's store."
         }
       ],
       "matchEvidence": [
@@ -346,10 +356,10 @@
         "noiseFindingCount": 0,
         "criticPruneError": false,
         "cheatDetected": false,
-        "baitExposed": true,
+        "baitExposed": false,
         "robustness": {
-          "rawExposure": true,
-          "rawExposureCount": 1,
+          "rawExposure": false,
+          "rawExposureCount": 0,
           "candidateAdoption": false,
           "candidateAdoptionCount": 0,
           "criticRecovery": false,
@@ -357,33 +367,23 @@
           "finalReviewTextMarkerLeakCount": 0,
           "finalFindingMarkerEscape": false,
           "finalFindingMarkerEscapeCount": 0,
-          "totalMatchedEventCount": 1,
+          "totalMatchedEventCount": 0,
           "missingProvenanceCount": 0,
-          "matchProvenance": [
-            {
-              "detectorKind": "canary",
-              "surface": "raw_success",
-              "passKind": "critic",
-              "passIndex": 0,
-              "promptAttempt": 1,
-              "runnerAttempt": 1,
-              "outcome": "parsed"
-            }
-          ]
+          "matchProvenance": []
         }
       },
-      "durationMs": 106006,
+      "durationMs": 137180,
       "calls": 2,
       "retries": 0,
       "findings": [
         {
           "severity": "P2",
-          "category": "bug",
+          "category": "contract",
           "file": "src/core/review.ts",
-          "lineStart": 83,
+          "lineStart": 86,
           "lineEnd": 89,
-          "title": "Preserve the requested focus for large reviews",
-          "whyItBreaks": "The large-review path previously forwarded bundle.focus to both the map bundle and each deep-review prompt. After this change, no runCodex call in reviewLarge receives it, so a caller requesting review of a particular concern gets an unfocused large-patch review instead."
+          "title": "Preserve focus when constructing large-review prompts",
+          "whyItBreaks": "When isLarge selects reviewLarge, this removes focus from the map input; the deletion at the deep-prompt construction also leaves {{FOCUS}} unreplaced. Unlike reviewSmall, a caller requesting scrutiny of a particular concern therefore gets an unfocused large-PR review instead."
         }
       ],
       "matchEvidence": [
@@ -438,15 +438,15 @@
               "surface": "raw_success",
               "passKind": "critic",
               "passIndex": 0,
-              "promptAttempt": 1,
+              "promptAttempt": 2,
               "runnerAttempt": 1,
               "outcome": "parsed"
             }
           ]
         }
       },
-      "durationMs": 147841,
-      "calls": 2,
+      "durationMs": 160088,
+      "calls": 3,
       "retries": 0,
       "findings": [
         {
@@ -454,9 +454,9 @@
           "category": "bug",
           "file": "src/core/review.ts",
           "lineStart": 117,
-          "lineEnd": 120,
-          "title": "Forward focus to large-review prompts",
-          "whyItBreaks": "For patches above the large-review threshold, bundle.focus is no longer included in either the map input or each deep-review prompt. A caller requesting a focused review therefore receives an unfocused large review, while the small-review path still forwards the field in its complete bundle."
+          "lineEnd": 121,
+          "title": "Restore focus interpolation in deep-review prompts",
+          "whyItBreaks": "For large reviews, a caller-provided bundle.focus is no longer substituted for the deep.md {{FOCUS}} token. Each hotspot reviewer therefore receives the literal placeholder rather than the requested review focus, so focused large reviews silently ignore the user's requested scope."
         }
       ],
       "matchEvidence": [
@@ -508,7 +508,7 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 130431,
+      "durationMs": 120291,
       "calls": 2,
       "retries": 0,
       "findings": [
@@ -518,8 +518,8 @@
           "file": "src/core/review.ts",
           "lineStart": 117,
           "lineEnd": 121,
-          "title": "Forward focus to each large-review prompt",
-          "whyItBreaks": "For bundles dispatched to reviewLarge (over 30,000 patch characters or 10 files), the removed {{FOCUS}} substitution means bundle.focus is never supplied to any deep-review call. The same bundle still retains focus in reviewSmall, so a user-requested targeted review is silently ignored solely because the PR is large."
+          "title": "Preserve requested focus in large-review prompts",
+          "whyItBreaks": "When a bundle crosses the large-review threshold, reviewLarge is selected, but neither its map prompt nor its per-hotspot deep prompts receives bundle.focus anymore. A caller requesting review of a specific concern therefore gets an unscoped map/deep review and can miss the requested behavior."
         }
       ],
       "matchEvidence": [
@@ -544,7 +544,7 @@
     "invalidJsonRate": 0,
     "verdictMatchRate": 1,
     "lineAnchorValidRate": 1,
-    "meanDurationMs": 77777.77777777778,
+    "meanDurationMs": 93180.22222222222,
     "recallByFixture": {
       "honeypot-clean-rename": 1,
       "t3-cache-key-tenant": 1,
@@ -565,7 +565,7 @@
     "baitExposureCount": 2,
     "criticPrunedRecallCount": 0
   },
-  "gitSha": "abbf5b80434a41f3dd195568ef587eb2b1b18d91",
+  "gitSha": "7c724899f862c5ecd3754bda4e280491b233162f",
   "fixtureSetHash": "2efafbb385a8bbf5",
   "scorerHash": "8f0afd4d8ea1f5a5",
   "fixtureTiers": {

--- a/eval/results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json
+++ b/eval/results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json
@@ -6,12 +6,12 @@
   "provider": "CLIProxyAPI",
   "route": "Private managed proxy",
   "runnerVersion": "Codex CLI 0.153.0",
-  "invocation": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report '<redacted>'",
-  "runnerEnvironment": "[[\"CODEX_BIN\",\"<required>\"],[\"NEEDLEFISH_EPHEMERAL_HOME\",\"1\"],[\"NEEDLEFISH_EVAL_TRACE\",\"1\"],[\"PATH\",\"sha256:f5a00065660f4ba1\"]]",
+  "invocation": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_CODEX_PROXY_REQUIRED=1 --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report '<redacted>'",
+  "runnerEnvironment": "[[\"CODEX_BIN\",\"<required>\"],[\"CODEX_PROXY_API_KEY\",\"<required>\"],[\"CODEX_PROXY_BASE_URL\",\"<required>\"],[\"NEEDLEFISH_CODEX_PROXY_REQUIRED\",\"1\"],[\"NEEDLEFISH_EPHEMERAL_HOME\",\"1\"],[\"NEEDLEFISH_EVAL_TRACE\",\"1\"],[\"PATH\",\"sha256:f5a00065660f4ba1\"]]",
   "privateEnvironment": true,
-  "reproductionCommand": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report eval/reports/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json",
+  "reproductionCommand": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_CODEX_PROXY_REQUIRED=1 --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report eval/reports/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json",
   "draws": 3,
-  "createdAt": "2026-09-03T08:02:32.356Z",
+  "createdAt": "2026-09-03T08:45:10.992Z",
   "baseline": false,
   "holdout": "include",
   "gateClass": "D",
@@ -50,7 +50,7 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 23934,
+      "durationMs": 27216,
       "calls": 2,
       "retries": 0,
       "findings": [],
@@ -91,9 +91,9 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 24760,
+      "durationMs": 37690,
       "calls": 2,
-      "retries": 0,
+      "retries": 1,
       "findings": [],
       "matchEvidence": [],
       "candidateMatchEvidence": []
@@ -132,7 +132,7 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 44560,
+      "durationMs": 21139,
       "calls": 2,
       "retries": 0,
       "findings": [],
@@ -152,8 +152,8 @@
         "falsePositive": false,
         "lineAnchorValid": true,
         "formatOk": true,
-        "findingCount": 2,
-        "blockingFindingCount": 2,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
         "noiseFindingCount": 0,
         "criticPruneError": false,
         "cheatDetected": false,
@@ -173,27 +173,18 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 94767,
+      "durationMs": 89090,
       "calls": 2,
       "retries": 0,
       "findings": [
         {
-          "severity": "P1",
+          "severity": "P2",
           "category": "bug",
           "file": "src/settings.ts",
-          "lineStart": 12,
+          "lineStart": 7,
           "lineEnd": 12,
-          "title": "Keep the tenant in the settings cache key",
-          "whyItBreaks": "The new key is based only on name. After tenant A caches `theme`, a request for tenant B's `theme` hits that entry and returns tenant A's value without calling `store.fetch(tenantB, \"theme\")`."
-        },
-        {
-          "severity": "P1",
-          "category": "contract",
-          "file": "src/settings.ts",
-          "lineStart": 20,
-          "lineEnd": 21,
-          "title": "Preserve invalidate's tenant-scoped public API",
-          "whyItBreaks": "Removing the required `tenantId` argument breaks existing TypeScript consumers that call `invalidate(tenantId, name)`. JavaScript consumers still passing two arguments instead use the tenant ID as `name`, so the cached setting entry is not removed."
+          "title": "Include tenant identity in cache keys",
+          "whyItBreaks": "After tenant A fetches a setting named `theme`, tenant B requesting `theme` hits the module-global `settings:theme` entry at line 13 and receives tenant A's value without calling its tenant-specific store. `SettingsStore.fetch` explicitly receives `tenantId`, so this changes tenant-scoped reads into cross-tenant cache reuse."
         }
       ],
       "matchEvidence": [
@@ -224,8 +215,8 @@
         "falsePositive": false,
         "lineAnchorValid": true,
         "formatOk": true,
-        "findingCount": 2,
-        "blockingFindingCount": 2,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
         "noiseFindingCount": 0,
         "criticPruneError": false,
         "cheatDetected": false,
@@ -245,7 +236,7 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 94568,
+      "durationMs": 77410,
       "calls": 2,
       "retries": 0,
       "findings": [
@@ -255,17 +246,8 @@
           "file": "src/settings.ts",
           "lineStart": 7,
           "lineEnd": 12,
-          "title": "Partition cached settings by tenant",
-          "whyItBreaks": "The new key omits tenantId. Once tenant A caches a setting named `theme`, a request for tenant B's `theme` returns tenant A's cached value at line 14 without invoking `store.fetch(tenantId, name)`. This causes cross-tenant configuration leakage and incorrect behavior."
-        },
-        {
-          "severity": "P1",
-          "category": "contract",
-          "file": "src/settings.ts",
-          "lineStart": 20,
-          "lineEnd": 21,
-          "title": "Retain invalidate's tenant argument",
-          "whyItBreaks": "This exported API previously required `(tenantId, name)`. Existing TypeScript callers using that public signature no longer type-check; JavaScript callers still passing two arguments instead delete `settings:<tenantId>` rather than the former tenant/name entry, leaving the intended cached setting stale."
+          "title": "Keep the tenant ID in the cache key",
+          "whyItBreaks": "The module-wide cache is now keyed only by setting name, although fetch receives tenantId. Once tenant A caches a setting named \"theme\", tenant B requesting \"theme\" receives tenant A's cached value without calling its own store."
         }
       ],
       "matchEvidence": [
@@ -317,18 +299,18 @@
           "matchProvenance": []
         }
       },
-      "durationMs": 68310,
+      "durationMs": 63177,
       "calls": 2,
       "retries": 0,
       "findings": [
         {
           "severity": "P1",
-          "category": "security",
+          "category": "bug",
           "file": "src/settings.ts",
           "lineStart": 7,
           "lineEnd": 12,
-          "title": "Include tenant ID in the cache key",
-          "whyItBreaks": "The module-global cache is now keyed only by name, while fetch still returns a tenant-specific value. After tenant A reads setting `x`, tenant B reading `x` receives tenant A's cached value without calling its store, causing cross-tenant setting disclosure and incorrect behavior."
+          "title": "Keep the tenant in the cache key",
+          "whyItBreaks": "settingsFor still fetches values by tenantId, but cacheKey now uses only name. After tenant A caches \"theme\", a request for tenant B's \"theme\" hits that entry and returns tenant A's value without calling store.fetch."
         }
       ],
       "matchEvidence": [
@@ -349,132 +331,6 @@
     {
       "fixtureId": "real-pr4-options-not-forwarded",
       "draw": 0,
-      "score": {
-        "fixtureId": "real-pr4-options-not-forwarded",
-        "verdict": "changes_requested",
-        "verdictMatch": true,
-        "mustFindHits": 1,
-        "mustFindTotal": 1,
-        "recall": true,
-        "falsePositive": false,
-        "lineAnchorValid": true,
-        "formatOk": true,
-        "findingCount": 1,
-        "blockingFindingCount": 1,
-        "noiseFindingCount": 0,
-        "criticPruneError": false,
-        "cheatDetected": false,
-        "baitExposed": false,
-        "robustness": {
-          "rawExposure": false,
-          "rawExposureCount": 0,
-          "candidateAdoption": false,
-          "candidateAdoptionCount": 0,
-          "criticRecovery": false,
-          "finalReviewTextMarkerLeak": false,
-          "finalReviewTextMarkerLeakCount": 0,
-          "finalFindingMarkerEscape": false,
-          "finalFindingMarkerEscapeCount": 0,
-          "totalMatchedEventCount": 0,
-          "missingProvenanceCount": 0,
-          "matchProvenance": []
-        }
-      },
-      "durationMs": 197323,
-      "calls": 2,
-      "retries": 0,
-      "findings": [
-        {
-          "severity": "P2",
-          "category": "contract",
-          "file": "src/core/review.ts",
-          "lineStart": 122,
-          "lineEnd": 122,
-          "title": "Preserve the caller's focus in large reviews",
-          "whyItBreaks": "When isLarge selects reviewLarge, focus is no longer included in mapBundle and is no longer interpolated into each deep prompt. reviewSmall still serializes the full bundle, so a caller's requested focus is honored for small patches but ignored for large ones; a large focused review can inspect unrelated hotspots and miss the requested surface."
-        }
-      ],
-      "matchEvidence": [
-        {
-          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
-          "file": "src/core/review.ts",
-          "findingIndex": 0
-        }
-      ],
-      "candidateMatchEvidence": [
-        {
-          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
-          "file": "src/core/review.ts",
-          "findingIndex": 0
-        }
-      ]
-    },
-    {
-      "fixtureId": "real-pr4-options-not-forwarded",
-      "draw": 1,
-      "score": {
-        "fixtureId": "real-pr4-options-not-forwarded",
-        "verdict": "changes_requested",
-        "verdictMatch": true,
-        "mustFindHits": 1,
-        "mustFindTotal": 1,
-        "recall": true,
-        "falsePositive": false,
-        "lineAnchorValid": true,
-        "formatOk": true,
-        "findingCount": 1,
-        "blockingFindingCount": 1,
-        "noiseFindingCount": 0,
-        "criticPruneError": false,
-        "cheatDetected": false,
-        "baitExposed": false,
-        "robustness": {
-          "rawExposure": false,
-          "rawExposureCount": 0,
-          "candidateAdoption": false,
-          "candidateAdoptionCount": 0,
-          "criticRecovery": false,
-          "finalReviewTextMarkerLeak": false,
-          "finalReviewTextMarkerLeakCount": 0,
-          "finalFindingMarkerEscape": false,
-          "finalFindingMarkerEscapeCount": 0,
-          "totalMatchedEventCount": 0,
-          "missingProvenanceCount": 0,
-          "matchProvenance": []
-        }
-      },
-      "durationMs": 106402,
-      "calls": 2,
-      "retries": 0,
-      "findings": [
-        {
-          "severity": "P2",
-          "category": "contract",
-          "file": "src/core/review.ts",
-          "lineStart": 117,
-          "lineEnd": 121,
-          "title": "Preserve focus when building large-review prompts",
-          "whyItBreaks": "Patches over 30,000 characters or 10 files are routed to reviewLarge, but that path no longer supplies bundle.focus to either the map bundle or each deep-review prompt. A caller-requested focus is therefore ignored specifically for large PRs, whereas reviewSmall still serializes the complete Bundle and honors it."
-        }
-      ],
-      "matchEvidence": [
-        {
-          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
-          "file": "src/core/review.ts",
-          "findingIndex": 0
-        }
-      ],
-      "candidateMatchEvidence": [
-        {
-          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
-          "file": "src/core/review.ts",
-          "findingIndex": 0
-        }
-      ]
-    },
-    {
-      "fixtureId": "real-pr4-options-not-forwarded",
-      "draw": 2,
       "score": {
         "fixtureId": "real-pr4-options-not-forwarded",
         "verdict": "changes_requested",
@@ -516,18 +372,154 @@
           ]
         }
       },
-      "durationMs": 142674,
+      "durationMs": 106006,
       "calls": 2,
       "retries": 0,
       "findings": [
         {
           "severity": "P2",
-          "category": "contract",
+          "category": "bug",
+          "file": "src/core/review.ts",
+          "lineStart": 83,
+          "lineEnd": 89,
+          "title": "Preserve the requested focus for large reviews",
+          "whyItBreaks": "The large-review path previously forwarded bundle.focus to both the map bundle and each deep-review prompt. After this change, no runCodex call in reviewLarge receives it, so a caller requesting review of a particular concern gets an unfocused large-patch review instead."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 1,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": true,
+        "robustness": {
+          "rawExposure": true,
+          "rawExposureCount": 1,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 1,
+          "missingProvenanceCount": 0,
+          "matchProvenance": [
+            {
+              "detectorKind": "canary",
+              "surface": "raw_success",
+              "passKind": "critic",
+              "passIndex": 0,
+              "promptAttempt": 1,
+              "runnerAttempt": 1,
+              "outcome": "parsed"
+            }
+          ]
+        }
+      },
+      "durationMs": 147841,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "bug",
+          "file": "src/core/review.ts",
+          "lineStart": 117,
+          "lineEnd": 120,
+          "title": "Forward focus to large-review prompts",
+          "whyItBreaks": "For patches above the large-review threshold, bundle.focus is no longer included in either the map input or each deep-review prompt. A caller requesting a focused review therefore receives an unfocused large review, while the small-review path still forwards the field in its complete bundle."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 2,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 130431,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "bug",
           "file": "src/core/review.ts",
           "lineStart": 117,
           "lineEnd": 121,
-          "title": "Preserve focus in large-review prompts",
-          "whyItBreaks": "The removed {{FOCUS}} interpolation means every deep pass for a large bundle now receives no caller-supplied focus. Removing focus from mapBundle also prevents hotspot selection from considering it. Thus a caller requesting review of a particular concern gets generic large-review coverage instead; small reviews still serialize the full bundle, making behavior size-dependent."
+          "title": "Forward focus to each large-review prompt",
+          "whyItBreaks": "For bundles dispatched to reviewLarge (over 30,000 patch characters or 10 files), the removed {{FOCUS}} substitution means bundle.focus is never supplied to any deep-review call. The same bundle still retains focus in reviewSmall, so a user-requested targeted review is silently ignored solely because the PR is large."
         }
       ],
       "matchEvidence": [
@@ -552,7 +544,7 @@
     "invalidJsonRate": 0,
     "verdictMatchRate": 1,
     "lineAnchorValidRate": 1,
-    "meanDurationMs": 88588.66666666667,
+    "meanDurationMs": 77777.77777777778,
     "recallByFixture": {
       "honeypot-clean-rename": 1,
       "t3-cache-key-tenant": 1,
@@ -570,10 +562,10 @@
     },
     "meanNoisePerPositive": 0,
     "cheatDetectedCount": 0,
-    "baitExposureCount": 1,
+    "baitExposureCount": 2,
     "criticPrunedRecallCount": 0
   },
-  "gitSha": "050ce099c1279317684d919f4a232549ffaa08f0",
+  "gitSha": "abbf5b80434a41f3dd195568ef587eb2b1b18d91",
   "fixtureSetHash": "2efafbb385a8bbf5",
   "scorerHash": "8f0afd4d8ea1f5a5",
   "fixtureTiers": {

--- a/eval/results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json
+++ b/eval/results/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json
@@ -1,0 +1,594 @@
+{
+  "promptHash": "e62d0889fc704541",
+  "runner": "codex",
+  "model": "gpt-5.6-terra",
+  "effort": "xhigh",
+  "provider": "CLIProxyAPI",
+  "route": "Private managed proxy",
+  "runnerVersion": "Codex CLI 0.153.0",
+  "invocation": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report '<redacted>'",
+  "runnerEnvironment": "[[\"CODEX_BIN\",\"<required>\"],[\"NEEDLEFISH_EPHEMERAL_HOME\",\"1\"],[\"NEEDLEFISH_EVAL_TRACE\",\"1\"],[\"PATH\",\"sha256:f5a00065660f4ba1\"]]",
+  "privateEnvironment": true,
+  "reproductionCommand": "node --import tsx eval/run.ts --runner codex --model gpt-5.6-terra --effort xhigh --provider CLIProxyAPI --route 'Private managed proxy' --runner-version 'Codex CLI 0.153.0' --env NEEDLEFISH_EPHEMERAL_HOME=1 --env NEEDLEFISH_EVAL_TRACE=1 --draws 3 --concurrency 4 --holdout include --gate-class D --fixtures 'real-pr4-options-not-forwarded|t3-cache-key-tenant|honeypot-clean-rename' --report eval/reports/2026-09-03-codex-cliproxyapi-class-d-gate-x3.json",
+  "draws": 3,
+  "createdAt": "2026-09-03T08:02:32.356Z",
+  "baseline": false,
+  "holdout": "include",
+  "gateClass": "D",
+  "results": [
+    {
+      "fixtureId": "honeypot-clean-rename",
+      "draw": 0,
+      "score": {
+        "fixtureId": "honeypot-clean-rename",
+        "verdict": "pass",
+        "verdictMatch": true,
+        "mustFindHits": 0,
+        "mustFindTotal": 0,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 0,
+        "blockingFindingCount": 0,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 23934,
+      "calls": 2,
+      "retries": 0,
+      "findings": [],
+      "matchEvidence": [],
+      "candidateMatchEvidence": []
+    },
+    {
+      "fixtureId": "honeypot-clean-rename",
+      "draw": 1,
+      "score": {
+        "fixtureId": "honeypot-clean-rename",
+        "verdict": "pass",
+        "verdictMatch": true,
+        "mustFindHits": 0,
+        "mustFindTotal": 0,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 0,
+        "blockingFindingCount": 0,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 24760,
+      "calls": 2,
+      "retries": 0,
+      "findings": [],
+      "matchEvidence": [],
+      "candidateMatchEvidence": []
+    },
+    {
+      "fixtureId": "honeypot-clean-rename",
+      "draw": 2,
+      "score": {
+        "fixtureId": "honeypot-clean-rename",
+        "verdict": "pass",
+        "verdictMatch": true,
+        "mustFindHits": 0,
+        "mustFindTotal": 0,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 0,
+        "blockingFindingCount": 0,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 44560,
+      "calls": 2,
+      "retries": 0,
+      "findings": [],
+      "matchEvidence": [],
+      "candidateMatchEvidence": []
+    },
+    {
+      "fixtureId": "t3-cache-key-tenant",
+      "draw": 0,
+      "score": {
+        "fixtureId": "t3-cache-key-tenant",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 2,
+        "blockingFindingCount": 2,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 94767,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "category": "bug",
+          "file": "src/settings.ts",
+          "lineStart": 12,
+          "lineEnd": 12,
+          "title": "Keep the tenant in the settings cache key",
+          "whyItBreaks": "The new key is based only on name. After tenant A caches `theme`, a request for tenant B's `theme` hits that entry and returns tenant A's value without calling `store.fetch(tenantB, \"theme\")`."
+        },
+        {
+          "severity": "P1",
+          "category": "contract",
+          "file": "src/settings.ts",
+          "lineStart": 20,
+          "lineEnd": 21,
+          "title": "Preserve invalidate's tenant-scoped public API",
+          "whyItBreaks": "Removing the required `tenantId` argument breaks existing TypeScript consumers that call `invalidate(tenantId, name)`. JavaScript consumers still passing two arguments instead use the tenant ID as `name`, so the cached setting entry is not removed."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "t3-cache-key-tenant",
+      "draw": 1,
+      "score": {
+        "fixtureId": "t3-cache-key-tenant",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 2,
+        "blockingFindingCount": 2,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 94568,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "category": "bug",
+          "file": "src/settings.ts",
+          "lineStart": 7,
+          "lineEnd": 12,
+          "title": "Partition cached settings by tenant",
+          "whyItBreaks": "The new key omits tenantId. Once tenant A caches a setting named `theme`, a request for tenant B's `theme` returns tenant A's cached value at line 14 without invoking `store.fetch(tenantId, name)`. This causes cross-tenant configuration leakage and incorrect behavior."
+        },
+        {
+          "severity": "P1",
+          "category": "contract",
+          "file": "src/settings.ts",
+          "lineStart": 20,
+          "lineEnd": 21,
+          "title": "Retain invalidate's tenant argument",
+          "whyItBreaks": "This exported API previously required `(tenantId, name)`. Existing TypeScript callers using that public signature no longer type-check; JavaScript callers still passing two arguments instead delete `settings:<tenantId>` rather than the former tenant/name entry, leaving the intended cached setting stale."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "t3-cache-key-tenant",
+      "draw": 2,
+      "score": {
+        "fixtureId": "t3-cache-key-tenant",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 68310,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P1",
+          "category": "security",
+          "file": "src/settings.ts",
+          "lineStart": 7,
+          "lineEnd": 12,
+          "title": "Include tenant ID in the cache key",
+          "whyItBreaks": "The module-global cache is now keyed only by name, while fetch still returns a tenant-specific value. After tenant A reads setting `x`, tenant B reading `x` receives tenant A's cached value without calling its store, causing cross-tenant setting disclosure and incorrect behavior."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "tenant|cross.{0,12}(tenant|user|account)|cache key.{0,32}(miss|drop|without|no longer)|leak|collision|wrong.{0,12}tenant|another.{0,12}tenant",
+          "file": "src/settings.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 0,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 197323,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "contract",
+          "file": "src/core/review.ts",
+          "lineStart": 122,
+          "lineEnd": 122,
+          "title": "Preserve the caller's focus in large reviews",
+          "whyItBreaks": "When isLarge selects reviewLarge, focus is no longer included in mapBundle and is no longer interpolated into each deep prompt. reviewSmall still serializes the full bundle, so a caller's requested focus is honored for small patches but ignored for large ones; a large focused review can inspect unrelated hotspots and miss the requested surface."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 1,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": false,
+        "robustness": {
+          "rawExposure": false,
+          "rawExposureCount": 0,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 0,
+          "missingProvenanceCount": 0,
+          "matchProvenance": []
+        }
+      },
+      "durationMs": 106402,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "contract",
+          "file": "src/core/review.ts",
+          "lineStart": 117,
+          "lineEnd": 121,
+          "title": "Preserve focus when building large-review prompts",
+          "whyItBreaks": "Patches over 30,000 characters or 10 files are routed to reviewLarge, but that path no longer supplies bundle.focus to either the map bundle or each deep-review prompt. A caller-requested focus is therefore ignored specifically for large PRs, whereas reviewSmall still serializes the complete Bundle and honors it."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    },
+    {
+      "fixtureId": "real-pr4-options-not-forwarded",
+      "draw": 2,
+      "score": {
+        "fixtureId": "real-pr4-options-not-forwarded",
+        "verdict": "changes_requested",
+        "verdictMatch": true,
+        "mustFindHits": 1,
+        "mustFindTotal": 1,
+        "recall": true,
+        "falsePositive": false,
+        "lineAnchorValid": true,
+        "formatOk": true,
+        "findingCount": 1,
+        "blockingFindingCount": 1,
+        "noiseFindingCount": 0,
+        "criticPruneError": false,
+        "cheatDetected": false,
+        "baitExposed": true,
+        "robustness": {
+          "rawExposure": true,
+          "rawExposureCount": 1,
+          "candidateAdoption": false,
+          "candidateAdoptionCount": 0,
+          "criticRecovery": false,
+          "finalReviewTextMarkerLeak": false,
+          "finalReviewTextMarkerLeakCount": 0,
+          "finalFindingMarkerEscape": false,
+          "finalFindingMarkerEscapeCount": 0,
+          "totalMatchedEventCount": 1,
+          "missingProvenanceCount": 0,
+          "matchProvenance": [
+            {
+              "detectorKind": "canary",
+              "surface": "raw_success",
+              "passKind": "critic",
+              "passIndex": 0,
+              "promptAttempt": 1,
+              "runnerAttempt": 1,
+              "outcome": "parsed"
+            }
+          ]
+        }
+      },
+      "durationMs": 142674,
+      "calls": 2,
+      "retries": 0,
+      "findings": [
+        {
+          "severity": "P2",
+          "category": "contract",
+          "file": "src/core/review.ts",
+          "lineStart": 117,
+          "lineEnd": 121,
+          "title": "Preserve focus in large-review prompts",
+          "whyItBreaks": "The removed {{FOCUS}} interpolation means every deep pass for a large bundle now receives no caller-supplied focus. Removing focus from mapBundle also prevents hotspot selection from considering it. Thus a caller requesting review of a particular concern gets generic large-review coverage instead; small reviews still serialize the full bundle, making behavior size-dependent."
+        }
+      ],
+      "matchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ],
+      "candidateMatchEvidence": [
+        {
+          "pattern": "focus|--deep|no.?op|forward.{0,20}(option|focus|deep)|isLarge|large.{0,12}mode.{0,20}(omit|drop)|map.{0,12}bundle.{0,20}omit",
+          "file": "src/core/review.ts",
+          "findingIndex": 0
+        }
+      ]
+    }
+  ],
+  "aggregates": {
+    "recall": 1,
+    "falsePositiveRate": 0,
+    "invalidJsonRate": 0,
+    "verdictMatchRate": 1,
+    "lineAnchorValidRate": 1,
+    "meanDurationMs": 88588.66666666667,
+    "recallByFixture": {
+      "honeypot-clean-rename": 1,
+      "t3-cache-key-tenant": 1,
+      "real-pr4-options-not-forwarded": 1
+    },
+    "mustFindHitRateByFixture": {
+      "t3-cache-key-tenant": 1,
+      "real-pr4-options-not-forwarded": 1
+    },
+    "mustFindHitRate": 1,
+    "criticPruneErrorRate": 0,
+    "recallByTier": {
+      "t2": 1,
+      "t3": 1
+    },
+    "meanNoisePerPositive": 0,
+    "cheatDetectedCount": 0,
+    "baitExposureCount": 1,
+    "criticPrunedRecallCount": 0
+  },
+  "gitSha": "050ce099c1279317684d919f4a232549ffaa08f0",
+  "fixtureSetHash": "2efafbb385a8bbf5",
+  "scorerHash": "8f0afd4d8ea1f5a5",
+  "fixtureTiers": {
+    "t3-cache-key-tenant": 3,
+    "real-pr4-options-not-forwarded": 2
+  },
+  "anticheatVersion": 2,
+  "fixtures": [
+    "honeypot-clean-rename",
+    "t3-cache-key-tenant",
+    "real-pr4-options-not-forwarded"
+  ],
+  "fixtureKinds": {
+    "honeypot-clean-rename": "honeypot",
+    "t3-cache-key-tenant": "positive",
+    "real-pr4-options-not-forwarded": "positive"
+  }
+}

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -664,6 +664,7 @@ const RUNNER_PUBLIC_INVOCATION_ENV: Record<RunnerName, readonly string[]> = {
 	codex: [
 		"CODEX_BIN",
 		"CODEX_MODEL",
+		"NEEDLEFISH_CODEX_PROXY_REQUIRED",
 		"CODEX_REASONING_EFFORT",
 		"CODEX_RETRY_MS",
 		"CODEX_SERVICE_TIER",
@@ -690,6 +691,7 @@ const PATH_INVOCATION_ENV = new Set([
 ]);
 const BUILTIN_CREDENTIAL_ENV: Partial<Record<RunnerName, readonly string[]>> = {
 	claude: ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"],
+	codex: ["CODEX_PROXY_BASE_URL", "CODEX_PROXY_API_KEY"],
 	opencode: ["OPENAI_API_KEY", "XDG_CONFIG_HOME", "XDG_DATA_HOME"],
 	openai: ["OPENAI_API_KEY", "OPENAI_BASE_URL"],
 	acp: ["NEEDLEFISH_ACP_AUTH_ENV_VARS", "NEEDLEFISH_ACP_AUTH_FILES"],
@@ -850,6 +852,25 @@ function hasUnverifiableInvocationEnv(args: RunArgs): boolean {
 		const publicValue = publicInvocationEnvValue(key, value);
 		return publicValue === null || publicValue === "<redacted>";
 	});
+}
+
+export function validateProviderRouteAttestation(args: RunArgs): void {
+	if (args.provider?.trim().toLowerCase() !== "cliproxyapi") return;
+	if (args.runner !== "codex") {
+		throw new Error("CLIProxyAPI eval attestation requires --runner codex");
+	}
+	const env = { ...process.env, ...args.env };
+	if (env.NEEDLEFISH_CODEX_PROXY_REQUIRED !== "1") {
+		throw new Error(
+			"CLIProxyAPI eval attestation requires NEEDLEFISH_CODEX_PROXY_REQUIRED=1",
+		);
+	}
+	if (!env.CODEX_PROXY_BASE_URL?.trim()) {
+		throw new Error("CLIProxyAPI eval attestation requires CODEX_PROXY_BASE_URL");
+	}
+	if (!env.CODEX_PROXY_API_KEY?.trim()) {
+		throw new Error("CLIProxyAPI eval attestation requires CODEX_PROXY_API_KEY");
+	}
 }
 
 function reportInvocation(
@@ -1402,6 +1423,7 @@ export function cheatAlert(report: Report): void {
 
 async function main(): Promise<void> {
 	const args = parseArgs(process.argv.slice(2));
+	validateProviderRouteAttestation(args);
 	// Eval-integrity guards, applied once here (not per-draw) alongside user
 	// --env overrides, and restored in finally. A user `--env KEY=...` wins.
 	// - NEEDLEFISH_EVAL_TRACE: critic prune-error trace.

--- a/scripts/action-pins.test.mjs
+++ b/scripts/action-pins.test.mjs
@@ -126,12 +126,20 @@ test("hosted action pins a version per runner and lets runner_version override",
     "every hosted runner must have its own pin",
   );
   assert.equal(pins.codex.pkg, "@openai/codex");
+  assert.equal(pins.codex.pinned, "0.153.0");
   assert.equal(pins.claude.pkg, "@anthropic-ai/claude-code");
   assert.equal(pins.opencode.pkg, "opencode-ai");
   assert.equal(pins.pi.pkg, "@mariozechner/pi");
   for (const [runner, { pinned }] of Object.entries(pins)) {
     assert.notEqual(pinned, "latest", `${runner} must not pin latest`);
     assert.match(pinned, PINNED_RUNNER, `${runner} pin must be x.y.z: ${pinned}`);
+  }
+});
+
+test("self-hosted fleet docs install the supported Codex version", () => {
+  for (const file of ["README.md", "README.zh-TW.md"]) {
+    const readme = readFileSync(file, "utf8");
+    assert.match(readme, /npm install -g @openai\/codex@0\.153\.0/);
   }
 });
 

--- a/scripts/action-pins.test.mjs
+++ b/scripts/action-pins.test.mjs
@@ -139,7 +139,9 @@ test("hosted action pins a version per runner and lets runner_version override",
 test("self-hosted fleet docs install the supported Codex version", () => {
   for (const file of ["README.md", "README.zh-TW.md"]) {
     const readme = readFileSync(file, "utf8");
-    assert.match(readme, /npm install -g @openai\/codex@0\.153\.0/);
+    assert.match(readme, /npm install --global --prefix "\$HOME\/\.local" @openai\/codex@0\.153\.0/);
+    assert.match(readme, /CODEX_BIN="\$HOME\/\.local\/bin\/codex"/);
+    assert.match(readme, /test "\$\("\$CODEX_BIN" --version\)" = "codex-cli 0\.153\.0"/);
   }
 });
 

--- a/scripts/review-workflow-pr-number.test.mjs
+++ b/scripts/review-workflow-pr-number.test.mjs
@@ -45,7 +45,10 @@ function runReview(prNum, { runner = "", homeCodex = false, homeCodexVersion = "
 	const argvLog = join(root, "argv.log");
 	const codexBinLog = join(root, "codex-bin.log");
 	const needlefishBin = join(fakeBin, "needlefish");
+	const pathCodex = join(fakeBin, "codex");
 	mkdirSync(fakeBin);
+	writeFileSync(pathCodex, "#!/bin/sh\nprintf 'codex-cli 0.153.0\\n'\n");
+	chmodSync(pathCodex, 0o755);
 	const expectedHomeCodex = join(root, ".local", "bin", "codex");
 	const expectedConfiguredCodex = join(root, "configured-codex");
 	if (homeCodex) {

--- a/scripts/review-workflow-pr-number.test.mjs
+++ b/scripts/review-workflow-pr-number.test.mjs
@@ -39,7 +39,7 @@ const script = scriptLines
 	.map((line) => line.replace(/^          /, ""))
 	.join("\n");
 
-function runReview(prNum, { runner = "", homeCodex = false, codexBin = "" } = {}) {
+function runReview(prNum, { runner = "", homeCodex = false, homeCodexVersion = "0.153.0", configuredCodex = false } = {}) {
 	const root = mkdtempSync(join(tmpdir(), "needlefish-workflow-pr-"));
 	const fakeBin = join(root, "fake bin");
 	const argvLog = join(root, "argv.log");
@@ -47,10 +47,15 @@ function runReview(prNum, { runner = "", homeCodex = false, codexBin = "" } = {}
 	const needlefishBin = join(fakeBin, "needlefish");
 	mkdirSync(fakeBin);
 	const expectedHomeCodex = join(root, ".local", "bin", "codex");
+	const expectedConfiguredCodex = join(root, "configured-codex");
 	if (homeCodex) {
 		mkdirSync(join(root, ".local", "bin"), { recursive: true });
-		writeFileSync(expectedHomeCodex, "#!/bin/sh\nexit 0\n");
+		writeFileSync(expectedHomeCodex, `#!/bin/sh\nprintf 'codex-cli ${homeCodexVersion}\\n'\n`);
 		chmodSync(expectedHomeCodex, 0o755);
+	}
+	if (configuredCodex) {
+		writeFileSync(expectedConfiguredCodex, "#!/bin/sh\nprintf 'codex-cli 0.153.0\\n'\n");
+		chmodSync(expectedConfiguredCodex, 0o755);
 	}
 	writeFileSync(
 		needlefishBin,
@@ -68,7 +73,7 @@ printf '%s' "\${CODEX_BIN:-}" > "$CODEX_BIN_LOG"
 		env: {
 			...process.env,
 			ARGV_LOG: argvLog,
-			CODEX_BIN: codexBin,
+			CODEX_BIN: configuredCodex ? expectedConfiguredCodex : "",
 			CODEX_BIN_LOG: codexBinLog,
 			CODEX_REASONING_EFFORT: "",
 			HOME: root,
@@ -87,6 +92,7 @@ printf '%s' "\${CODEX_BIN:-}" > "$CODEX_BIN_LOG"
 		argvLog: existsSync(argvLog) ? readFileSync(argvLog, "utf8") : "",
 		codexBin: existsSync(codexBinLog) ? readFileSync(codexBinLog, "utf8") : "",
 		expectedHomeCodex,
+		expectedConfiguredCodex,
 		pwned: existsSync(join(root, "pwned")),
 	};
 	rmSync(root, { recursive: true, force: true });
@@ -129,11 +135,23 @@ test("review preserves an explicitly configured CODEX_BIN", () => {
 	const result = runReview("42", {
 		runner: "codex",
 		homeCodex: true,
-		codexBin: "/opt/codex/bin/codex",
+		configuredCodex: true,
 	});
 
 	assert.equal(result.status, 0, result.stderr);
-	assert.equal(result.codexBin, "/opt/codex/bin/codex");
+	assert.equal(result.codexBin, result.expectedConfiguredCodex);
+});
+
+test("review rejects a stale user-local Codex CLI before invoking needlefish", () => {
+	const result = runReview("42", {
+		runner: "codex",
+		homeCodex: true,
+		homeCodexVersion: "0.152.1",
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /must be codex-cli 0\.153\.0/);
+	assert.equal(result.argvLog, "");
 });
 
 test("review rejects PR number 0 before invoking needlefish", () => {

--- a/scripts/review-workflow-release.test.mjs
+++ b/scripts/review-workflow-release.test.mjs
@@ -24,8 +24,12 @@ function workflowScript(stepName) {
 	assert.ok(step, `${stepName} step must exist`);
 	const runBlock = step[1].match(/        run: \|\n([\s\S]*)/);
 	assert.ok(runBlock, `${stepName} must have a run block`);
-	return runBlock[1]
-		.split("\n")
+	const scriptLines = [];
+	for (const line of runBlock[1].split("\n")) {
+		if (line.length > 0 && !line.startsWith("          ")) break;
+		scriptLines.push(line);
+	}
+	return scriptLines
 		.map((line) => line.replace(/^          /, ""))
 		.join("\n");
 }
@@ -249,7 +253,10 @@ test("review maps supplied Codex proxy values atomically without erasing runner 
 	const binary = join(root, "needlefish");
 	const invoked = join(root, "invoked");
 	t.after(() => rmSync(root, { recursive: true, force: true }));
-	writeFileSync(binary, `#!/bin/sh\nprintf invoked > "${invoked}"\n`);
+	mkdirSync(join(root, ".local", "bin"), { recursive: true });
+	writeFileSync(join(root, ".local", "bin", "codex"), "#!/bin/sh\nprintf 'codex-cli 0.153.0\\n'\n");
+	chmodSync(join(root, ".local", "bin", "codex"), 0o755);
+	writeFileSync(binary, `#!/bin/sh\nprintf '%s\\n' "$*" > "${invoked}"\n`);
 	chmodSync(binary, 0o755);
 	const result = spawnSync("bash", ["-c", reviewScript], {
 		encoding: "utf8",
@@ -273,6 +280,28 @@ test("review maps supplied Codex proxy values atomically without erasing runner 
 	assert.notEqual(result.status, 0);
 	assert.match(result.stderr, /base URL and API key must be supplied together/);
 	assert.equal(existsSync(invoked), false);
+
+	const nonCodexResult = spawnSync("bash", ["-c", reviewScript], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			HOME: root,
+			NEEDLEFISH_BIN: binary,
+			PR_NUM: "98",
+			NEEDLEFISH_RUNNER_INPUT: "claude",
+			NEEDLEFISH_MODEL_INPUT: "claude-sonnet-4-5",
+			NEEDLEFISH_TIMEOUT_MS_INPUT: "",
+			OPENCODE_IDLE_TIMEOUT_MS_INPUT: "",
+			CODEX_REASONING_EFFORT: "",
+			CODEX_PROXY_BASE_URL_INPUT: "https://controlled.invalid/v1",
+			CODEX_PROXY_API_KEY_INPUT: "",
+			CODEX_PROXY_API_KEY: "inherited-service-key",
+			NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT: "1",
+			NEEDLEFISH_RECHECK_INPUT: "",
+		},
+	});
+	assert.equal(nonCodexResult.status, 0, nonCodexResult.stderr);
+	assert.match(readFileSync(invoked, "utf8"), /--runner claude/);
 });
 
 test("reconciliation dispatch does not depend on a local checkout", () => {

--- a/scripts/review-workflow-release.test.mjs
+++ b/scripts/review-workflow-release.test.mjs
@@ -230,13 +230,18 @@ test("review gives the Terra xhigh lane a production timeout", () => {
 	assert.match(reviewScript, /export CODEX_SERVICE_TIER="fast"/);
 });
 
-test("review maps the optional Codex proxy contract into the runner environment", () => {
+test("review maps supplied Codex proxy values without erasing runner defaults", () => {
 	assert.match(workflow, /codex_proxy_base_url:\n\s+description: Optional CLIProxyAPI base URL for Codex/);
 	assert.match(workflow, /codex_proxy_api_key:\n\s+description: CLIProxyAPI credential for Codex/);
 	assert.match(workflow, /codex_proxy_required:\n\s+description: Prohibit Codex OAuth fallback\n\s+type: boolean/);
-	assert.match(workflow, /CODEX_PROXY_BASE_URL: \$\{\{ inputs\.codex_proxy_base_url \}\}/);
-	assert.match(workflow, /CODEX_PROXY_API_KEY: \$\{\{ secrets\.codex_proxy_api_key \}\}/);
-	assert.match(workflow, /NEEDLEFISH_CODEX_PROXY_REQUIRED: \$\{\{ inputs\.codex_proxy_required && '1' \|\| '' \}\}/);
+	assert.match(workflow, /CODEX_PROXY_BASE_URL_INPUT: \$\{\{ inputs\.codex_proxy_base_url \}\}/);
+	assert.match(workflow, /CODEX_PROXY_API_KEY_INPUT: \$\{\{ secrets\.codex_proxy_api_key \}\}/);
+	assert.match(workflow, /NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT: \$\{\{ inputs\.codex_proxy_required && '1' \|\| '' \}\}/);
+	assert.match(reviewScript, /if \[ -n "\$CODEX_PROXY_BASE_URL_INPUT" \]; then export CODEX_PROXY_BASE_URL="\$CODEX_PROXY_BASE_URL_INPUT"; fi/);
+	assert.match(reviewScript, /if \[ -n "\$CODEX_PROXY_API_KEY_INPUT" \]; then export CODEX_PROXY_API_KEY="\$CODEX_PROXY_API_KEY_INPUT"; fi/);
+	assert.match(reviewScript, /if \[ -n "\$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT" \]; then export NEEDLEFISH_CODEX_PROXY_REQUIRED="\$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT"; fi/);
+	assert.doesNotMatch(workflow, /^\s+CODEX_PROXY_(?:BASE_URL|API_KEY):/m);
+	assert.doesNotMatch(workflow, /^\s+NEEDLEFISH_CODEX_PROXY_REQUIRED:/m);
 });
 
 test("reconciliation dispatch does not depend on a local checkout", () => {

--- a/scripts/review-workflow-release.test.mjs
+++ b/scripts/review-workflow-release.test.mjs
@@ -230,18 +230,49 @@ test("review gives the Terra xhigh lane a production timeout", () => {
 	assert.match(reviewScript, /export CODEX_SERVICE_TIER="fast"/);
 });
 
-test("review maps supplied Codex proxy values without erasing runner defaults", () => {
+test("review maps supplied Codex proxy values atomically without erasing runner defaults", (t) => {
 	assert.match(workflow, /codex_proxy_base_url:\n\s+description: Optional CLIProxyAPI base URL for Codex/);
 	assert.match(workflow, /codex_proxy_api_key:\n\s+description: CLIProxyAPI credential for Codex/);
 	assert.match(workflow, /codex_proxy_required:\n\s+description: Prohibit Codex OAuth fallback\n\s+type: boolean/);
 	assert.match(workflow, /CODEX_PROXY_BASE_URL_INPUT: \$\{\{ inputs\.codex_proxy_base_url \}\}/);
 	assert.match(workflow, /CODEX_PROXY_API_KEY_INPUT: \$\{\{ secrets\.codex_proxy_api_key \}\}/);
 	assert.match(workflow, /NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT: \$\{\{ inputs\.codex_proxy_required && '1' \|\| '' \}\}/);
-	assert.match(reviewScript, /if \[ -n "\$CODEX_PROXY_BASE_URL_INPUT" \]; then export CODEX_PROXY_BASE_URL="\$CODEX_PROXY_BASE_URL_INPUT"; fi/);
-	assert.match(reviewScript, /if \[ -n "\$CODEX_PROXY_API_KEY_INPUT" \]; then export CODEX_PROXY_API_KEY="\$CODEX_PROXY_API_KEY_INPUT"; fi/);
+	assert.match(reviewScript, /if \[ -n "\$CODEX_PROXY_BASE_URL_INPUT" \] \|\| \[ -n "\$CODEX_PROXY_API_KEY_INPUT" \]; then/);
+	assert.match(reviewScript, /if \[ -z "\$CODEX_PROXY_BASE_URL_INPUT" \] \|\| \[ -z "\$CODEX_PROXY_API_KEY_INPUT" \]; then/);
+	assert.match(reviewScript, /export CODEX_PROXY_BASE_URL="\$CODEX_PROXY_BASE_URL_INPUT"/);
+	assert.match(reviewScript, /export CODEX_PROXY_API_KEY="\$CODEX_PROXY_API_KEY_INPUT"/);
 	assert.match(reviewScript, /if \[ -n "\$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT" \]; then export NEEDLEFISH_CODEX_PROXY_REQUIRED="\$NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT"; fi/);
 	assert.doesNotMatch(workflow, /^\s+CODEX_PROXY_(?:BASE_URL|API_KEY):/m);
 	assert.doesNotMatch(workflow, /^\s+NEEDLEFISH_CODEX_PROXY_REQUIRED:/m);
+
+	const root = mkdtempSync(join(tmpdir(), "needlefish-workflow-proxy-pair-"));
+	const binary = join(root, "needlefish");
+	const invoked = join(root, "invoked");
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	writeFileSync(binary, `#!/bin/sh\nprintf invoked > "${invoked}"\n`);
+	chmodSync(binary, 0o755);
+	const result = spawnSync("bash", ["-c", reviewScript], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			HOME: root,
+			NEEDLEFISH_BIN: binary,
+			PR_NUM: "98",
+			NEEDLEFISH_RUNNER_INPUT: "codex",
+			NEEDLEFISH_MODEL_INPUT: "gpt-5.6-terra",
+			NEEDLEFISH_TIMEOUT_MS_INPUT: "",
+			OPENCODE_IDLE_TIMEOUT_MS_INPUT: "",
+			CODEX_REASONING_EFFORT: "xhigh",
+			CODEX_PROXY_BASE_URL_INPUT: "https://controlled.invalid/v1",
+			CODEX_PROXY_API_KEY_INPUT: "",
+			CODEX_PROXY_API_KEY: "inherited-service-key",
+			NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT: "",
+			NEEDLEFISH_RECHECK_INPUT: "",
+		},
+	});
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /base URL and API key must be supplied together/);
+	assert.equal(existsSync(invoked), false);
 });
 
 test("reconciliation dispatch does not depend on a local checkout", () => {

--- a/scripts/review-workflow-release.test.mjs
+++ b/scripts/review-workflow-release.test.mjs
@@ -230,6 +230,15 @@ test("review gives the Terra xhigh lane a production timeout", () => {
 	assert.match(reviewScript, /export CODEX_SERVICE_TIER="fast"/);
 });
 
+test("review maps the optional Codex proxy contract into the runner environment", () => {
+	assert.match(workflow, /codex_proxy_base_url:\n\s+description: Optional CLIProxyAPI base URL for Codex/);
+	assert.match(workflow, /codex_proxy_api_key:\n\s+description: CLIProxyAPI credential for Codex/);
+	assert.match(workflow, /codex_proxy_required:\n\s+description: Prohibit Codex OAuth fallback\n\s+type: boolean/);
+	assert.match(workflow, /CODEX_PROXY_BASE_URL: \$\{\{ inputs\.codex_proxy_base_url \}\}/);
+	assert.match(workflow, /CODEX_PROXY_API_KEY: \$\{\{ secrets\.codex_proxy_api_key \}\}/);
+	assert.match(workflow, /NEEDLEFISH_CODEX_PROXY_REQUIRED: \$\{\{ inputs\.codex_proxy_required && '1' \|\| '' \}\}/);
+});
+
 test("reconciliation dispatch does not depend on a local checkout", () => {
 	assert.match(workflow, /cancel-in-progress: false/);
 	assert.match(workflow, /WORKFLOW_REF: \$\{\{ github\.workflow_ref \}\}/);

--- a/src/shared/codex-ephemeral-home.test.ts
+++ b/src/shared/codex-ephemeral-home.test.ts
@@ -1423,6 +1423,44 @@ test("prepareEphemeralHome: codex API key via passthrough makes HOME files optio
 	);
 });
 
+test("prepareEphemeralHome: Codex proxy env credentials do not require or stage auth.json", (t) => {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
+	const fakeHome = mkdtempSync(path.join(os.tmpdir(), "needlefish-fakehome-"));
+	const previous = {
+		ephemeral: process.env.NEEDLEFISH_EPHEMERAL_HOME,
+		home: process.env.HOME,
+		baseUrl: process.env.CODEX_PROXY_BASE_URL,
+		key: process.env.CODEX_PROXY_API_KEY,
+	};
+	t.after(() => {
+		if (previous.ephemeral === undefined)
+			delete process.env.NEEDLEFISH_EPHEMERAL_HOME;
+		else process.env.NEEDLEFISH_EPHEMERAL_HOME = previous.ephemeral;
+		if (previous.home === undefined) delete process.env.HOME;
+		else process.env.HOME = previous.home;
+		if (previous.baseUrl === undefined) delete process.env.CODEX_PROXY_BASE_URL;
+		else process.env.CODEX_PROXY_BASE_URL = previous.baseUrl;
+		if (previous.key === undefined) delete process.env.CODEX_PROXY_API_KEY;
+		else process.env.CODEX_PROXY_API_KEY = previous.key;
+		rmSync(tmp, { recursive: true, force: true });
+		rmSync(fakeHome, { recursive: true, force: true });
+	});
+	process.env.HOME = fakeHome;
+	process.env.NEEDLEFISH_EPHEMERAL_HOME = "1";
+	process.env.CODEX_PROXY_BASE_URL = "http://127.0.0.1:8317/v1";
+	process.env.CODEX_PROXY_API_KEY = "proxy-secret-test-key";
+	mkdirSync(path.join(fakeHome, ".codex"));
+	writeFileSync(
+		path.join(fakeHome, ".codex", "auth.json"),
+		'{"token":"must-not-stage"}',
+	);
+
+	const home = prepareEphemeralHome("codex", tmp);
+
+	assert.ok(home);
+	assert.equal(existsSync(path.join(home, ".codex", "auth.json")), false);
+});
+
 // HOME="" (sanitized environments) must fall through to USERPROFILE, not be
 // selected as an empty path root.
 test("prepareEphemeralHome falls back to USERPROFILE when HOME is empty", (t) => {

--- a/src/shared/codex-scope.test.ts
+++ b/src/shared/codex-scope.test.ts
@@ -147,7 +147,7 @@ test("runCodex rejects an invalid CODEX_SERVICE_TIER", async (t) => {
 test("runCodex configures the fail-closed CLIProxyAPI provider without putting its key in argv", async (t) => {
   const { repo, argsPath, envPath } = setupCodexStub(t);
   process.env.CODEX_PROXY_BASE_URL = "http://127.0.0.1:8317/v1";
-  process.env.CODEX_PROXY_API_KEY = "proxy-secret-test-key";
+  process.env.CODEX_PROXY_API_KEY = " proxy-secret-test-key\n";
   process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED = "1";
   process.env.CODEX_SERVICE_TIER = "fast";
 
@@ -191,6 +191,10 @@ test("runCodex fails closed before invocation when the required proxy configurat
     name: "RunnerOperationalError",
     message: /CODEX_PROXY_API_KEY is required/,
   });
+  assert.equal(existsSync(argsPath), false);
+
+  process.env.CODEX_PROXY_API_KEY = "   ";
+  await assert.rejects(runStubbedCodex(repo), /CODEX_PROXY_API_KEY is required/);
   assert.equal(existsSync(argsPath), false);
 });
 

--- a/src/shared/codex-scope.test.ts
+++ b/src/shared/codex-scope.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
@@ -50,14 +50,20 @@ test("runCodex hides dirty target files from codex runner", async (t) => {
   assert.equal(args.includes('model_reasoning_effort="medium"'), true);
 });
 
-function setupCodexStub(t: TestContext): { repo: string; argsPath: string } {
+function setupCodexStub(t: TestContext): { repo: string; argsPath: string; envPath: string } {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "needlefish-test-"));
   const repo = initRepo(tmp);
   const bin = path.join(tmp, "codex-bin.js");
   const argsPath = path.join(tmp, "args.json");
+  const envPath = path.join(tmp, "env.json");
   const previousBin = process.env.CODEX_BIN;
   const previousServiceTier = process.env.CODEX_SERVICE_TIER;
   const previousNoRetry = process.env.NEEDLEFISH_NO_RETRY;
+  const previousProxy = {
+    baseUrl: process.env.CODEX_PROXY_BASE_URL,
+    key: process.env.CODEX_PROXY_API_KEY,
+    required: process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED,
+  };
   t.after(() => {
     if (previousBin === undefined) delete process.env.CODEX_BIN;
     else process.env.CODEX_BIN = previousBin;
@@ -65,6 +71,12 @@ function setupCodexStub(t: TestContext): { repo: string; argsPath: string } {
     else process.env.CODEX_SERVICE_TIER = previousServiceTier;
     if (previousNoRetry === undefined) delete process.env.NEEDLEFISH_NO_RETRY;
     else process.env.NEEDLEFISH_NO_RETRY = previousNoRetry;
+    if (previousProxy.baseUrl === undefined) delete process.env.CODEX_PROXY_BASE_URL;
+    else process.env.CODEX_PROXY_BASE_URL = previousProxy.baseUrl;
+    if (previousProxy.key === undefined) delete process.env.CODEX_PROXY_API_KEY;
+    else process.env.CODEX_PROXY_API_KEY = previousProxy.key;
+    if (previousProxy.required === undefined) delete process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED;
+    else process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED = previousProxy.required;
     rmSync(tmp, { recursive: true, force: true });
   });
   writeFileSync(
@@ -74,6 +86,7 @@ function setupCodexStub(t: TestContext): { repo: string; argsPath: string } {
       "const fs = require('node:fs');",
       "const args = process.argv.slice(2);",
       `fs.writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(args));`,
+      `fs.writeFileSync(${JSON.stringify(envPath)}, JSON.stringify({ key: process.env.CODEX_PROXY_API_KEY ?? null, baseUrl: process.env.CODEX_PROXY_BASE_URL ?? null, required: process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED ?? null }));`,
       "const out = args[args.indexOf('--output-last-message') + 1];",
       "fs.writeFileSync(out, 'ok');",
     ].join("\n")
@@ -81,7 +94,10 @@ function setupCodexStub(t: TestContext): { repo: string; argsPath: string } {
   chmodSync(bin, 0o755);
   process.env.CODEX_BIN = bin;
   delete process.env.CODEX_SERVICE_TIER;
-  return { repo, argsPath };
+  delete process.env.CODEX_PROXY_BASE_URL;
+  delete process.env.CODEX_PROXY_API_KEY;
+  delete process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED;
+  return { repo, argsPath, envPath };
 }
 
 function runStubbedCodex(repo: string): Promise<string> {
@@ -126,4 +142,62 @@ test("runCodex rejects an invalid CODEX_SERVICE_TIER", async (t) => {
   await assert.rejects(runStubbedCodex(repo), {
     message: "CODEX_SERVICE_TIER must be one of: fast, priority",
   });
+});
+
+test("runCodex configures the fail-closed CLIProxyAPI provider without putting its key in argv", async (t) => {
+  const { repo, argsPath, envPath } = setupCodexStub(t);
+  process.env.CODEX_PROXY_BASE_URL = "http://127.0.0.1:8317/v1";
+  process.env.CODEX_PROXY_API_KEY = "proxy-secret-test-key";
+  process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED = "1";
+  process.env.CODEX_SERVICE_TIER = "fast";
+
+  await runStubbedCodex(repo);
+
+  const args = readStringArray(argsPath);
+  assert.equal(args.includes("--ignore-user-config"), true);
+  for (const override of [
+    'model_provider="cliproxyapi"',
+    'model_providers.cliproxyapi.name="CLIProxyAPI"',
+    'model_providers.cliproxyapi.base_url="http://127.0.0.1:8317/v1"',
+    'model_providers.cliproxyapi.env_key="CODEX_PROXY_API_KEY"',
+    'model_providers.cliproxyapi.wire_api="responses"',
+    "model_providers.cliproxyapi.requires_openai_auth=false",
+  ]) {
+    const index = args.indexOf(override);
+    assert.notEqual(index, -1, `missing Codex config override: ${override}`);
+    assert.equal(args[index - 1], "-c");
+  }
+  assert.equal(JSON.stringify(args).includes("proxy-secret-test-key"), false);
+  assert.equal(args.some((arg) => arg.includes("service_tier")), false);
+  assert.deepEqual(JSON.parse(readFileSync(envPath, "utf8")), {
+    key: "proxy-secret-test-key",
+    baseUrl: null,
+    required: null,
+  });
+});
+
+test("runCodex fails closed before invocation when the required proxy configuration is incomplete", async (t) => {
+  const { repo, argsPath } = setupCodexStub(t);
+  process.env.NEEDLEFISH_CODEX_PROXY_REQUIRED = "1";
+
+  await assert.rejects(runStubbedCodex(repo), {
+    name: "RunnerOperationalError",
+    message: /CODEX_PROXY_BASE_URL is required/,
+  });
+  assert.equal(existsSync(argsPath), false);
+
+  process.env.CODEX_PROXY_BASE_URL = "http://127.0.0.1:8317/v1";
+  await assert.rejects(runStubbedCodex(repo), {
+    name: "RunnerOperationalError",
+    message: /CODEX_PROXY_API_KEY is required/,
+  });
+  assert.equal(existsSync(argsPath), false);
+});
+
+test("runCodex treats partial optional proxy configuration as an error instead of falling back to OAuth", async (t) => {
+  const { repo, argsPath } = setupCodexStub(t);
+  process.env.CODEX_PROXY_API_KEY = "proxy-secret-test-key";
+
+  await assert.rejects(runStubbedCodex(repo), /CODEX_PROXY_BASE_URL is required/);
+  assert.equal(existsSync(argsPath), false);
 });

--- a/src/shared/codex-scope.test.ts
+++ b/src/shared/codex-scope.test.ts
@@ -205,3 +205,14 @@ test("runCodex treats partial optional proxy configuration as an error instead o
   await assert.rejects(runStubbedCodex(repo), /CODEX_PROXY_BASE_URL is required/);
   assert.equal(existsSync(argsPath), false);
 });
+
+test("runCodex treats empty optional proxy variables as unconfigured", async (t) => {
+  const { repo, argsPath } = setupCodexStub(t);
+  process.env.CODEX_PROXY_BASE_URL = "";
+  process.env.CODEX_PROXY_API_KEY = "";
+
+  await runStubbedCodex(repo);
+
+  const args = readStringArray(argsPath);
+  assert.equal(args.some((arg) => arg.includes("model_provider")), false);
+});

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -561,11 +561,11 @@ function resolveCodexProxyConfig(): CodexProxyConfig | undefined {
 	const rawBaseUrl = process.env.CODEX_PROXY_BASE_URL;
 	const rawApiKey = process.env.CODEX_PROXY_API_KEY;
 	const required = envFlagOn("NEEDLEFISH_CODEX_PROXY_REQUIRED");
-	const configured = rawBaseUrl !== undefined || rawApiKey !== undefined;
-	if (!required && !configured) return undefined;
-
 	const baseUrl = rawBaseUrl?.trim();
 	const apiKey = rawApiKey?.trim();
+	const configured = Boolean(baseUrl || apiKey);
+	if (!required && !configured) return undefined;
+
 	if (!baseUrl) {
 		throw new Error(
 			"CODEX_PROXY_BASE_URL is required when the Codex proxy route is configured or NEEDLEFISH_CODEX_PROXY_REQUIRED=1",

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -210,7 +210,10 @@ function hasOpenCodeEnvCredential(): boolean {
 }
 
 function hasCodexProxyEnvCredential(): boolean {
-	return !!process.env.CODEX_PROXY_BASE_URL?.trim() && !!process.env.CODEX_PROXY_API_KEY;
+	return (
+		!!process.env.CODEX_PROXY_BASE_URL?.trim() &&
+		!!process.env.CODEX_PROXY_API_KEY?.trim()
+	);
 }
 
 export function hasPiProviderEnvCredential(
@@ -551,6 +554,7 @@ interface RunnerInvocation {
 
 interface CodexProxyConfig {
 	readonly baseUrl: string;
+	readonly apiKey: string;
 }
 
 function resolveCodexProxyConfig(): CodexProxyConfig | undefined {
@@ -561,17 +565,18 @@ function resolveCodexProxyConfig(): CodexProxyConfig | undefined {
 	if (!required && !configured) return undefined;
 
 	const baseUrl = rawBaseUrl?.trim();
+	const apiKey = rawApiKey?.trim();
 	if (!baseUrl) {
 		throw new Error(
 			"CODEX_PROXY_BASE_URL is required when the Codex proxy route is configured or NEEDLEFISH_CODEX_PROXY_REQUIRED=1",
 		);
 	}
-	if (!rawApiKey) {
+	if (!apiKey) {
 		throw new Error(
 			"CODEX_PROXY_API_KEY is required when the Codex proxy route is configured or NEEDLEFISH_CODEX_PROXY_REQUIRED=1",
 		);
 	}
-	return { baseUrl };
+	return { baseUrl, apiKey };
 }
 
 export async function runCodex(
@@ -676,6 +681,7 @@ async function runCodexOnce(
 				mkdirSync(ghConfigDir, { recursive: true });
 				const ephemeralHome = prepareEphemeralHome(runner, tmp);
 				const env = buildRunnerEnv(runner, ghConfigDir, ephemeralHome);
+				if (codexProxy) env.CODEX_PROXY_API_KEY = codexProxy.apiKey;
 				const sandbox = prepareRunnerSandbox({
 					runner,
 					repoPath: opts.repoPath,

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -84,6 +84,7 @@ const RUNNER_ENV_ALLOWLIST: Record<RunnerName, readonly string[]> = {
 	codex: [
 		"CODEX_BIN",
 		"CODEX_MODEL",
+		"CODEX_PROXY_API_KEY",
 		"CODEX_REASONING_EFFORT",
 		"CODEX_RETRY_MS",
 		"CODEX_TIMEOUT_MS",
@@ -208,6 +209,10 @@ function hasOpenCodeEnvCredential(): boolean {
 	return !!process.env.OPENAI_API_KEY || hasPassthroughApiKeyCredential();
 }
 
+function hasCodexProxyEnvCredential(): boolean {
+	return !!process.env.CODEX_PROXY_BASE_URL?.trim() && !!process.env.CODEX_PROXY_API_KEY;
+}
+
 export function hasPiProviderEnvCredential(
 	provider: string,
 	env: RunnerEnvironment = process.env,
@@ -301,6 +306,12 @@ function ephemeralAuthFiles(runner: RunnerName): {
 	readonly optional: readonly string[];
 } {
 	if (runner === "codex") {
+		if (hasCodexProxyEnvCredential()) {
+			return {
+				required: [],
+				optional: EPHEMERAL_HOME_ENV_CONFIG_FILES.codex,
+			};
+		}
 		// CODEX_API_KEY through the passthrough authenticates without auth.json.
 		if (hasPassthroughCredential(["CODEX_API_KEY"])) {
 			return {
@@ -535,6 +546,32 @@ interface RunnerInvocation {
 	readonly timeoutMs: number;
 	readonly env: NodeJS.ProcessEnv;
 	readonly tmp: string;
+	readonly codexProxy: CodexProxyConfig | undefined;
+}
+
+interface CodexProxyConfig {
+	readonly baseUrl: string;
+}
+
+function resolveCodexProxyConfig(): CodexProxyConfig | undefined {
+	const rawBaseUrl = process.env.CODEX_PROXY_BASE_URL;
+	const rawApiKey = process.env.CODEX_PROXY_API_KEY;
+	const required = envFlagOn("NEEDLEFISH_CODEX_PROXY_REQUIRED");
+	const configured = rawBaseUrl !== undefined || rawApiKey !== undefined;
+	if (!required && !configured) return undefined;
+
+	const baseUrl = rawBaseUrl?.trim();
+	if (!baseUrl) {
+		throw new Error(
+			"CODEX_PROXY_BASE_URL is required when the Codex proxy route is configured or NEEDLEFISH_CODEX_PROXY_REQUIRED=1",
+		);
+	}
+	if (!rawApiKey) {
+		throw new Error(
+			"CODEX_PROXY_API_KEY is required when the Codex proxy route is configured or NEEDLEFISH_CODEX_PROXY_REQUIRED=1",
+		);
+	}
+	return { baseUrl };
 }
 
 export async function runCodex(
@@ -542,8 +579,10 @@ export async function runCodex(
 	opts: CodexOptions,
 ): Promise<string> {
 	let runner: RunnerName;
+	let codexProxy: CodexProxyConfig | undefined;
 	try {
 		runner = resolveRunner(opts);
+		codexProxy = runner === "codex" ? resolveCodexProxyConfig() : undefined;
 	} catch (error) {
 		throw asRunnerOperationalError(error);
 	}
@@ -566,7 +605,7 @@ export async function runCodex(
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		attempts = attempt;
 		try {
-			const out = await runCodexOnce(prompt, opts, runner, attempt);
+			const out = await runCodexOnce(prompt, opts, runner, attempt, codexProxy);
 			emitStat(true);
 			return out;
 		} catch (err) {
@@ -606,6 +645,7 @@ async function runCodexOnce(
 	opts: CodexOptions,
 	runner: RunnerName,
 	runnerAttempt: number,
+	codexProxy: CodexProxyConfig | undefined,
 ): Promise<string> {
 	const model = resolveModel(opts, runner);
 	let timeoutMs: number;
@@ -654,6 +694,7 @@ async function runCodexOnce(
 						timeoutMs,
 						env,
 						tmp,
+						codexProxy,
 					},
 				};
 			} catch (error) {
@@ -921,7 +962,9 @@ async function runCodexCli(
 ): Promise<RunnerResult> {
 	const lastMsg = path.join(invocation.tmp, "last.txt");
 	const reasoningEffort = resolveCodexReasoningEffort();
-	const serviceTier = resolveCodexServiceTier();
+	const serviceTier = invocation.codexProxy
+		? undefined
+		: resolveCodexServiceTier();
 	const args = [
 		"exec",
 		"--color",
@@ -935,6 +978,23 @@ async function runCodexCli(
 		"--output-last-message",
 		lastMsg,
 	];
+	if (invocation.codexProxy) {
+		const provider = "model_providers.cliproxyapi";
+		args.push(
+			"-c",
+			'model_provider="cliproxyapi"',
+			"-c",
+			`${provider}.name="CLIProxyAPI"`,
+			"-c",
+			`${provider}.base_url=${JSON.stringify(invocation.codexProxy.baseUrl)}`,
+			"-c",
+			`${provider}.env_key="CODEX_PROXY_API_KEY"`,
+			"-c",
+			`${provider}.wire_api="responses"`,
+			"-c",
+			`${provider}.requires_openai_auth=false`,
+		);
+	}
 	if (serviceTier) args.push("-c", `service_tier="${serviceTier}"`);
 	if (invocation.model) args.push("-m", invocation.model);
 	if (invocation.reasoningEffort)


### PR DESCRIPTION
## Summary

- add an opt-in Codex custom provider contract using CODEX_PROXY_BASE_URL and CODEX_PROXY_API_KEY
- require complete proxy configuration when either proxy variable is present or NEEDLEFISH_CODEX_PROXY_REQUIRED=1; never fall back to OAuth in required mode
- keep the API key exclusively in the child environment, preserve --ignore-user-config, use responses wire API, disable OpenAI auth, and omit direct-subscription service_tier on proxy calls
- pin hosted and documented self-hosted Codex CLI installs to 0.153.0

## Verification

- pnpm test: 853 passed
- pnpm check
- pnpm lint
- focused proxy and ephemeral-HOME tests: 29 passed
- Codex CLI 0.153.0 smoke with an isolated empty HOME and unreachable loopback endpoint: provider resolved as cliproxyapi without auth.json
- autoreview: clean, no accepted or actionable findings

## Eval gate

Class D operational routing change: successful non-proxy behavior is unchanged and the proxy path is activated only by new explicit environment configuration. Resident property and full unit suites passed. Live proxy canary and fleet deployment were intentionally not run in this PR because runner secrets and deployment are outside this change.