### PR TITLE
fix: preserve quoted paths and rename sources in review

### DIFF
--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -59,10 +59,6 @@ function hasHeadCommit(cwd: string): boolean {
   }
 }
 
-function gitLines(args: readonly string[], cwd: string): string[] {
-  return git(args, cwd).split("\n").filter(Boolean);
-}
-
 function gitNulFields(args: readonly string[], cwd: string): string[] {
   const output = git(args, cwd);
   if (!output) return [];
@@ -168,8 +164,8 @@ function uncommittedDiffBundle(cwd: string, opts: LocalOptions, headExists: bool
   const trackedPaths = headExists ? gitNulFields(trackedDiffArgs(["--name-only", "-z"], trackedBinaryPaths), cwd) : [];
   const trackedSkipped = trackedBinaryPaths.map((filePath) => `${filePath} (binary)`);
   const untrackedFiles = headExists
-    ? gitLines(["ls-files", "--others", "--exclude-standard"], cwd)
-    : gitLines(["ls-files", "--cached", "--others", "--exclude-standard"], cwd);
+    ? gitNulFields(["ls-files", "-z", "--others", "--exclude-standard"], cwd)
+    : gitNulFields(["ls-files", "-z", "--cached", "--others", "--exclude-standard"], cwd);
   const untracked = buildUntrackedPatch(cwd, untrackedFiles);
   const patch = joinSections([trackedPatch, untracked.patch]);
 

--- a/src/shared/repo.ts
+++ b/src/shared/repo.ts
@@ -21,8 +21,11 @@ export function ghText(args: readonly string[], cwd?: string, input?: string): s
 }
 
 export function changedFiles(cwd: string, baseSha: string, headSha = "HEAD"): ChangedFile[] {
-  const nameOnly = git(["diff", "--name-only", baseSha, headSha], cwd);
-  return changedFilesFromPaths(nameOnly.split("\n"));
+  // NUL output preserves repository-controlled pathnames (including newlines,
+  // quotes, and leading/trailing whitespace). Disable rename detection so the
+  // removed source path remains visible to docs-only classification.
+  const nameOnly = git(["diff", "--name-only", "-z", "--no-renames", baseSha, headSha], cwd);
+  return changedFilesFromPaths(nameOnly.split("\0"));
 }
 
 export function changedFilesFromPaths(paths: readonly string[]): ChangedFile[] {


### PR DESCRIPTION
## Problem
Git's newline-delimited pathname output can quote or otherwise transform repository filenames. Rename detection can also hide the removed source path, allowing source or policy changes to be misclassified as docs-only and skip review.

## Fix
- Use NUL-delimited `git diff --name-only -z --no-renames` output for committed changes.
- Use NUL-delimited `git ls-files -z` output for untracked files.

This preserves hostile filenames and keeps both sides of renames visible to classification.

## Validation
- `pnpm check`
- `pnpm lint`
- `pnpm test`
