### PR TITLE
fix(workflow): default the Codex proxy base URL from a repository variable

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -289,7 +289,10 @@ jobs:
           NEEDLEFISH_TIMEOUT_MS_INPUT: ${{ inputs.timeout_ms || github.event.inputs.timeout_ms }}
           OPENCODE_IDLE_TIMEOUT_MS_INPUT: ${{ inputs.idle_timeout_ms || github.event.inputs.idle_timeout_ms }}
           CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort || github.event.inputs.codex_reasoning_effort }}
-          CODEX_PROXY_BASE_URL_INPUT: ${{ inputs.codex_proxy_base_url }}
+          # The base URL is not secret; a repo variable lets pull_request events
+          # (which carry no workflow inputs) use the same proxy route that a
+          # dispatch with codex_proxy_base_url uses. Inputs win when supplied.
+          CODEX_PROXY_BASE_URL_INPUT: ${{ inputs.codex_proxy_base_url || vars.CODEX_PROXY_BASE_URL }}
           CODEX_PROXY_API_KEY_INPUT: ${{ secrets.codex_proxy_api_key }}
           NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT: ${{ inputs.codex_proxy_required && '1' || '' }}
           # ubuntu-needlefish routes pi through the local CLIProxyAPI (ccp);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- GitHub: the review workflow falls back to the `CODEX_PROXY_BASE_URL`
+  repository variable when the `codex_proxy_base_url` input is absent, so
+  `pull_request` events can use the proxy route instead of failing closed when
+  only the secret is set.
 - GitHub: the reconcile job now reads check-runs with `filter=all`, so its
   two-infra-failure retry cap can actually trip, and detects an active review
   for the same PR by workflow file and the PR number carried in `run-name`

--- a/README.md
+++ b/README.md
@@ -355,7 +355,10 @@ jobs:
    ```
 4. Supply Codex's proxy route to the reusable workflow with
    `codex_proxy_base_url`, `codex_proxy_required: true`, and the
-   `codex_proxy_api_key` workflow secret. Needlefish
+   `codex_proxy_api_key` workflow secret. `pull_request` events carry no
+   workflow inputs, so for this repo's own reviews set the repository variable
+   `CODEX_PROXY_BASE_URL` alongside the secret; the workflow falls back to it
+   when the input is absent. Needlefish
    registers the `cliproxyapi` custom provider on the command line while the
    credential remains only in the child environment; required mode rejects
    incomplete configuration instead of falling back to OAuth. Proxy invocations

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -306,7 +306,9 @@ jobs:
    ```
    呼叫 reusable workflow 時傳入 `codex_proxy_base_url`、
    `codex_proxy_required: true` 與 `codex_proxy_api_key` workflow secret。
-   Needlefish 會在命令列註冊
+   `pull_request` 事件不帶 workflow input，所以本 repo 自己的 review 要另外
+   設定 repository variable `CODEX_PROXY_BASE_URL`；input 缺席時 workflow 會
+   退回使用這個變數。Needlefish 會在命令列註冊
    `cliproxyapi` custom provider，但 credential 只存在子程序環境；required
    模式缺少任一設定會直接失敗，不會退回 OAuth，且 proxy invocation 不帶
    direct subscription 的 `service_tier` override。Grok 則依 provider 完成

--- a/scripts/review-workflow-release.test.mjs
+++ b/scripts/review-workflow-release.test.mjs
@@ -238,7 +238,7 @@ test("review maps supplied Codex proxy values atomically without erasing runner 
 	assert.match(workflow, /codex_proxy_base_url:\n\s+description: Optional CLIProxyAPI base URL for Codex/);
 	assert.match(workflow, /codex_proxy_api_key:\n\s+description: CLIProxyAPI credential for Codex/);
 	assert.match(workflow, /codex_proxy_required:\n\s+description: Prohibit Codex OAuth fallback\n\s+type: boolean/);
-	assert.match(workflow, /CODEX_PROXY_BASE_URL_INPUT: \$\{\{ inputs\.codex_proxy_base_url \}\}/);
+	assert.match(workflow, /CODEX_PROXY_BASE_URL_INPUT: \$\{\{ inputs\.codex_proxy_base_url \|\| vars\.CODEX_PROXY_BASE_URL \}\}/);
 	assert.match(workflow, /CODEX_PROXY_API_KEY_INPUT: \$\{\{ secrets\.codex_proxy_api_key \}\}/);
 	assert.match(workflow, /NEEDLEFISH_CODEX_PROXY_REQUIRED_INPUT: \$\{\{ inputs\.codex_proxy_required && '1' \|\| '' \}\}/);
 	assert.match(reviewScript, /if \[ -n "\$CODEX_PROXY_BASE_URL_INPUT" \] \|\| \[ -n "\$CODEX_PROXY_API_KEY_INPUT" \]; then/);


### PR DESCRIPTION
## Problem

Every `pull_request` review on this repo has failed since the `codex_proxy_api_key` secret was added: `pull_request` events carry no workflow inputs, so `CODEX_PROXY_BASE_URL_INPUT` is empty while the key is set, and the step's guard ("base URL and API key must be supplied together") exits 1 before the model runs. The guard is right: a key without a route must never fall back to OAuth (which is exhausted on the runner until Oct 5). What was missing is a non-input source for the route.

## Change

`CODEX_PROXY_BASE_URL_INPUT: ${{ inputs.codex_proxy_base_url || vars.CODEX_PROXY_BASE_URL }}`. The base URL is not secret. An explicit input still wins. The repository variable is set. README and changelog note it.

## Evidence

Workflow shape test updated; 202/202 `scripts/` tests, `pnpm check`, `pnpm lint`, YAML parse. Live proof will be the next `pull_request` review on this repo completing through the proxy without the guard firing; manual dispatches with the input already work (PR #104 got a real review that way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)