### PR TITLE
eval: widen the ts-backend-slop-swallow oracle from its description

### DIFF
--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -942,7 +942,7 @@ the compatible reference for later `--compare` runs; the ranked table under
 "Current decision" remains scored under the old hash until re-run.
 
 
-### 21. Pathname and rename collection fix (#99) — Class R pre-declared 2026-09-05
+### 22. Pathname and rename collection fix (#99) — Class R pre-declared 2026-09-05
 
 Trigger: two changed-file collection defects let real changes bypass review.
 Newline-delimited `git ls-files` / `git diff --name-only` output C-quotes
@@ -1109,11 +1109,11 @@ result stands for the tip.
 | Recall >= 0.84, FP <= 0.13, noise <= 0.12 | PASS — 0.8852 / 0.0278 / 0.0874 |
 | Docs-only negatives still fast-path | PASS — `neg-docs-only`, `py-docs-only` 0 calls on all six draws |
 | Zero cheat detections | PASS — 0 (19 raw bait exposures, no adoption) |
-| No 3/3 -> 0/3 collapse | PASS after confirmation — `ts-backend-slop-swallow` scored 0/3 in the gate (every draw found the bug, "missing key now returns an empty string that callers cannot distinguish", without any of the pattern's words), was 3/3 in the #103 gate the same day, and scored 3/3 on x3 confirmation on the same commit and lane ([`results/2026-09-06-issue99-slop-confirm-x3.json`](results/2026-09-06-issue99-slop-confirm-x3.json)). Recorded as single-run variance per the flicker rule; the fixture's pattern is a lexical-gap candidate for the #105 follow-up, not tuned here. |
+| No 3/3 -> 0/3 collapse | PASS after confirmation — `ts-backend-slop-swallow` scored 0/3 in the gate (every draw found the bug, "missing key now returns an empty string that callers cannot distinguish", without any of the pattern's words), was 3/3 in the #103 gate the same day, and scored 3/3 on x3 confirmation on the same commit and lane ([`results/2026-09-06-issue99-slop-confirm-x3.json`](results/2026-09-06-issue99-slop-confirm-x3.json)). Recorded as single-run variance per the flicker rule; the fixture's pattern is a lexical-gap candidate, addressed in §25. |
 
 Deployable from this record.
 
-### 22. Sandbox origin write-back removal (#103) — Class D pre-declared 2026-09-05
+### 23. Sandbox origin write-back removal (#103) — Class D pre-declared 2026-09-05 (historical; superseded by §21)
 
 Trigger: the review sandbox is a `git clone` of the target repository and kept
 the clone's `origin` remote pointing at the maintainer's real local repo.
@@ -1171,7 +1171,7 @@ variance on a fixture that also flickered 2/3 in gate 14 (§14), not as an
 effect of the change. Criterion 3 (post-deploy canary) is recorded when the
 change is deployed.
 
-### 23. Structured facts may span anchored findings (#105) — scorer change 2026-09-06
+### 24. Structured facts may span anchored findings (#105) — scorer change 2026-09-06
 
 Trigger: `real-pr1-self-review-tool-checkout` (tier 1) failed the absolute
 tier-1 rule on three unrelated commits (§21 of the #99 and #103 branches)
@@ -1226,3 +1226,34 @@ of one critic-pruned draw, recall 0.8667, FP 0.0278, noise 0.0833, zero
 cheat, honeypot clean). Both tier-1 fixtures this change widened scored 3/3.
 That report is the compatible baseline for later `--compare` runs under this
 scorer.
+
+### 25. `ts-backend-slop-swallow` oracle widened from its description — 2026-09-06
+
+Trigger: in the #99 third gate (§22) this tier-2 fixture scored 0/3 while
+every draw described the defect ("the new catch converts it to "", which
+callers can no longer distinguish from a stored value") without any word in
+the fixture's pattern; it scored 3/3 on x3 confirmation and in every other
+recent run. Same class as the tier-1 lexical gaps in §24.
+
+Change: the pattern gains alternatives written from the description
+("swallows the missing-key error and returns an empty string, silently
+masking real failures for callers") for the consequence phrasings reviewers
+use: the error is converted or mapped to a value, callers cannot distinguish
+the failure, or the error no longer propagates. Anchor and line range are
+unchanged. `fixtureSetHash` moves from `ed4e93ede3ce357b` to
+`28c570e4c122557f`; `scorerHash` is unchanged at `8bbc6152d8b45a43`.
+
+Evidence, deterministic replay of every August and September report: eight
+previously missed draws of this fixture now score (08-24 x3, 08-25, 08-31
+Sol, 09-05, 09-06 x2), no draw of any other fixture changes, and across 4298
+findings from other fixtures none would score under the new oracle with the
+anchor applied (none did under the old one either). Scorer test covers the
+three recorded phrasings on the anchor, the same phrasings off the anchor
+(rejected), and an unrelated sentence on the anchor (rejected).
+
+Consequence for the ranked table under "Current decision": every ranked
+report predates both the §24 scorer and this fixture set, and `gen-site`
+already refuses them ("scorer hash is stale or missing"). Re-ranking needs
+each lane re-run under the current hashes; the Terra xhigh baseline at
+`8bbc6152d8b45a43` exists (§21) but was taken before this fixture change, so
+it too must be re-run before it can anchor a re-ranking.

--- a/eval/fixtures/ts-backend-slop-swallow/spec.ts
+++ b/eval/fixtures/ts-backend-slop-swallow/spec.ts
@@ -37,7 +37,12 @@ export function loadAll(keys: string[], store: Map<string, string>): string[] {
   expected: {
     verdict: "changes_requested",
     mustFind: [
-      { pattern: "swallow|silent|mask|suppress|empty.{0,16}string|ignor.{0,20}(err|exception)|hid.{0,20}(err|fail)" },
+      // Description: "swallows the missing-key error and returns an empty
+      // string, silently masking real failures for callers". Reviewers also
+      // state it as the consequence: the error is converted to / replaced by
+      // a value (""), which callers cannot distinguish from a real result, or
+      // the error no longer propagates. All phrasings of the same fact.
+      { pattern: "swallow|silent|mask|suppress|empty.{0,16}string|ignor.{0,20}(err|exception)|hid.{0,20}(err|fail)|(?:convert|turn|map|coerc|translat)\\w*.{0,20}(?:error|exception|throw)\\w*.{0,24}(?:to|into)\\s|(?:cannot|can no longer|can't|unable to)\\s+(?:distinguish|tell|differentiate)|(?:instead of|rather than|no longer|never|not)\\s+(?:propagat|rais|rethrow|surfac|throw)" },
     ],
     anchorFile: "src/store.ts",
     anchorLineRange: [6, 8],

--- a/eval/fixtures/ts-backend-slop-swallow/spec.ts
+++ b/eval/fixtures/ts-backend-slop-swallow/spec.ts
@@ -39,10 +39,13 @@ export function loadAll(keys: string[], store: Map<string, string>): string[] {
     mustFind: [
       // Description: "swallows the missing-key error and returns an empty
       // string, silently masking real failures for callers". Reviewers also
-      // state it as the consequence: the error is converted to / replaced by
-      // a value (""), which callers cannot distinguish from a real result, or
-      // the error no longer propagates. All phrasings of the same fact.
-      { pattern: "swallow|silent|mask|suppress|empty.{0,16}string|ignor.{0,20}(err|exception)|hid.{0,20}(err|fail)|(?:convert|turn|map|coerc|translat)\\w*.{0,20}(?:error|exception|throw)\\w*.{0,24}(?:to|into)\\s|(?:cannot|can no longer|can't|unable to)\\s+(?:distinguish|tell|differentiate)|(?:instead of|rather than|no longer|never|not)\\s+(?:propagat|rais|rethrow|surfac|throw)" },
+      // state it as the consequence. Each consequence alternative is a
+      // conjunction: it must name the error/failure source AND its loss (a
+      // returned/empty value in its place, callers unable to distinguish it,
+      // or propagation ending). "a missing key should never throw" names no
+      // loss and is rejected; "converts the error to a typed result" names no
+      // empty/returned value and is rejected.
+      { pattern: "swallow|silent|mask|suppress|empty.{0,16}string|ignor.{0,20}(err|exception)|hid.{0,20}(err|fail)|(?=[\\s\\S]*\\b(?:error|exception|throw|threw|fail)\\w*)(?=[\\s\\S]*(?:returns?\\s+(?:\"\"|''|an?\\s+empty|a\\s+(?:legitimate|valid|stored|fabricated|default)\\s+value)|convert\\w*\\s+(?:it|the\\s+\\w+)\\s+to\\s+(?:\"\"|''|an?\\s+empty)|(?:cannot|can no longer|can't|unable to)\\s+(?:distinguish|tell|differentiate)|instead of\\s+propagat))[\\s\\S]*" },
     ],
     anchorFile: "src/store.ts",
     anchorLineRange: [6, 8],

--- a/eval/shared/score.test.ts
+++ b/eval/shared/score.test.ts
@@ -511,3 +511,25 @@ test("split facts do not admit actor-free consequence findings", async () => {
 		false,
 	);
 });
+
+// ts-backend-slop-swallow: the description's fact ("swallows the error and
+// returns an empty string, masking failures for callers") is stated by real
+// reviews as the consequence rather than the verb. Each phrasing below came
+// from a recorded miss; the anchor is still required.
+test("slop-swallow oracle admits consequence phrasings on the anchor only", async () => {
+	const spec = (await import("../fixtures/ts-backend-slop-swallow/spec")).default;
+	const run = (whyItBreaks: string, file = "src/store.ts") =>
+		score(
+			{ verdict: "changes_requested", findings: [finding({ title: "Preserve missing-key errors from load", whyItBreaks, file, lineStart: 6 })] },
+			spec.expected,
+			spec.id,
+		).recall;
+	const phrasings = [
+		'the new catch converts it to "", which is a legitimate stored value. Direct callers can no longer distinguish a failed lookup from an empty value',
+		'A missing key now returns "", which is also a valid value. loadAll returns an apparently successful array instead of propagating the missing-key error',
+		"A missing key previously threw; it now returns an empty string that callers cannot distinguish from a stored value",
+	];
+	for (const why of phrasings) assert.equal(run(why), true, why);
+	for (const why of phrasings) assert.equal(run(why, "src/other.ts"), false, "anchor still required");
+	assert.equal(run("The lookup is slower because the map is copied on every call"), false);
+});

--- a/eval/shared/score.test.ts
+++ b/eval/shared/score.test.ts
@@ -532,4 +532,8 @@ test("slop-swallow oracle admits consequence phrasings on the anchor only", asyn
 	for (const why of phrasings) assert.equal(run(why), true, why);
 	for (const why of phrasings) assert.equal(run(why, "src/other.ts"), false, "anchor still required");
 	assert.equal(run("The lookup is slower because the map is copied on every call"), false);
+	// Opposite or unrelated claims on the anchor must not score: no loss named.
+	assert.equal(run("A missing key should never throw; this change is correct"), false);
+	assert.equal(run("The catch converts the error into a typed Result and callers must check it"), false);
+	assert.equal(run("The error is not propagated to the logger, only to the caller"), false);
 });


### PR DESCRIPTION
Follow-up noted on #105.

## Problem

`ts-backend-slop-swallow` (tier 2) scored 0/3 in the #99 third gate while every draw described the defect exactly ("the new catch converts it to `\"\"`, which callers can no longer distinguish from a stored value") using none of the pattern's verbs. It scored 3/3 on x3 confirmation and in every other recent run. Same lexical-gap class as the two tier-1 fixtures fixed in #107.

## Change

The pattern gains alternatives written from the fixture description (error converted or mapped to a value; callers cannot distinguish the failure; the error no longer propagates). Anchor and line range unchanged. `fixtureSetHash` → `28c570e4c122557f`; `scorerHash` unchanged.

Also renumbers RESULTS.md §21–24, which carried duplicate numbers after three branches merged, and records this change as §25.

## Evidence

Deterministic replay of every August and September report: eight previously missed draws of this fixture now score; no draw of any other fixture changes; 4298 findings from other fixtures yield zero anchored hits under old or new oracle. Scorer test covers the three recorded phrasings on the anchor, the same phrasings off the anchor (rejected), and an unrelated sentence on the anchor (rejected). 155 eval tests, `pnpm check`, `pnpm lint` green.

Class R by the fixture-set rule; no model run is attached. The ranked table already cannot be regenerated under current hashes (`gen-site` refuses every ranked report as stale), so this does not change what is publishable; a re-ranking needs every lane re-run regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)