### PR TITLE
chore: remove redundant tests and unused declarations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,11 +7,4 @@ export default tseslint.config(
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
-  {
-    files: ["src/**/*.ts", "eval/**/*.ts", "scripts/**/*.mjs"],
-    rules: {
-      // Start unopinionated -- this is the first lint pass on this codebase.
-      // Tighten rules in a follow-up once the baseline violation count is known.
-    },
-  }
 );

--- a/src/core/review-trace.ts
+++ b/src/core/review-trace.ts
@@ -1,13 +1,5 @@
 import type { Finding, MapResult, RawReview } from "../shared/schema.js";
 
-export type ReviewTraceSurface =
-	| "raw_success"
-	| "raw_failure"
-	| "candidate_finding"
-	| "candidate_review_text"
-	| "final_finding"
-	| "final_review_text";
-
 export type ReviewTracePassKind = "review" | "map" | "deep" | "critic";
 
 export type ReviewTraceOutcome =

--- a/src/core/verdict.test.ts
+++ b/src/core/verdict.test.ts
@@ -16,18 +16,6 @@ const finding: Finding = {
   validation: "pnpm test",
 };
 
-test("deriveVerdict requests changes for blocking findings", () => {
-  const verdict = deriveVerdict([finding], []);
-
-  assert.equal(verdict, "changes_requested");
-});
-
-test("deriveVerdict needs human when only residual risk blocks", () => {
-  const verdict = deriveVerdict([], [{ text: "deep pass failed", blocks: true }]);
-
-  assert.equal(verdict, "needs_human");
-});
-
 test("deriveVerdict passes when no blocking evidence remains", () => {
   const verdict = deriveVerdict([], [{ text: "low confidence area", blocks: false }]);
 


### PR DESCRIPTION
Remove two verdict tests whose exact inputs and expectations already appear in the retained severity table, the unused `ReviewTraceSurface` type, and an empty ESLint override with stale setup comments. This removes 27 lines without changing runtime behavior or distinct test coverage.

The audit inspected every major directory, including source, eval tooling and fixtures, scripts, launchers, prompts, workflows, docs, plans, assets, and tool configuration. Helpers and historical artifacts with distinct purposes were retained.

Validation:
- Focused verdict and review-trace tests passed before and after cleanup.
- Full `pnpm test`: 884 passed, zero failures or skips.
- `pnpm check`, `pnpm lint`, and `git diff --check` passed.
- Effective ESLint configurations are identical for all 187 tracked JavaScript/TypeScript files.
- Emitted JavaScript for `review-trace.ts` is byte-identical; repository reference search found no consumers of the removed type.

Eval gate: not applicable; no runtime, prompt, normalization, or scoring behavior changed.
