### PR TITLE
fix(eval): keep historical conclusions out of current reports

### DIFF
--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -1948,6 +1948,16 @@ test("gen-baseline-doc refuses unsafe or incomplete reports", async (t) => {
   assert.doesNotMatch(noArg.stderr, /refusing to generate baseline doc/);
 });
 
+test("renderResults does not attach historical run conclusions to current inputs", () => {
+  const spec = holdoutSpec("current-report-notes", false);
+  const report = resumeReport(spec, { anticheatVersion: 2 });
+  for (const reports of [[], [{ stem: "current-run", report }]]) {
+    const md = renderResults([], reports);
+    assert.doesNotMatch(md, /grok-build-0\.1|grok-composer-2\.5-fast|codex medium|claude opus-47/);
+    assert.match(md, /\[Historical experiment notes\]\(RESULTS_HISTORY\.md\)/);
+  }
+});
+
 test("renderResults: mixed prompt hashes are reported, not asserted shared", () => {
   const spec = holdoutSpec("gen-results-hashes", false);
   const a = resumeReport(spec, { anticheatVersion: 2, effort: "xhigh" });

--- a/eval/gen-results.ts
+++ b/eval/gen-results.ts
@@ -189,11 +189,8 @@ export function renderResults(specs: FixtureSpec[], reports: NamedReport[]): str
   }
   lines.push(``);
   lines.push(`## Notes`);
-  lines.push(`- **Runner reliability confound (opencode @ max):** high invalidJson = timeout/parse fail from opencode's agentic loop, not model quality. Proven by grok-build-0.1: opencode agentic = 12% recall / 56% invalidJson; same model via direct single-shot (openai runner) = 47% recall / 2% invalidJson. opencode @ max numbers are runner-confounded — treat as lower bounds, not model quality.`);
-  lines.push(`- **Partials (⚠️):** grok-build-0.1-direct = 98/102 (4 draws lost to grok outage on sql-data-migration-break); grok-composer-2.5-fast = 52/102 (skipped mid-run, grok instability). Their recall/fp are over completed draws only.`);
+  lines.push(`- [Historical experiment notes](RESULTS_HISTORY.md) record results from earlier runs.`);
   lines.push(`- recall is a regex lower bound; a model may have found the bug with different wording and still scored 0. Use \`eval/inspect.ts <fixture-id>\` to verify specific misses.`);
-  lines.push(`- codex medium (76%) ≈ high (74%) within 3-draw noise — reasoning effort is not monotonic in recall here.`);
-  lines.push(`- claude opus-47 (76%) > opus-48 (64%) — newer opus regressed on this set.`);
 
   return lines.join("\n") + "\n";
 }


### PR DESCRIPTION
`renderResults` appended fixed historical model rankings and partial-run counts even when no reports were loaded. Remove the four historical assertions from dynamic output and link to their existing record in `RESULTS_HISTORY.md`.

A regression test covers empty inputs and an unrelated current report. Current report metrics and scoring are unchanged; the renderer was tested without overwriting the maintained `RESULTS.md`.

Validation: `pnpm check`, `pnpm lint`, full `pnpm test` (888 passed), `git diff --check`, and structured Codex autoreview passed. Pipeline eval classification: not applicable; this changes report presentation only.
