### PR TITLE
chore: remove unused runner state and redundant test setup

### DIFF
--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -388,24 +388,19 @@ test("matchesSpec: regex against title + whyItBreaks, optional category", () => 
 });
 
 test("score: positive fixture with a matching anchored finding passes recall + anchor", () => {
-  const loaded = loadFixture(posOverBlock);
-  try {
-    const expected = posOverBlock.expected;
-    const result = {
-      verdict: "changes_requested" as Verdict,
-      findings: [
-        finding({ title: "over-block: isEligible rejects viewers", whyItBreaks: "the viewer read-only branch in handle is now unreachable", file: "src/handler.ts", lineStart: 18 }),
-      ],
-    };
-    const s = score(result, expected, posOverBlock.id);
-    assert.equal(s.formatOk, true);
-    assert.equal(s.verdictMatch, true);
-    assert.equal(s.recall, true);
-    assert.equal(s.lineAnchorValid, true);
-    assert.equal(s.falsePositive, false);
-  } finally {
-    loaded.cleanup();
-  }
+  const expected = posOverBlock.expected;
+  const result = {
+    verdict: "changes_requested" as Verdict,
+    findings: [
+      finding({ title: "over-block: isEligible rejects viewers", whyItBreaks: "the viewer read-only branch in handle is now unreachable", file: "src/handler.ts", lineStart: 18 }),
+    ],
+  };
+  const s = score(result, expected, posOverBlock.id);
+  assert.equal(s.formatOk, true);
+  assert.equal(s.verdictMatch, true);
+  assert.equal(s.recall, true);
+  assert.equal(s.lineAnchorValid, true);
+  assert.equal(s.falsePositive, false);
 });
 
 test("score: positive fixture with no matching finding fails recall", () => {

--- a/src/shared/classify.test.ts
+++ b/src/shared/classify.test.ts
@@ -29,10 +29,8 @@ test("classifySurface keeps policy markdown as docs (prose) without promoting it
 });
 
 test("classifySurface rule order is unchanged for non-docs surfaces", () => {
-  assert.equal(classifySurface(".github/workflows/review.yml"), "workflow");
   assert.equal(classifySurface(".github/workflows/docs.yml"), "workflow");
   assert.equal(classifySurface("docs/.github/workflows/ci.yml"), "workflow");
-  assert.equal(classifySurface("package.json"), "dependency");
   assert.equal(classifySurface("pnpm-lock.yaml"), "dependency");
   assert.equal(classifySurface("node_modules/foo/index.js"), "dependency");
   assert.equal(classifySurface("src/foo.test.ts"), "test");
@@ -45,7 +43,6 @@ test("classifySurface rule order is unchanged for non-docs surfaces", () => {
   assert.equal(classifySurface("foo.sql"), "schema");
   assert.equal(classifySurface("bin/cli.ts"), "cli");
   assert.equal(classifySurface("cli/main.ts"), "cli");
-  assert.equal(classifySurface("src/api/users.ts"), "public-api");
   assert.equal(classifySurface("lib/api/foo.ts"), "public-api");
   assert.equal(classifySurface("routes/index.ts"), "public-api");
   assert.equal(classifySurface(".env"), "config");
@@ -76,7 +73,6 @@ test("isDocsFastPathEligible is a generic user-facing-docs allowlist", () => {
   assert.equal(isDocsFastPathEligible("AGENTS.md"), false);
   assert.equal(isDocsFastPathEligible("src/AGENTS.md"), false);
   assert.equal(isDocsFastPathEligible("docs/AGENTS.md"), false);
-  assert.equal(isDocsFastPathEligible("CLAUDE.md"), false);
   assert.equal(isDocsFastPathEligible("DESIGN.md"), false);
   assert.equal(isDocsFastPathEligible(".github/workflows/review.yml"), false);
 });
@@ -97,14 +93,8 @@ test("isDocsFastPathEligible excludes CLAUDE.md policy files anywhere in the tre
   assert.equal(isDocsFastPathEligible("CLAUDE.local.md"), false);
   assert.equal(isDocsFastPathEligible("docs\\nested\\CLAUDE.md"), false);
   // The AGENTS.md rule this mirrors, and ordinary docs, are unaffected.
-  assert.equal(isDocsFastPathEligible("AGENTS.md"), false);
-  assert.equal(isDocsFastPathEligible("docs/AGENTS.md"), false);
   assert.equal(isDocsFastPathEligible("packages/app/AGENTS.review.md"), false);
-  assert.equal(isDocsFastPathEligible("prompts/review.md"), false);
-  assert.equal(isDocsFastPathEligible("docs/prompts/review.md"), false);
-  assert.equal(isDocsFastPathEligible("docs/guide.md"), true);
   assert.equal(isDocsFastPathEligible("docs/claude-setup.md"), true);
-  assert.equal(isDocsFastPathEligible("README.md"), true);
 });
 
 // The backstop that closes the class rather than one vendor at a time: under a
@@ -128,7 +118,6 @@ test("isDocsFastPathEligible fails closed on unrecognized ALL-CAPS Markdown unde
   assert.equal(isDocsFastPathEligible("docs/LICENSE.md"), true);
   assert.equal(isDocsFastPathEligible("docs/README.zh-TW.md"), true);
   // Descriptively named prose is unaffected -- this is not an uppercase ban.
-  assert.equal(isDocsFastPathEligible("docs/guide.md"), true);
   assert.equal(isDocsFastPathEligible("docs/api-reference.md"), true);
   assert.equal(isDocsFastPathEligible("docs/Getting-Started.md"), true);
   assert.equal(isDocsFastPathEligible("docs/qwen.md"), true);

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -1030,7 +1030,7 @@ async function runCodexCli(
 	try {
 		out = readFileSync(lastMsg, "utf8");
 	} catch {
-		out = res.stdout ?? "";
+		out = res.stdout;
 	}
 	return { res, out };
 }
@@ -1070,7 +1070,7 @@ async function runClaude(invocation: RunnerInvocation): Promise<RunnerResult> {
 		timeoutMs: invocation.timeoutMs,
 		env: invocation.env,
 	});
-	return { res, out: res.stdout ?? "" };
+	return { res, out: res.stdout };
 }
 
 async function runOpenCode(
@@ -1109,7 +1109,7 @@ async function runOpenCode(
 			OPENCODE_CONFIG_CONTENT: unrestrictedConfig,
 		},
 	});
-	return { res, out: res.stdout ?? "" };
+	return { res, out: res.stdout };
 }
 
 async function runGrok(invocation: RunnerInvocation): Promise<RunnerResult> {
@@ -1139,7 +1139,7 @@ async function runGrok(invocation: RunnerInvocation): Promise<RunnerResult> {
 		timeoutMs: invocation.timeoutMs,
 		env: invocation.env,
 	});
-	return { res, out: res.stdout ?? "" };
+	return { res, out: res.stdout };
 }
 
 const PI_THINKING_LEVELS = [
@@ -1194,25 +1194,11 @@ async function runPi(invocation: RunnerInvocation): Promise<RunnerResult> {
 		timeoutMs: invocation.timeoutMs,
 		env: invocation.env,
 	});
-	return { res, out: res.stdout ?? "" };
+	return { res, out: res.stdout };
 }
 
 function outputFor(runner: RunnerName, result: RunnerResult): string {
-	switch (runner) {
-		case "codex":
-		case "claude":
-			return result.out;
-		case "opencode":
-			return extractOpenCodeText(result.out);
-		case "openai":
-			return result.out;
-		case "grok":
-			return result.out;
-		case "pi":
-			return result.out;
-		case "acp":
-			return result.out;
-	}
+	return runner === "opencode" ? extractOpenCodeText(result.out) : result.out;
 }
 
 async function runOpenAIDirect(

--- a/src/shared/runner-process.ts
+++ b/src/shared/runner-process.ts
@@ -43,7 +43,6 @@ export interface ManagedRunnerProcessInvocation {
   readonly env: NodeJS.ProcessEnv;
   readonly onSpawn?: RunnerLifecycleHandler;
   readonly onStdout?: RunnerChunkHandler;
-  readonly onStderr?: RunnerChunkHandler;
   readonly onTimeout?: RunnerLifecycleHandler;
 }
 
@@ -283,12 +282,6 @@ export async function runManagedRunnerProcess(
     child.stderr.on("data", (chunk: unknown) => {
       const text = collect(stderr, stderrBytes, chunk);
       if (text !== null) refreshIdleTimer();
-      if (text === null || invocation.onStderr === undefined) return;
-      try {
-        invocation.onStderr(text, controller);
-      } catch (error) {
-        failFromHandler(error);
-      }
     });
     child.stdin.on("error", (error) => {
       if (timeoutError === undefined && bufferError === undefined && spawnError === undefined) {

--- a/src/shared/temp-lifecycle.ts
+++ b/src/shared/temp-lifecycle.ts
@@ -47,7 +47,6 @@ interface RunnerProcessGroup {
   readonly directory: string | null;
   readonly terminate: (signal: NodeJS.Signals) => void;
   readonly kill: () => void;
-  readonly exited: Promise<void>;
 }
 
 const activeTempDirectories = new Set<string>();
@@ -145,7 +144,6 @@ export function registerRunnerProcessGroup(
     directory: findRegisteredTempDirectory(repoPath),
     terminate,
     kill,
-    exited,
   };
   activeRunnerProcessGroups.set(pid, group);
   const unregister = (): void => {


### PR DESCRIPTION
Remove runner and test code with no remaining responsibility: the unread stored `exited` promise, unused `onStderr` hook, non-null stdout fallbacks, repeated output dispatch branches, unused Git fixture setup in a pure scoring test, and 11 exact duplicate classifier assertions.

Stderr buffering and idle refresh, exit unregistration, opencode output extraction, all five scoring assertions and all 109 unique classifier assertions remain covered. The hook has no repository callers; undocumented external deep imports of published `dist` cannot be ruled out.

Validation: `pnpm check`, `pnpm lint`, full `pnpm test` (887 passed), `git diff --check`, and structured Codex autoreview passed.

`gateClass: D`: existing runtime outputs are preserved. The resident tests passed. The eval gate is skipped for this PR at the owner's explicit direction (2026-09-06), not recorded as passing. No live model gate or deployment canary was run.

