### PR TITLE
fix: isolate review trace provenance from pipeline values

### DIFF
--- a/src/core/review-trace.test.ts
+++ b/src/core/review-trace.test.ts
@@ -1,6 +1,69 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { observeReviewTrace } from "./review-trace.js";
+import {
+	observeCandidateReviewTrace,
+	observeFinalReviewTrace,
+	observeMapCandidateTrace,
+	observeReviewTrace,
+	type ReviewTraceEvent,
+	type ReviewTraceProvenance,
+} from "./review-trace.js";
+import type { RawReview } from "../shared/schema.js";
+
+test("candidate, map, and final traces copy only declared provenance fields", async () => {
+	const review: RawReview = {
+		summary: "candidate",
+		findings: [{
+			category: "bug", severity: "P2", confidence: 0.9,
+			file: "src/app.ts", lineStart: 1, lineEnd: 1,
+			title: "bug", whyItBreaks: "breaks", suggestedFix: "fix", validation: "test",
+		}],
+		checked: ["checked"],
+		residual_risks: [],
+	};
+	const provenance: ReviewTraceProvenance = {
+		passKind: "review", passIndex: 2, promptAttempt: 3, runnerAttempt: 4,
+	};
+	// review() passes PromptResult objects, whose extra value is mutable.
+	const result = { value: review, ...provenance };
+	const events: ReviewTraceEvent[] = [];
+	const observer = (event: ReviewTraceEvent): void => { events.push(event); };
+	await observeCandidateReviewTrace({ observer, review, provenance: result });
+	const mapResult = { summary: "map", hotspots: [] };
+	const mapPromptResult = { value: mapResult, ...provenance };
+	await observeMapCandidateTrace({
+		observer, mapResult, provenance: mapPromptResult,
+	});
+	await observeFinalReviewTrace({ observer, review, summary: "final", provenance: result });
+	assert.deepEqual(events.map((event) => event.surface), [
+		"candidate_finding", "candidate_review_text", "candidate_review_text",
+		"final_finding", "final_review_text",
+	]);
+	const text = { checked: review.checked, residual_risks: [] };
+	assert.deepEqual(events.map((event) => event.content), [
+		JSON.stringify(review.findings[0]),
+		JSON.stringify({ summary: "candidate", ...text }),
+		JSON.stringify(mapResult),
+		JSON.stringify(review.findings[0]),
+		JSON.stringify({ summary: "final", ...text }),
+	]);
+	for (const event of events) {
+		assert.deepEqual(Object.keys(event), [
+			"content", "surface", ...(event.finding ? ["finding"] : []), "outcome",
+			"passKind", "passIndex", "promptAttempt", "runnerAttempt",
+		]);
+		assert.equal(Object.isFrozen(event), true);
+		assert.equal(event.outcome, "parsed");
+		assert.deepEqual({
+			passKind: event.passKind, passIndex: event.passIndex,
+			promptAttempt: event.promptAttempt, runnerAttempt: event.runnerAttempt,
+		}, provenance);
+		if (event.finding) {
+			assert.equal(Object.isFrozen(event.finding), true);
+			assert.notEqual(event.finding, review.findings[0]);
+		}
+	}
+});
 
 test("observeReviewTrace propagates asynchronous observer rejection", async () => {
 	const rejection = new Error("trace delivery failed");

--- a/src/core/review-trace.ts
+++ b/src/core/review-trace.ts
@@ -96,6 +96,16 @@ function snapshotFinding(finding: Finding): ReviewTraceFindingSnapshot {
 	});
 }
 
+function snapshotProvenance({
+	passKind,
+	passIndex,
+	promptAttempt,
+	runnerAttempt,
+}: ReviewTraceProvenance): ReviewTraceProvenance {
+	// Callers pass PromptResult: spreading it would expose its mutable value.
+	return { passKind, passIndex, promptAttempt, runnerAttempt };
+}
+
 export async function observeCandidateReviewTrace({
 	observer,
 	review,
@@ -109,7 +119,7 @@ export async function observeCandidateReviewTrace({
 			surface: "candidate_finding",
 			finding: snapshotFinding(finding),
 			outcome: "parsed",
-			...provenance,
+			...snapshotProvenance(provenance),
 		}));
 	}
 	deliveries.push(observeReviewTrace(observer, {
@@ -120,7 +130,7 @@ export async function observeCandidateReviewTrace({
 		}),
 		surface: "candidate_review_text",
 		outcome: "parsed",
-		...provenance,
+		...snapshotProvenance(provenance),
 	}));
 	await Promise.all(deliveries);
 }
@@ -135,7 +145,7 @@ export async function observeMapCandidateTrace({
 		content: JSON.stringify(mapResult),
 		surface: "candidate_review_text",
 		outcome: "parsed",
-		...provenance,
+		...snapshotProvenance(provenance),
 	});
 }
 
@@ -153,7 +163,7 @@ export async function observeFinalReviewTrace({
 			surface: "final_finding",
 			finding: snapshotFinding(finding),
 			outcome: "parsed",
-			...provenance,
+			...snapshotProvenance(provenance),
 		}));
 	}
 	deliveries.push(observeReviewTrace(observer, {
@@ -164,7 +174,7 @@ export async function observeFinalReviewTrace({
 		}),
 		surface: "final_review_text",
 		outcome: "parsed",
-		...provenance,
+		...snapshotProvenance(provenance),
 	}));
 	await Promise.all(deliveries);
 }

--- a/src/core/review.test.ts
+++ b/src/core/review.test.ts
@@ -95,6 +95,48 @@ test("review preserves deep evidence through tail coverage", async (t) => {
 	};
 
 	const result = await review(bundle);
+	const events: ReviewTraceEvent[] = [];
+	const observed = await review(bundle, {}, (event) => {
+		events.push(event);
+		const value: unknown = Reflect.get(event, "value");
+		if (typeof value === "object" && value !== null) {
+			Reflect.set(value, "summary", "observer-mutated");
+			for (const key of ["findings", "hotspots"]) {
+				const entries: unknown = Reflect.get(value, key);
+				if (Array.isArray(entries)) entries.length = 0;
+			}
+		}
+	});
+	assert.deepEqual(
+		{
+			...observed,
+			stats: observed.stats?.map((stat) => ({ ...stat, durationMs: 0 })),
+			totalDurationMs: 0,
+			traceDeliveryFailed: false,
+		},
+		{
+			...result,
+			stats: result.stats?.map((stat) => ({ ...stat, durationMs: 0 })),
+			totalDurationMs: 0,
+			traceDeliveryFailed: false,
+		},
+		"trace observers must not mutate map, candidate, or final pipeline values",
+	);
+	assert.equal(observed.traceDeliveryFailed, false);
+	assert.ok(events.every((event) => !Object.hasOwn(event, "value")));
+	assert.deepEqual(
+		events.map((event) => [event.passKind, event.surface]),
+		[
+			["map", "raw_success"],
+			["map", "candidate_review_text"],
+			["deep", "raw_success"],
+			["deep", "candidate_finding"],
+			["deep", "candidate_review_text"],
+			["critic", "raw_success"],
+			["critic", "final_finding"],
+			["critic", "final_review_text"],
+		],
+	);
 
 	assert.equal(result.verdict, "changes_requested");
 	assert.deepEqual(result.checked, [


### PR DESCRIPTION
Trace callers pass `PromptResult` objects as provenance. Spreading those objects into events also exposed their mutable `value`, allowing an observer to change map/review data despite the event being frozen. Copy only the four declared provenance fields at all five emission sites.

Regression tests reproduced the leak and observer mutation before the fix. They verify event fields, content, ordering and frozen finding snapshots, and compare the real stubbed review pipeline with and without an observer attempting mutation.

Validation: `pnpm check`, `pnpm lint`, full `pnpm test` (888 passed), `git diff --check`, and structured Codex autoreview passed. No live model eval or deployment ran.

`gateClass: R`: removing the mutation path can affect values subsequently fed to model passes. The eval gate is skipped for this PR at the owner's explicit direction (2026-09-06), not recorded as passing. No production-lane full-fixture or x3 confirmation model gate was run.

