### PR TITLE
docs: restructure the benchmark standing in RESULTS.md and both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ The page is not deployed yet; this link intentionally opens its source until a
 custom domain or GitHub Pages deployment is authorized.
 
 **Measured on the 2026-09-06 rerank**, all seven published lanes at 87 × 3,
-scorer `8bbc6152d8b45a43`. Bold marks the deployed lane and the best value in
-each column.
+scorer `8bbc6152d8b45a43`. This table is a hand-copied excerpt of the
+generated ranked table in `eval/RESULTS.md`, which is the source of truth;
+the benchmark page itself is never hand-edited. Bold marks the deployed lane
+and the best value in each column.
 
 | Rank | Lane | Balanced | Tier-1 | FP | Noise/review | Mean |
 | ---: | --- | ---: | ---: | ---: | ---: | ---: |

--- a/README.md
+++ b/README.md
@@ -121,14 +121,15 @@ operational outcomes, not zero model scores.
 The page is not deployed yet; this link intentionally opens its source until a
 custom domain or GitHub Pages deployment is authorized.
 
-Current standing (rerank of 2026-09-06, scorer `8bbc6152d8b45a43`, all seven
-published lanes at 87 × 3):
+**Measured on the 2026-09-06 rerank**, all seven published lanes at 87 × 3,
+scorer `8bbc6152d8b45a43`. Bold marks the deployed lane and the best value in
+each column.
 
-| Rank | Lane | Balanced | Tier-1 | FP | Noise/review |
-| ---: | --- | ---: | ---: | ---: | ---: |
-| 1 | Grok 4.6 xhigh (Grok CLI) | 95.5% | 100% | 1.4% | 0.011 |
-| 2 | GPT-5.6 Terra high (Codex CLI), **deployed** | 90.0% | 100% | 9.7% | 0.077 |
-| 2 | GPT-5.6 Sol medium (Codex CLI) | 88.4% | 100% | 13.9% | 0.077 |
+| Rank | Lane | Balanced | Tier-1 | FP | Noise/review | Mean |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | Grok 4.6 xhigh (Grok CLI) | **95.5%** | 100% | **1.4%** | **0.011** | 230s |
+| 2 | **GPT-5.6 Terra high (Codex CLI), deployed** | 90.0% | 100% | 9.7% | 0.077 | **63s** |
+| 2 | GPT-5.6 Sol medium (Codex CLI) | 88.4% | 100% | 13.9% | 0.077 | 75s |
 
 GLM-5.3-Flash, DeepSeek V4 Flash Vision Exp, Terra xhigh, and Luna max score
 in the same band but miss at least one Tier-1 draw in their full report, so

--- a/README.md
+++ b/README.md
@@ -121,9 +121,26 @@ operational outcomes, not zero model scores.
 The page is not deployed yet; this link intentionally opens its source until a
 custom domain or GitHub Pages deployment is authorized.
 
+Current standing (rerank of 2026-09-06, scorer `8bbc6152d8b45a43`, all seven
+published lanes at 87 × 3):
+
+| Rank | Lane | Balanced | Tier-1 | FP | Noise/review |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 1 | Grok 4.6 xhigh (Grok CLI) | 95.5% | 100% | 1.4% | 0.011 |
+| 2 | GPT-5.6 Terra high (Codex CLI), **deployed** | 90.0% | 100% | 9.7% | 0.077 |
+| 2 | GPT-5.6 Sol medium (Codex CLI) | 88.4% | 100% | 13.9% | 0.077 |
+
+GLM-5.3-Flash, DeepSeek V4 Flash Vision Exp, Terra xhigh, and Luna max score
+in the same band but miss at least one Tier-1 draw in their full report, so
+they are shown without a rank. Terra xhigh also exceeds the 0.12 positive-noise
+gate. Grok 4.6 leads but is 3.7× slower per review and needs the Grok CLI
+authenticated on the runner; it remains a candidate.
+
 The deployed Codex `gpt-5.6-terra` at `high` effort passes the current Tier-1
-and positive-noise qualification gates. See the [chronological record](https://github.com/frankekn/needlefish/blob/main/eval/RESULTS.md)
-and [raw reports](https://github.com/frankekn/needlefish/tree/main/eval/results).
+and positive-noise qualification gates. The full ranked table with confidence
+intervals lives under "Current decision" in the
+[chronological record](https://github.com/frankekn/needlefish/blob/main/eval/RESULTS.md);
+every row links its [raw report](https://github.com/frankekn/needlefish/tree/main/eval/results).
 
 ## Development install
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -114,10 +114,25 @@ specificity 的算術平均；Tier-1 recall 仍是不可繞過的資格門檻。
 頁面尚未部署；在 custom domain 或 GitHub Pages 部署獲得授權前，此連結會刻意
 開啟原始碼。
 
+目前排名（2026-09-06 重跑，scorer `8bbc6152d8b45a43`，七個公開 lane 皆為
+87 × 3）：
+
+| 名次 | Lane | Balanced | Tier-1 | FP | Noise/review |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 1 | Grok 4.6 xhigh（Grok CLI） | 95.5% | 100% | 1.4% | 0.011 |
+| 2 | GPT-5.6 Terra high（Codex CLI），**目前部署** | 90.0% | 100% | 9.7% | 0.077 |
+| 2 | GPT-5.6 Sol medium（Codex CLI） | 88.4% | 100% | 13.9% | 0.077 |
+
+GLM-5.3-Flash、DeepSeek V4 Flash Vision Exp、Terra xhigh 與 Luna max 分數
+落在同一區間，但完整 report 中至少漏掉一個 Tier-1 draw，因此不給名次；
+Terra xhigh 另外超過 0.12 的 positive-noise 門檻。Grok 4.6 領先，但每次審查
+慢 3.7 倍，且需要 runner 上已登入的 Grok CLI，目前仍是 candidate。
+
 目前部署的 Codex `gpt-5.6-terra` @ `high` 已通過 Tier-1 與 positive-noise
-資格門檻。詳見
-[時間序實驗記錄](https://github.com/frankekn/needlefish/blob/main/eval/RESULTS.md)與
-[raw reports](https://github.com/frankekn/needlefish/tree/main/eval/results)。
+資格門檻。含信賴區間的完整排名表在
+[時間序實驗記錄](https://github.com/frankekn/needlefish/blob/main/eval/RESULTS.md)的
+「Current decision」；每一列都連到各自的
+[raw report](https://github.com/frankekn/needlefish/tree/main/eval/results)。
 
 ## 開發環境安裝
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -114,14 +114,14 @@ specificity 的算術平均；Tier-1 recall 仍是不可繞過的資格門檻。
 頁面尚未部署；在 custom domain 或 GitHub Pages 部署獲得授權前，此連結會刻意
 開啟原始碼。
 
-目前排名（2026-09-06 重跑，scorer `8bbc6152d8b45a43`，七個公開 lane 皆為
-87 × 3）：
+**量測條件：2026-09-06 重跑**，七個公開 lane 皆為 87 × 3，scorer
+`8bbc6152d8b45a43`。粗體標示目前部署的 lane 與每欄最佳值。
 
-| 名次 | Lane | Balanced | Tier-1 | FP | Noise/review |
-| ---: | --- | ---: | ---: | ---: | ---: |
-| 1 | Grok 4.6 xhigh（Grok CLI） | 95.5% | 100% | 1.4% | 0.011 |
-| 2 | GPT-5.6 Terra high（Codex CLI），**目前部署** | 90.0% | 100% | 9.7% | 0.077 |
-| 2 | GPT-5.6 Sol medium（Codex CLI） | 88.4% | 100% | 13.9% | 0.077 |
+| 名次 | Lane | Balanced | Tier-1 | FP | Noise/review | 平均時間 |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | Grok 4.6 xhigh（Grok CLI） | **95.5%** | 100% | **1.4%** | **0.011** | 230s |
+| 2 | **GPT-5.6 Terra high（Codex CLI），目前部署** | 90.0% | 100% | 9.7% | 0.077 | **63s** |
+| 2 | GPT-5.6 Sol medium（Codex CLI） | 88.4% | 100% | 13.9% | 0.077 | 75s |
 
 GLM-5.3-Flash、DeepSeek V4 Flash Vision Exp、Terra xhigh 與 Luna max 分數
 落在同一區間，但完整 report 中至少漏掉一個 Tier-1 draw，因此不給名次；

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -115,7 +115,9 @@ specificity 的算術平均；Tier-1 recall 仍是不可繞過的資格門檻。
 開啟原始碼。
 
 **量測條件：2026-09-06 重跑**，七個公開 lane 皆為 87 × 3，scorer
-`8bbc6152d8b45a43`。粗體標示目前部署的 lane 與每欄最佳值。
+`8bbc6152d8b45a43`。此表是從 `eval/RESULTS.md` 產生的排名表手動摘錄，
+以該檔為準；benchmark 頁面本身不會手動修改。粗體標示目前部署的 lane 與
+每欄最佳值。
 
 | 名次 | Lane | Balanced | Tier-1 | FP | Noise/review | 平均時間 |
 | ---: | --- | ---: | ---: | ---: | ---: | ---: |

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -37,7 +37,7 @@ recorded (§26) but does not restore the rank.
 | --- | ---: | --- | --- |
 | [GLM-5.3-Flash](results/2026-09-06-pi-zai-glm53-flash-max-x3.json) max | 94.81% | Tier-1 95.24%: `real-pr1-self-review-tool-checkout` 2/3 | 3/3 |
 | [DeepSeek V4 Flash Vision Exp](results/2026-09-06-pi-cliproxy-deepseek-v4-flash-vision-exp-max-x3.json) max | 91.66% | Tier-1 95.24%: `real-pr1-codex-no-sandbox-flag` 2/3 | 3/3 |
-| [GPT-5.6 Terra](results/2026-09-06-codex-gpt56-terra-xhigh-x3.json) xhigh | 90.39% | Tier-1 90.48%: `t1-inverted-guard` 2/3, `real-pr1-self-review-tool-checkout` 2/3; noise 0.120 > 0.12 | 3/3 and 3/3; the noise gate is not re-testable by confirmation |
+| [GPT-5.6 Terra](results/2026-09-06-codex-gpt56-terra-xhigh-x3.json) xhigh | 90.39% | Tier-1 90.48%: `t1-inverted-guard` 2/3, `real-pr1-self-review-tool-checkout` 2/3; noise 0.1202 > 0.12 | 3/3 and 3/3; the noise gate is not re-testable by confirmation |
 | [GPT-5.6 Luna](results/2026-09-06-codex-gpt56-luna-max-x3.json) max | 88.43% | Tier-1 76.19%: `t1-inverted-guard` 0/3 plus two fixtures at 2/3; noise 0.131 | not run: 0/3 is not flicker |
 
 **Deployed-lane change, Terra xhigh → Terra high**, same model, subscription,
@@ -51,7 +51,7 @@ harness, and run. Bold marks the better value in each row.
 | Tier-3 recall | 72.22% | **77.78%** | +5.6 pt |
 | Usable specificity | **94.44%** | 90.28% | −4.2 pt |
 | False positives (of 72 clean draws) | **4.17% (3)** | 9.72% (7) | +4 draws |
-| Positive noise / review | 0.120 | **0.077** | −0.043 |
+| Positive noise / review | 0.1202 | **0.0765** | −0.0437 |
 | Invalid output | 0.38% | **0%** | −1 draw |
 | Mean review time | 80s | **63s** | −21% |
 

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -7,26 +7,69 @@ paths.
 
 ## Current decision
 
-As of 2026-09-07, the deployed lane is **Codex `gpt-5.6-terra` at high
-effort**. Under the current scorer (`8bbc6152d8b45a43`) and fixture set
-(`e9923bbc7753a04a`, 87 fixtures), it has 100% Tier-1 recall and 0.077
-positive noise. Grok 4.6 ranks 1 alone; Terra high and GPT-5.6 Sol share rank
-2. The previously deployed Terra xhigh lane, GLM-5.3-Flash, DeepSeek V4 Flash
-Vision Exp, and Luna max each miss at least one Tier-1 draw in their full
-report and receive no rank. Terra xhigh, GLM, and DeepSeek each recovered 3/3
-on x3 confirmation of the missed fixture (§26); the site ranks the full
-report, not the confirmation, so they stay unranked. Terra xhigh also sits at
-0.1202 positive noise, over the 0.12 gate. Luna misses `t1-inverted-guard`
-0/3, which is not flicker.
+**Deployed lane: Codex `gpt-5.6-terra` at `high` effort** (selected
+2026-09-07). Grok 4.6 ranks first alone; Terra high and GPT-5.6 Sol share
+rank 2. Four lanes score in the same band but miss a hard gate and receive
+no rank (table below).
+
+**Measured on the 2026-09-06 rerank**, commit `a5a0c68`, 87 fixtures × 3
+draws, sealed holdouts included, Class R, anti-cheat v2; prompt
+`e62d0889fc704541`, fixture set `e9923bbc7753a04a`, scorer
+`8bbc6152d8b45a43`. Every report has `cheatDetectedCount: 0`. Bold marks the
+deployed lane and the best value in each column.
+
+| Rank | Lane | Harness | Effort | Balanced | 95% CI | Tier-1 | FP | Noise/review | Mean |
+| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | [Grok 4.6](results/2026-09-06-grok-grok46-xhigh-x3.json) | Grok CLI 1.0.13 | xhigh | **95.48%** | 92.2–98.8% | 100% | **1.39%** | **0.011** | 230s |
+| 2 | **[GPT-5.6 Terra](results/2026-09-06-codex-gpt56-terra-high-x3.json) (deployed)** | Codex CLI 0.153.4 | high | 89.95% | 83.8–96.1% | 100% | 9.72% | 0.077 | **63s** |
+| 2 | [GPT-5.6 Sol](results/2026-09-06-codex-gpt56-sol-medium-x3.json) | Codex CLI 0.153.4 | medium | 88.41% | 81.1–95.7% | 100% | 13.89% | 0.077 | 75s |
+
+Reading: Grok 4.6 leads on accuracy and noise but is 3.7× slower per review
+and needs the Grok CLI authenticated on the runner, so it stays a candidate.
+Terra high and Sol are statistically unresolved against each other; Terra
+high is faster and cleaner on clean fixtures.
+
+**Unranked lanes**, same run. A lane whose full report misses any Tier-1 draw
+or exceeds 0.12 positive noise receives no rank; a later x3 confirmation is
+recorded (§26) but does not restore the rank.
+
+| Lane | Balanced | Gate missed in the full report | x3 confirmation on the missed fixture |
+| --- | ---: | --- | --- |
+| [GLM-5.3-Flash](results/2026-09-06-pi-zai-glm53-flash-max-x3.json) max | 94.81% | Tier-1 95.24%: `real-pr1-self-review-tool-checkout` 2/3 | 3/3 |
+| [DeepSeek V4 Flash Vision Exp](results/2026-09-06-pi-cliproxy-deepseek-v4-flash-vision-exp-max-x3.json) max | 91.66% | Tier-1 95.24%: `real-pr1-codex-no-sandbox-flag` 2/3 | 3/3 |
+| [GPT-5.6 Terra](results/2026-09-06-codex-gpt56-terra-xhigh-x3.json) xhigh | 90.39% | Tier-1 90.48%: `t1-inverted-guard` 2/3, `real-pr1-self-review-tool-checkout` 2/3; noise 0.120 > 0.12 | 3/3 and 3/3; the noise gate is not re-testable by confirmation |
+| [GPT-5.6 Luna](results/2026-09-06-codex-gpt56-luna-max-x3.json) max | 88.43% | Tier-1 76.19%: `t1-inverted-guard` 0/3 plus two fixtures at 2/3; noise 0.131 | not run: 0/3 is not flicker |
+
+**Deployed-lane change, Terra xhigh → Terra high**, same model, subscription,
+harness, and run. Bold marks the better value in each row.
+
+| | xhigh (before) | high (now) | Δ |
+| --- | ---: | ---: | ---: |
+| Balanced | **90.39%** | 89.95% | −0.4 pt |
+| Tier-1 recall | 90.48% | **100%** | +9.5 pt |
+| Anchored recall | 86.34% | **89.62%** | +3.3 pt |
+| Tier-3 recall | 72.22% | **77.78%** | +5.6 pt |
+| Usable specificity | **94.44%** | 90.28% | −4.2 pt |
+| False positives (of 72 clean draws) | **4.17% (3)** | 9.72% (7) | +4 draws |
+| Positive noise / review | 0.120 | **0.077** | −0.043 |
+| Invalid output | 0.38% | **0%** | −1 draw |
+| Mean review time | 80s | **63s** | −21% |
+
+Reading: the switch buys Tier-1 completeness, recall, and speed at the cost of
+four more blocked clean draws. Sol medium was the alternative at rank 2; it
+has higher recall but nearly double the false-positive rate of Terra high.
+
+<details>
+<summary>Full metric tables (every column the site publishes)</summary>
 
 Balanced Review Accuracy is the arithmetic mean of anchored recall and usable
 specificity. Invalid model output cannot count as a correct result, so it is
 counted once. Tier-1 recall and `meanNoisePerPositive <= 0.12` are hard gates;
-validity, verdict match, and speed remain separate diagnostics. Point-sorted uncertainty groups are anchored to
-their highest-scoring lane; lower lanes share that rank while their paired 95%
-normal interval versus the anchor includes zero. This prevents non-transitive
-bridge comparisons from collapsing distinct groups. Each row also shows its
-lane-level 95% interval.
+validity, verdict match, and speed remain separate diagnostics. Point-sorted
+uncertainty groups are anchored to their highest-scoring lane; lower lanes
+share that rank while their paired 95% normal interval versus the anchor
+includes zero. This prevents non-transitive bridge comparisons from collapsing
+distinct groups. Each row also shows its lane-level 95% interval.
 
 | Rank | Model | Harness | Provider route | Effort | Balanced | 95% CI | Recall | Specificity | T1 | T2 | T3 | FP | Noise/review | Invalid | Verdict | Mean |
 | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -43,18 +86,16 @@ Disqualified — not ranked:
 | [GPT-5.6 Terra](results/2026-09-06-codex-gpt56-terra-xhigh-x3.json) | Codex CLI 0.153.4 | Codex subscription | xhigh | 90.39% | 85.3–95.5% | 86.34% | 94.44% | 90.48% | 92.59% | 72.22% | 4.17% | 0.120 | 0.38% | 96.17% | 80s |
 | [GPT-5.6 Luna](results/2026-09-06-codex-gpt56-luna-max-x3.json) | Codex CLI 0.153.4 | Codex subscription | max | 88.43% | 81.6–95.2% | 87.98% | 88.89% | 76.19% | 92.59% | 83.33% | 5.56% | 0.131 | 1.92% | 94.64% | 147s |
 
-Harness, provider, and route labels are operator-attested report metadata; the
-site does not independently derive them from generic runner state. All ranked
-reports contain 87 fixtures × 3 draws, include sealed holdouts, were taken at
-commit `a5a0c68` with Class R declared, and use prompt `e62d0889fc704541`,
-fixture set `e9923bbc7753a04a`, scorer `8bbc6152d8b45a43`, and anti-cheat v2.
-Every report has `cheatDetectedCount: 0`. Each Pi report binds the staged
-`models.json` hash and records `PI_AUTH_SOURCE=environment` (provider keys
-supplied through the environment, so no auth-store entry is selected or
-hashed); the Grok report binds its staged config. No legacy identity
-exceptions remain in the manifest.
+</details>
 
-Not ranked:
+Harness, provider, and route labels are operator-attested report metadata; the
+site does not independently derive them from generic runner state. Each Pi
+report binds the staged `models.json` hash and records
+`PI_AUTH_SOURCE=environment` (provider keys supplied through the environment,
+so no auth-store entry is selected or hashed); the Grok report binds its
+staged config. No legacy identity exceptions remain in the manifest.
+
+Not ranked for operational reasons:
 
 - Qwen3.8 Max via OpenCode Go and Qwen3.8 Flash Next were not re-run; the
   provider's monthly cap (reset expected mid-September 2026) and the missing


### PR DESCRIPTION
Applies the table conventions from MiaAI-Lab's Qwen3.8-Flash-Next dual-DGX README to the eval docs: a conditions line above every result table, bold for the deployed lane and the best value per column, separate tables for ranked, unranked, and before/now/delta comparisons, and a reading line under each table. The full 17-column site tables move into a collapsed details block.

- eval/RESULTS.md "Current decision": compact ranked table (rank, harness, effort, balanced, CI, Tier-1, FP, noise, mean), an unranked-lanes table stating the gate missed and the x3 confirmation outcome, and a Terra xhigh → high delta table for the 0.4.3 lane change.
- README.md and README.zh-TW.md: same compact three-lane table with a mean-time column.

Numbers are copied from the generated ranked table; no code or eval change.