### PR TITLE
fix(runner): restore streamed stderr callbacks

### DIFF
--- a/src/shared/runner-process.test.ts
+++ b/src/shared/runner-process.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
-import { readRunnerDurationMs, spawnRunnerProcess } from "./runner-process";
+import { readRunnerDurationMs, runManagedRunnerProcess, spawnRunnerProcess } from "./runner-process";
 
 test("spawnRunnerProcess reports EPIPE when stdin closes before prompt drains", async () => {
   const result = await spawnRunnerProcess({
@@ -221,3 +221,38 @@ function killProcessIfRunning(pid: number): void {
     if (!isMissingProcess(error)) throw error;
   }
 }
+
+test("runManagedRunnerProcess delivers stderr before exit so a consumer can acknowledge readiness", async () => {
+  let observed = "";
+  let acknowledged = false;
+  const result = await runManagedRunnerProcess({
+    command: process.execPath,
+    args: ["-e", `
+      process.stdin.setEncoding("utf8");
+      let input = "";
+      process.stdin.on("data", chunk => { input += chunk; });
+      process.stdin.on("end", () => {
+        if (input !== "ack\\n") process.exitCode = 2;
+        else process.stdout.write("done\\n");
+      });
+      process.stderr.write("ready\\n");
+    `],
+    repoPath: process.cwd(),
+    timeoutMs: 3000,
+    env: process.env,
+    onStderr: (chunk, controller) => {
+      observed += chunk;
+      if (!acknowledged && observed.includes("ready\n")) {
+        acknowledged = true;
+        controller.writeStdin("ack\n");
+        controller.endStdin();
+      }
+    },
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.equal(result.signal, null);
+  assert.equal(observed, "ready\n");
+  assert.equal(result.stderr, observed);
+  assert.equal(result.stdout, "done\n");
+});

--- a/src/shared/runner-process.ts
+++ b/src/shared/runner-process.ts
@@ -43,6 +43,7 @@ export interface ManagedRunnerProcessInvocation {
   readonly env: NodeJS.ProcessEnv;
   readonly onSpawn?: RunnerLifecycleHandler;
   readonly onStdout?: RunnerChunkHandler;
+  readonly onStderr?: RunnerChunkHandler;
   readonly onTimeout?: RunnerLifecycleHandler;
 }
 
@@ -282,6 +283,12 @@ export async function runManagedRunnerProcess(
     child.stderr.on("data", (chunk: unknown) => {
       const text = collect(stderr, stderrBytes, chunk);
       if (text !== null) refreshIdleTimer();
+      if (text === null || invocation.onStderr === undefined) return;
+      try {
+        invocation.onStderr(text, controller);
+      } catch (error) {
+        failFromHandler(error);
+      }
     });
     child.stdin.on("error", (error) => {
       if (timeoutError === undefined && bufferError === undefined && spawnError === undefined) {


### PR DESCRIPTION
Restore the optional `onStderr` callback removed in #115. Consumers importing the packaged managed runner can otherwise lose progress notifications; a child waiting for an acknowledgment triggered by stderr will time out because the callback never runs.

Reuse the original guarded dispatch and handler-error path. A real subprocess regression requires streamed stderr to trigger a stdin acknowledgment before the child can exit, and verifies that aggregate stderr remains available. Existing CLI/ACP callers do not supply this hook; no affected production consumer has been identified.

Validation: the regression fails with dispatch absent and passes after restoration; focused runner/ACP tests, `pnpm check`, `pnpm lint`, full `pnpm test`, `pnpm build`, `git diff --check`, and structured autoreview passed.

`gateClass: D`: compatibility restoration with no changes to production model inputs, candidate handling or review verdicts. Live model eval is skipped under the owner's prior instruction for this cleanup work, not recorded as passing. No merge or deployment performed.
